### PR TITLE
fix: 修复海光s3唤醒后退出慢问题

### DIFF
--- a/src/libdmr/compositing_manager.cpp
+++ b/src/libdmr/compositing_manager.cpp
@@ -176,6 +176,8 @@ CompositingManager::CompositingManager()
                 _composited = false;
             } else {
                 _composited = true;
+                if (m_cpuModelName.contains("Hygon") && runningOnNvidia())
+                    _composited = false;
             }
         } else {
             if (_platform == Platform::Arm64 && isDriverLoaded)


### PR DESCRIPTION
海光N卡下使用gpu渲染

Bug: https://pms.uniontech.com/bug-view-151257.html
Log: 修复部分已知问题