### PR TITLE
fix: compatibility with ffmpeg 5+

### DIFF
--- a/src/libdmr/playlist_model.cpp
+++ b/src/libdmr/playlist_model.cpp
@@ -45,6 +45,7 @@
 
 #include <random>
 extern "C" {
+#include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavutil/dict.h>
 #include <libavutil/avutil.h>


### PR DESCRIPTION
In https://github.com/FFmpeg/FFmpeg/commit/e67e02d15672a87da1b0566e197a1e19dc7e1e33 avcodec.h is no longer included by avformat.h. Let's include it explicitly to fix build on ffmpeg 5+.

Log: Fix compatibility with ffmpeg 5+