### PR TITLE
fix: 修复音量条控件位置异常

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -3391,6 +3391,11 @@ void MainWindow::resizeEvent(QResizeEvent *pEvent)
 //    if (!isFullScreen()) {
 //        my_setStayOnTop(this, false);
 //    }
+    if (CompositingManager::get().platform() != Platform::X86) {
+        QPoint relativePoint = mapToGlobal(QPoint(0, 0));
+        m_pToolbox->updateSliderPoint(relativePoint);
+    }
+
     m_pMovieWidget->resize(rect().size());
     m_pMovieWidget->move(0, 0);
 


### PR DESCRIPTION
主窗口resize时更新音量条控件位置

Bug: https://pms.uniontech.com/bug-view-144131.html
Log: 修复部分已知问题