### PR TITLE
fix: 修复清空列表未清除播放记录

### DIFF
--- a/src/libdmr/player_engine.cpp
+++ b/src/libdmr/player_engine.cpp
@@ -656,6 +656,7 @@ void PlayerEngine::playSelected(int id)
 void PlayerEngine::clearPlaylist()
 {
     _playlist->clear();
+    MovieConfiguration::get().clear();
 }
 
 void PlayerEngine::pauseResume()


### PR DESCRIPTION
清空列表时将列表内所有的记录清除

Bug: https://pms.uniontech.com/bug-view-181745.html
Log: 修复部分已知问题