### PR TITLE
chore: dont use </usr/include/linux/cdrom.h>

### DIFF
--- a/src/common/diskcheckthread.cpp
+++ b/src/common/diskcheckthread.cpp
@@ -7,7 +7,7 @@
 
 #include <sys/ioctl.h>
 #include <fcntl.h>
-#include </usr/include/linux/cdrom.h>
+#include <linux/cdrom.h>
 #include <QFile>
 #include <unistd.h>
 


### PR DESCRIPTION
Log: dont use </usr/include/linux/cdrom.h>

不应该 include 绝对路径