### PR TITLE
fix: 178561 全屏模式切换到迷你模式，切换过程中有2s不显示影院窗口

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -3989,9 +3989,8 @@ void MainWindow::toggleUIMode()
         if (m_bMiniMode) {
             flags |= Qt::X11BypassWindowManagerHint;
             m_preMiniWindowState = windowState();
-            setWindowState(Qt::WindowNoState);
             setWindowFlags(flags);
-            show();
+            showNormal();
         } else {
             flags &= ~Qt::X11BypassWindowManagerHint;
             setWindowFlags(flags);


### PR DESCRIPTION
修复全屏迷你模式切换时，显示影院窗口较慢

Bug: https://pms.uniontech.com/bug-view-178561.html
Log: 修复全屏迷你模式切换时，显示影院窗口较慢