### PR TITLE
fix: 修复兆芯KX6000硬解码播放卡顿问题

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -430,7 +430,21 @@ mpv_handle *MpvProxy::mpv_init()
         }
         //TODO(xxxxpengfei)：暂未处理intel集显情况
         if (CompositingManager::get().isZXIntgraphics() && !jmflag) {
-            my_set_property(pHandle, "vo", "gpu");
+            QProcess process;
+            QStringList options;
+            options << "-c" << QString("apt policy cx4-linux-graphics-driver-dri | sed -n \'2p\'");
+            process.start("/bin/bash", options);
+            process.waitForFinished();
+            process.waitForReadyRead();
+
+            QString comStr = process.readAllStandardOutput();
+            comStr = comStr.right(4).left(2);
+            int version = comStr.toInt();
+            if (version > 10) {
+                my_set_property(pHandle, "vo", "vaapi");
+                my_set_property(pHandle, "hwdec", "vaapi");
+            } else
+                my_set_property(pHandle, "vo", "gpu");
         }
 #endif
     } else { //3.设置硬解

--- a/src/libdmr/compositing_manager.cpp
+++ b/src/libdmr/compositing_manager.cpp
@@ -486,6 +486,7 @@ bool CompositingManager::isDriverLoadedCorrectly()
     static QRegExp dri_ok("direct rendering: DRI\\d+ enabled");
     static QRegExp swrast("GLX: Initialized DRISWRAST");
     static QRegExp regZX("loading driver: zx");
+    static QRegExp regCX4("loading driver: cx4");
     static QRegExp controller("1ec8");
 
     QString xorglog = QString("/var/log/Xorg.%1.log").arg(QX11Info::appScreen());
@@ -514,7 +515,7 @@ bool CompositingManager::isDriverLoadedCorrectly()
             return false;
         }
 
-        if (regZX.indexIn(ln) != -1) {
+        if (regZX.indexIn(ln) != -1 || regCX4.indexIn(ln) != -1) {
             m_bZXIntgraphics = true;
         }
 


### PR DESCRIPTION
兆芯KX6000强制使用vaapi解码及输出

Bug: https://pms.uniontech.com/bug-view-197463.html
Log: 修复部分已知问题