### PR TITLE
fix: 修复PANGU M900的CPU型号，切换迷你模式闪退的问题

### DIFF
--- a/src/common/mainwindow.h
+++ b/src/common/mainwindow.h
@@ -497,6 +497,11 @@ private:
     void mircastSuccess(QString name);
     void exitMircast();
 
+    /**
+     * @brief 使用dbus获取当前机器CPU型号
+     */
+    QString cpuHardwareByDBus();
+
 private:
     MessageWindow *m_pPopupWid;                     ///截图提示窗口
     QLabel *m_pFullScreenTimeLable;                 ///全屏时右上角的影片进度


### PR DESCRIPTION
   使用DBus接口获取当前CPU型号，并判断是否为PANGU M900

Log: 修复PANGU M900的CPU型号，切换迷你模式闪退的问题
Bug: https://pms.uniontech.com/bug-view-204685.html