### PR TITLE
fix: 修复m900查看缩略图时,播放卡顿问题

### DIFF
--- a/src/libdmr/compositing_manager.cpp
+++ b/src/libdmr/compositing_manager.cpp
@@ -289,7 +289,7 @@ bool CompositingManager::isMpvExists()
     QDir dir;
     QString path  = QLibraryInfo::location(QLibraryInfo::LibrariesPath);
     dir.setPath(path);
-    QStringList list = dir.entryList(QStringList() << (QString("libmpv.so.1") + "*"), QDir::NoDotAndDotDot | QDir::Files);
+    static QStringList list = dir.entryList(QStringList() << (QString("libmpv.so.1") + "*"), QDir::NoDotAndDotDot | QDir::Files);
     if (list.contains("libmpv.so.1")) {
         return true;
     }


### PR DESCRIPTION
修复m900查看缩略图时,播放卡顿问题

Bug: https://pms.uniontech.com/bug-view-228541.html
Log: 修复m900查看缩略图时,播放卡顿问题