### PR TITLE
fix: 修复龙芯5000连续播放卡死

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -1087,12 +1087,13 @@ void MpvProxy::refreshDecode()
             auto codec = currentInfo.mi.videoCodec();
             auto name = _file.fileName();
             isSoftCodec = codec.toLower().contains("mpeg2video") || codec.toLower().contains("wmv") || name.toLower().contains("wmv");
+#if !defined(_loongarch) && !defined(__loongarch__) && !defined(__loongarch64)
             //探测硬解码
             if(!isSoftCodec) {
                 isSoftCodec = !isSurportHardWareDecode(codec, currentInfo.mi.width, currentInfo.mi.height);
             }
+#endif
         }
-
         if (isSoftCodec) {
             qInfo() << "my_set_property hwdec no";
             my_set_property(m_handle, "hwdec", "no");

--- a/src/libdmr/playlist_model.cpp
+++ b/src/libdmr/playlist_model.cpp
@@ -431,6 +431,7 @@ void PlaylistModel::slotStateChanged()
             pif.loaded = true;
             emit itemInfoUpdated(_current);
         }
+        _userRequestingItem = false;
         break;
     }
     case PlayerEngine::Paused:
@@ -826,7 +827,7 @@ void PlaylistModel::playNext(bool fromUser)
     qInfo() << "playmode" << _playMode << "fromUser" << fromUser
             << "last" << _last << "current" << _current;
 
-    _userRequestingItem = fromUser;
+    _userRequestingItem = true;
 
     switch (_playMode) {
     case SinglePlay:
@@ -910,8 +911,6 @@ void PlaylistModel::playNext(bool fromUser)
         tryPlayCurrent(true);
         break;
     }
-
-    _userRequestingItem = false;
 }
 
 void PlaylistModel::playPrev(bool fromUser)
@@ -920,7 +919,7 @@ void PlaylistModel::playPrev(bool fromUser)
     qInfo() << "playmode" << _playMode << "fromUser" << fromUser
             << "last" << _last << "current" << _current;
 
-    _userRequestingItem = fromUser;
+    _userRequestingItem = true;
 
     switch (_playMode) {
     case SinglePlay:
@@ -998,9 +997,6 @@ void PlaylistModel::playPrev(bool fromUser)
         tryPlayCurrent(false);
         break;
     }
-
-    _userRequestingItem = false;
-
 }
 
 static QDebug operator<<(QDebug s, const QFileInfoList &v)
@@ -1329,7 +1325,6 @@ void PlaylistModel::changeCurrent(int pos)
     _current = pos;
     _last = _current;
     tryPlayCurrent(true);
-    _userRequestingItem = false;
     emit currentChanged();
 }
 


### PR DESCRIPTION
龙芯5000不使用gpuinfo探测

Bug: https://pms.uniontech.com/bug-view-134177.html
Log: 修复部分已知问题