### PR TITLE
fix: build error

### DIFF
--- a/src/libdmr/playlist_model.h
+++ b/src/libdmr/playlist_model.h
@@ -18,6 +18,8 @@
 #define THUMBNAIL_SIZE 500
 #define SEEK_TIME "00:00:01"
 
+using namespace Dtk::Gui;
+
 typedef video_thumbnailer *(*mvideo_thumbnailer)();
 typedef void (*mvideo_thumbnailer_destroy)(video_thumbnailer *thumbnailer);
 /* create image_data structure */


### PR DESCRIPTION
DGuiApplicationHelper has been moved into DGui, so using Dtk::Gui instead of Dtk::Widget

Log: fix build error