### PR TITLE
fix: 同步代码

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,5 +10,5 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 	  -DCMAKE_BUILD_TYPE=Release \
 	  -DCMAKE_INSTALL_PREFIX=/usr \
-      -DAPP_VERSION=$(DEB_VERSION_UPSTREAM) -DVERSION=$(DEB_VERSION_UPSTREAM) LIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH) DH_AUTO_ARGS = --parallel --buildsystem=cmake
+      -DAPP_VERSION=$(DEB_VERSION_UPSTREAM) -DVERSION=$(DEB_VERSION_UPSTREAM) LIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH)
 

--- a/src/backends/mediaplayer/qtplayer_glwidget.cpp
+++ b/src/backends/mediaplayer/qtplayer_glwidget.cpp
@@ -773,8 +773,8 @@ namespace dmr {
                     m_pGlProg->setUniformValue("bg", color);
                     prepareSplashImages();
                     QOpenGLTexture *pGLTexture;
-                    QOpenGLTexture BgLight(m_imgBgLight, QOpenGLTexture::DontGenerateMipMaps);
-                    pGLTexture = &BgLight;
+                    m_pLightTex->setData(m_imgBgLight);
+                    pGLTexture = m_pLightTex;
                     //和产品、ui商议深色主题下去除深色背景效果
 //                    DGuiApplicationHelper::ColorType themeType = DGuiApplicationHelper::instance()->themeType();
 //                    if (themeType == DGuiApplicationHelper::DarkType) {

--- a/src/backends/mpv/mpv_glwidget.cpp
+++ b/src/backends/mpv/mpv_glwidget.cpp
@@ -942,8 +942,8 @@ namespace dmr {
                     m_pGlProg->setUniformValue("bg", color);
                     prepareSplashImages();
                     QOpenGLTexture *pGLTexture;
-                    QOpenGLTexture BgLight(m_imgBgLight, QOpenGLTexture::DontGenerateMipMaps);
-                    pGLTexture = &BgLight;
+                    m_pLightTex->setData(m_imgBgLight);
+                    pGLTexture = m_pLightTex;
                     //和产品、ui商议深色主题下去除深色背景效果
 //                    DGuiApplicationHelper::ColorType themeType = DGuiApplicationHelper::instance()->themeType();
 //                    //                if (qApp->theme() == "dark") {


### PR DESCRIPTION
修复klv与pgu播放区域的logo显示纯黑画面

Log: 修复klv与pgu播放区域的logo显示纯黑画面