### PR TITLE
fix: 修复兆芯大板拖动闪烁问题

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -1102,8 +1102,7 @@ bool Platform_MainWindow::event(QEvent *pEvent)
 
 void Platform_MainWindow::leaveEvent(QEvent *)
 {
-    m_autoHideTimer.stop();
-    this->suspendToolsWindow();
+    m_autoHideTimer.start(AUTOHIDE_TIMEOUT);
 }
 
 void Platform_MainWindow::onWindowStateChanged()


### PR DESCRIPTION
优化窗口离开事件，不立刻隐藏窗口标题栏

Bug: https://pms.uniontech.com/bug-view-170807.html
Log: 修复部分已知问题