### PR TITLE
fix: 修复m3u8文件播放卡死问题

### DIFF
--- a/src/libdmr/filefilter.cpp
+++ b/src/libdmr/filefilter.cpp
@@ -218,6 +218,10 @@ FileFilter::MediaType FileFilter::typeJudgeByFFmpeg(const QUrl &url)
 
     QString strMimeType = m_mimeDB.mimeTypeForUrl(url).name();
 
+    if (strMimeType.contains("mpegurl")) {
+        return MediaType::Other;
+    }
+
     AVFormatContext *av_ctx = nullptr;
 
     nRet = g_mvideo_avformat_open_input(&av_ctx, url.toLocalFile().toUtf8().constData(), nullptr, nullptr);


### PR DESCRIPTION
m3u8文件为无效文件，不播放

Bug: https://pms.uniontech.com/bug-view-165611.html
Log: 修复部分已知问题