### PR TITLE
fix: 修复klv与pgu播放区域的logo显示纯黑画面

### DIFF
--- a/src/backends/mediaplayer/qtplayer_glwidget.cpp
+++ b/src/backends/mediaplayer/qtplayer_glwidget.cpp
@@ -773,8 +773,8 @@ namespace dmr {
                     m_pGlProg->setUniformValue("bg", color);
                     prepareSplashImages();
                     QOpenGLTexture *pGLTexture;
-                    QOpenGLTexture BgLight(m_imgBgLight, QOpenGLTexture::DontGenerateMipMaps);
-                    pGLTexture = &BgLight;
+                    m_pLightTex->setData(m_imgBgLight);
+                    pGLTexture = m_pLightTex;
                     //和产品、ui商议深色主题下去除深色背景效果
 //                    DGuiApplicationHelper::ColorType themeType = DGuiApplicationHelper::instance()->themeType();
 //                    if (themeType == DGuiApplicationHelper::DarkType) {

--- a/src/backends/mpv/mpv_glwidget.cpp
+++ b/src/backends/mpv/mpv_glwidget.cpp
@@ -946,8 +946,8 @@ namespace dmr {
                     m_pGlProg->setUniformValue("bg", color);
                     prepareSplashImages();
                     QOpenGLTexture *pGLTexture;
-                    QOpenGLTexture BgLight(m_imgBgLight, QOpenGLTexture::DontGenerateMipMaps);
-                    pGLTexture = &BgLight;
+                    m_pLightTex->setData(m_imgBgLight);
+                    pGLTexture = m_pLightTex;
                     //和产品、ui商议深色主题下去除深色背景效果
 //                    DGuiApplicationHelper::ColorType themeType = DGuiApplicationHelper::instance()->themeType();
 //                    //                if (qApp->theme() == "dark") {


### PR DESCRIPTION
修复klv与pgu播放区域的logo显示纯黑画面

Bug: https://pms.uniontech.com/bug-view-146185.html
Log: 修复klv与pgu播放区域的logo显示纯黑画面