### PR TITLE
fix: 修复GStreamer下重复播放起点时间不对的问题和异常图片渲染崩溃的问题

### DIFF
--- a/src/backends/mediaplayer/qtplayer_proxy.cpp
+++ b/src/backends/mediaplayer/qtplayer_proxy.cpp
@@ -123,6 +123,9 @@ void QtPlayerProxy::slotStateChanged(QMediaPlayer::State newState)
 {
     switch (newState) {
     case QMediaPlayer::StoppedState:
+#ifndef _LIBDMR_
+        MovieConfiguration::get().updateUrl(this->_file, ConfigKnownKey::StartPos, 0);
+#endif
         setState(PlayState::Stopped);
         break;
      case QMediaPlayer::PlayingState:
@@ -172,7 +175,10 @@ void QtPlayerProxy::processFrame(QVideoFrame &frame)
     frame.map(QAbstractVideoBuffer::ReadOnly);
     QImage recvImage(frame.bits(), frame.width(), frame.height(), QVideoFrame::imageFormatFromPixelFormat(frame.pixelFormat()));
     m_currentImage = recvImage;
-    m_pGLWidget->setVideoTex(recvImage);
+    if(!recvImage.isNull())
+    {
+        m_pGLWidget->setVideoTex(recvImage);
+    }
     m_pGLWidget->repaint();
     frame.unmap();
 }


### PR DESCRIPTION
修复GStreamer下重复播放起点时间不对的问题和异常图片渲染崩溃的问题

Log: 修复GStreamer下重复播放起点时间不对的问题和异常图片渲染崩溃的问题

/reivew
@pengfeixx @myk1343 @wyu71 