### PR TITLE
fix: thumbnail previewer caused dock show up

### DIFF
--- a/src/widgets/toolbox_proxy.cpp
+++ b/src/widgets/toolbox_proxy.cpp
@@ -317,7 +317,9 @@ class ThumbnailPreview: public DArrowRectangle {
 public:
     ThumbnailPreview(): DArrowRectangle(DArrowRectangle::ArrowBottom) {
         setAttribute(Qt::WA_DeleteOnClose);
-        setWindowFlags(Qt::ToolTip);
+        // FIXME(hualet): Qt::Tooltip will cause Dock to show up even
+        // the player is in fullscreen mode.
+        setWindowFlags(Qt::Tool);
         
         setObjectName("ThumbnailPreview");
 
@@ -418,7 +420,7 @@ public:
     VolumeSlider(PlayerEngine* eng, MainWindow* mw)
         :DArrowRectangle(DArrowRectangle::ArrowBottom), _engine(eng), _mw(mw) {
         setFixedSize(QSize(24, 105));
-        setWindowFlags(Qt::ToolTip);
+        setWindowFlags(Qt::Tool);
 
         setShadowBlurRadius(4);
         setRadius(4);


### PR DESCRIPTION
wrong window flags of thumbnail preview window causes dock to
show up even if the player's in fullscreen mode.

see https://github.com/linuxdeepin/developer-center/issues/1157