### PR TITLE
fix: 修复影院卸载后预览失败问题

### DIFF
--- a/src/libdmr/compositing_manager.cpp
+++ b/src/libdmr/compositing_manager.cpp
@@ -158,7 +158,8 @@ CompositingManager::CompositingManager()
         return;
     }
 
-    _composited = false;
+    _composited = true;
+#if defined (_MOVIE_USE_)
     QGSettings gsettings("com.deepin.deepin-movie", "/com/deepin/deepin-movie/");
     QString aa = gsettings.get("composited").toString();
     if ((gsettings.get("composited").toString() == "DisableComposited"
@@ -185,6 +186,7 @@ CompositingManager::CompositingManager()
             _composited = false;
         }
     }
+#endif
 
     //针对9200显卡适配
     QFileInfo jmfi("/dev/jmgpu");


### PR DESCRIPTION
在libdmr中不使用影院提供的gsetting接口

Bug: https://pms.uniontech.com/bug-view-163343.html
Log: 修复部分已知问题