### PR TITLE
fix: 修复url弹窗中文字与输入框的距离问题

### DIFF
--- a/src/widgets/url_dialog.cpp
+++ b/src/widgets/url_dialog.cpp
@@ -9,6 +9,8 @@
 
 #include <DGuiApplicationHelper>
 
+
+#include <iostream>
 DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 
@@ -21,10 +23,25 @@ namespace dmr {
         setOnButtonClickedClose(false);
         setDefaultButton(1);
         setIcon(QIcon::fromTheme("deepin-movie"));
-        setMessage(QApplication::translate("UrlDialog", "Please enter the URL:"));
 
-        m_lineEdit = new LineEdit(this);
-        addContent(m_lineEdit);
+        QLabel* m_messageLabel=new QLabel;
+        m_messageLabel->setText(QApplication::translate("UrlDialog", "Please enter the URL:"));
+        m_messageLabel->setAlignment(Qt::AlignHCenter|Qt::AlignBottom);
+        m_lineEdit = new LineEdit;
+
+        /**
+         * m_widget包含一个垂直布局
+         * 存放了m_messageLabel和m_lineEdit
+         */
+        QWidget* m_widget=new QWidget;
+        QVBoxLayout* m_contentLayout=new QVBoxLayout;
+        m_contentLayout->setSpacing(10);
+        m_contentLayout->setContentsMargins({0,0,0,0});
+        m_contentLayout->addWidget(m_messageLabel);
+        m_contentLayout->addWidget(m_lineEdit);
+        m_widget->setLayout(m_contentLayout);
+        addContent(m_widget);
+
         m_lineEdit->setFocusPolicy(Qt::StrongFocus);
         this->setFocusProxy(m_lineEdit);
 


### PR DESCRIPTION
设置url弹窗中文字与输入框距离为10

Log: 修复url弹窗问题
Bug: https://pms.uniontech.com/bug-view-155981.html