### PR TITLE
fix: the height for selectableedit on settings dialog

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -191,7 +191,7 @@ static QWidget *createSelectableLineEditOptionHandle(QObject *pObj)
     pMainWid->setLayout(pLayout);
     DPushButton *pPushButton = new DPushButton;
     pPushButton->setAutoDefault(false);
-    pLineEdit->setFixedHeight(21);
+    pLineEdit->setFixedHeight(40);
     pLineEdit->setObjectName("OptionSelectableLineEdit");
     pLineEdit->setText(pSettingOption->value().toString());
     QFontMetrics fontMetrics = pLineEdit->fontMetrics();
@@ -205,7 +205,8 @@ static QWidget *createSelectableLineEditOptionHandle(QObject *pObj)
     pLineEdit->setText(sElideText);
     sNameLast = sElideText;
     pPushButton->setIcon(QIcon(":resources/icons/select-normal.svg"));
-    pPushButton->setFixedHeight(21);
+    pPushButton->setFixedHeight(40);
+    pLayout->setContentsMargins(0, 0, 0, 0);
     pLayout->addWidget(pLineEdit);
     pLayout->addWidget(pPushButton);
 
@@ -217,7 +218,10 @@ static QWidget *createSelectableLineEditOptionHandle(QObject *pObj)
     pOptionLayout->setSpacing(0);
 
     pMainWid->setMinimumWidth(240);
-    pOptionLayout->addRow(new DLabel(QObject::tr(pSettingOption->name().toStdString().c_str())), pMainWid);
+    QLabel *title = new DLabel(QObject::tr(pSettingOption->name().toStdString().c_str()));
+    title->setFixedHeight(40);
+    title->setContentsMargins(0, 0, 16, 0);
+    pOptionLayout->addRow(title, pMainWid);
 
     //auto optionWidget = settingWidget->createWidget(option);
     workaround_updateStyle(pOptionWidget, "light");


### PR DESCRIPTION
**before**
![截图_deepin-movie_20220212200713](https://user-images.githubusercontent.com/10684972/153710835-a4bfb66d-9c67-4343-a68d-d596ac286669.png)

**after**
![image](https://user-images.githubusercontent.com/10684972/153710849-d8929808-c463-48dd-bf9b-f1cd21723508.png)

