### PR TITLE
fix: wrong ffmpeg version check

### DIFF
--- a/src/libdmr/playlist_model.cpp
+++ b/src/libdmr/playlist_model.cpp
@@ -1700,7 +1700,7 @@ static int open_codec_context(int *stream_idx,
 
     stream_index = ret;
     st = fmt_ctx->streams[stream_index];
-#if LIBAVFORMAT_VERSION_MAJOR >= 57 && LIBAVFORMAT_VERSION_MINOR <= 25
+#if LIBAVFORMAT_VERSION_MAJOR >= 57
     *dec_ctx = st->codecpar;
     dec = avcodec_find_decoder((*dec_ctx)->codec_id);
 #else


### PR DESCRIPTION
It seems that the version should not be restricted

Log:
Issue: Closes #59