### PR TITLE
fix: 修复初始化进度条中的缩略图时闪现黑色条纹

### DIFF
--- a/src/widgets/toolbox_proxy.cpp
+++ b/src/widgets/toolbox_proxy.cpp
@@ -714,8 +714,9 @@ public:
     void updateWithPreview(const QPoint &pos)
     {
         move(pos.x() - this->width() / 2, pos.y() - this->height() + 10);
-
-        show();
+        if(geometry().isValid()) {
+            show();
+        }
     }
 public slots:
     void slotWMChanged(QString msg)


### PR DESCRIPTION
修复初始化进度条中的缩略图时闪现黑色条纹
Bug: https://pms.uniontech.com/bug-view-229439.html Log: 修复初始化进度条中的缩略图时闪现黑色条纹