### PR TITLE
fix: 修复wayland下迷你模式异常

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -4179,7 +4179,7 @@ void MainWindow::toggleUIMode()
         m_pCommHintWid->setAnchorPoint(QPoint(30, 58));
 	QRect tmp = m_lastRectInNormalMode;
         this->setMinimumSize(614, 500);
-        this->setMaximumSize(QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX));
+        this->setMaximumSize(QSize(QWIDGETSIZE_MAX-1, QWIDGETSIZE_MAX-1));
         m_lastRectInNormalMode = tmp;
         setEnableSystemResize(true);
         if (m_nStateBeforeMiniMode & SBEM_Maximized) {


### PR DESCRIPTION
修复wayland从迷你模式切回正常模式无法缩放大小问题，应用规避操作

Bug: https://pms.uniontech.com/bug-view-212207.html
Log: 修复部分已知问题