### PR TITLE
fix: 修复本地视频名称上包含{}时，影院无法播放视频

### DIFF
--- a/src/libdmr/filefilter.cpp
+++ b/src/libdmr/filefilter.cpp
@@ -222,7 +222,7 @@ bool FileFilter::isSubtitle(QUrl url)
 
     AVFormatContext *av_ctx = nullptr;
 
-    nRet = g_mvideo_avformat_open_input(&av_ctx, url.toString().toUtf8().constData(), nullptr, nullptr);
+    nRet = g_mvideo_avformat_open_input(&av_ctx, url.toLocalFile().toUtf8().constData(), nullptr, nullptr);
 
     if(nRet < 0)
     {

--- a/tests/deepin-movie/common/test_mainwindow.cpp
+++ b/tests/deepin-movie/common/test_mainwindow.cpp
@@ -234,6 +234,33 @@ TEST(MainWindow, tabInteraction)
 }
 #endif
 
+TEST(MainWindow, loadSpecialFile)
+{
+    MainWindow *w = dApp->getMainWindow();
+    w->show();
+    PlayerEngine *engine =  w->engine();
+    QList<QUrl> listPlayFiles;
+    listPlayFiles << QUrl::fromLocalFile("/data/source/deepin-movie-reborn/movie/{}demo.mp4");
+    engine->playlist().loadPlaylist();
+    engine->playlist().clear();
+    const QList<QUrl> &valids = engine->addPlayFiles(listPlayFiles);
+    QCOMPARE(engine->isPlayableFile(valids[0]), true);
+    if (!valids.empty()) {
+        engine->playByName(valids[0]);
+    }
+
+    qDebug() << __func__ << "MainWindow.loadSpecialFile:" << engine->state();
+    w->checkOnlineState(false);
+    QTest::qWait(200);
+    w->resize(900, 700);
+    QTest::qWait(200);
+    w->resize(300, 300);
+    QTest::qWait(200);
+
+    // video judge
+    EXPECT_TRUE(FileFilter::instance()->isVideo(listPlayFiles[0]));
+}
+
 TEST(MainWindow, loadFile)
 {
     MainWindow *w = dApp->getMainWindow();


### PR DESCRIPTION
修复本地视频名称上包含{}时，影院无法播放视频

Log: 调用ffmpeg接口检查本地视频文件是否可播放时，文件路径转换为本地路径