### PR TITLE
fix: 修复bug139163

### DIFF
--- a/src/libdmr/player_engine.cpp
+++ b/src/libdmr/player_engine.cpp
@@ -767,7 +767,7 @@ bool PlayerEngine::addPlayFile(const QUrl &url)
     if (!isPlayableFile(realUrl))
         return false;
 
-    _playlist->append({realUrl});
+    _playlist->append(realUrl);
     return true;
 }
 

--- a/src/libdmr/player_widget.cpp
+++ b/src/libdmr/player_widget.cpp
@@ -32,6 +32,7 @@
  * files in the program, then also delete it here.
  */
 #include "player_widget.h"
+#include "filefilter.h"
 #include <player_engine.h>
 
 namespace dmr {
@@ -58,12 +59,9 @@ PlayerEngine &PlayerWidget::engine()
 
 void PlayerWidget::play(const QUrl &url)
 {
-    QUrl realUrl = url;;
+    QUrl realUrl;
+    realUrl = FileFilter::instance()->fileTransfer(url.toString());
 
-    if(QFileInfo(url.path()).isFile())
-    {
-        realUrl = QUrl::fromLocalFile(url.path());
-    }
     if (!realUrl.isValid())
         return;
 


### PR DESCRIPTION
139163 【文管5.6】【S6】【5.6.3.8】【N】快捷方式的视频拷贝至保险箱,空格预览无法自动播放
原因：PlayerWidget::play播放函数中，首先调用添加播放列表函数，该函数中将传入的软连接转为了真实路径进行保存；
解决办法：PlayerWidget::play播放函数中，首先将传入的软连接转为真实的路径，然后将真实路径传给后续调用的两个函数。

Log: 修复bug139163

Bug: https://pms.uniontech.com/bug-view-139163.html