### PR TITLE
fix: 修复本地视频名称上包含{}时，影院无法播放视频

### DIFF
--- a/src/libdmr/filefilter.cpp
+++ b/src/libdmr/filefilter.cpp
@@ -90,7 +90,7 @@ bool FileFilter::isMediaFile(QUrl url)
         return true;
     }
 
-    nRet = g_mvideo_avformat_open_input(&av_ctx, url.toString().toUtf8().constData(), nullptr, nullptr);
+    nRet = g_mvideo_avformat_open_input(&av_ctx, url.toLocalFile().toUtf8().constData(), nullptr, nullptr);
 
     if(nRet < 0)
     {
@@ -181,7 +181,7 @@ bool FileFilter::isAudio(QUrl url)
         return false;
     }
 
-    nRet = g_mvideo_avformat_open_input(&av_ctx, url.toString().toUtf8().constData(), nullptr, nullptr);
+    nRet = g_mvideo_avformat_open_input(&av_ctx, url.toLocalFile().toUtf8().constData(), nullptr, nullptr);
 
     if(nRet < 0)
     {
@@ -253,7 +253,7 @@ bool FileFilter::isVideo(QUrl url)
 
     AVFormatContext *av_ctx = nullptr;
 
-    nRet = g_mvideo_avformat_open_input(&av_ctx, url.toString().toUtf8().constData(), nullptr, nullptr);
+    nRet = g_mvideo_avformat_open_input(&av_ctx, url.toLocalFile().toUtf8().constData(), nullptr, nullptr);
 
     if(nRet < 0)
     {


### PR DESCRIPTION
修复本地视频名称上包含{}时，影院无法播放视频

Log: 调用ffmpeg接口检查本地视频文件是否可播放时，文件路径转换为本地路径