### PR TITLE
fixed: 影院循环播放10个smb上的视频一段时间后，点击播放按钮或点击列表中的视频均无法播放

### DIFF
--- a/src/widgets/platform/platform_playlist_widget.cpp
+++ b/src/widgets/platform/platform_playlist_widget.cpp
@@ -324,6 +324,9 @@ public:
         }
         if (!_pif.url.isLocalFile() || _pif.info.exists()) {
             emit doubleClicked();
+        }else{
+            //fixed:影院循环播放10个smb上的视频一段时间后，点击播放按钮或点击列表中的视频没反应
+            emit _playlist->engine()->sigInvalidFile(QFileInfo(_pif.url.toLocalFile()).fileName());
         }
     }
 

--- a/src/widgets/platform/platform_playlist_widget.h
+++ b/src/widgets/platform/platform_playlist_widget.h
@@ -114,7 +114,14 @@ public:
      * @param atr true为执行，false为跳过
      */
     void resetFocusAttribute(bool &atr);
-
+    /**
+     * @brief 返回_engine
+     * PlayItemWidget类中的文件url无效时，需要给用户提示。需要通过PlayerEngine给MainWindow发送信号
+     * @return engine的指针
+     */
+    inline PlayerEngine *engine() noexcept{
+        return _engine;
+    }
 signals:
     void stateChange(bool isShortcut);
     void sizeChange();

--- a/src/widgets/playlist_widget.cpp
+++ b/src/widgets/playlist_widget.cpp
@@ -324,6 +324,9 @@ public:
         }
         if (!_pif.url.isLocalFile() || _pif.info.exists()) {
             emit doubleClicked();
+        }else{
+            //fixed:影院循环播放10个smb上的视频一段时间后，点击播放按钮或点击列表中的视频没反应
+            emit _playlist->engine()->sigInvalidFile(QFileInfo(_pif.url.toLocalFile()).fileName());
         }
     }
 

--- a/src/widgets/playlist_widget.h
+++ b/src/widgets/playlist_widget.h
@@ -114,7 +114,14 @@ public:
      * @param atr true为执行，false为跳过
      */
     void resetFocusAttribute(bool &atr);
-
+    /**
+     * @brief 返回_engine
+     * PlayItemWidget类中的文件url无效时，需要给用户提示。需要通过PlayerEngine给MainWindow发送信号
+     * @return engine的指针
+     */
+    inline PlayerEngine *engine() noexcept{
+        return _engine;
+    }
 signals:
     void stateChange(bool isShortcut);
     void sizeChange();


### PR DESCRIPTION
若找不到视频 则给用户友好提示

Log: 正常播放视频  若找不到视频 则给用户友好提示
Bug: https://pms.uniontech.com/bug-view-218273.html