### PR TITLE
fix: 修复投屏，pc2投屏后把pc1投屏状态清除

### DIFF
--- a/src/widgets/mircastwidget.h
+++ b/src/widgets/mircastwidget.h
@@ -308,6 +308,8 @@ private:
     QString m_URLAddrPro;
     //本地准备的投屏url地址
     QString m_sLocalUrl;
+    //返回播放视频地址
+    QString m_sTrackURI;
     void *m_pEngine;            ///播放引擎
     int m_nCurDuration;   //当前播放视频总时长
     int m_nCurAbsTime;    //当前播放视频播放时长


### PR DESCRIPTION
修复投屏，pc2投屏后把pc1投屏状态清除

Bug: https://pms.uniontech.com/bug-view-159991.html
Log: 修复投屏，pc2投屏后把pc1投屏状态清除