### PR TITLE
fix: 修复在播放完第一段视频的时候，自动播放第二段视频的刚开始会出现断层画面

### DIFF
--- a/src/libdmr/playlist_model.cpp
+++ b/src/libdmr/playlist_model.cpp
@@ -413,7 +413,7 @@ void PlaylistModel::slotStateChanged()
     case PlayerEngine::Idle:
         if (!_userRequestingItem) {
             stop();
-			//WINID方式渲染结束时，保证gpu渲染资源的正常释放与切换，延时5ms执行下部视频的播放
+	    //WINID方式渲染结束时，保证gpu渲染资源的正常释放与切换，延时5ms执行下部视频的播放
             if(!CompositingManager::get().composited()) {
                 QTimer::singleShot(5, [=]() {
                     playNext(false);

--- a/src/libdmr/playlist_model.cpp
+++ b/src/libdmr/playlist_model.cpp
@@ -413,7 +413,14 @@ void PlaylistModel::slotStateChanged()
     case PlayerEngine::Idle:
         if (!_userRequestingItem) {
             stop();
-            playNext(false);
+			//WINID方式渲染结束时，保证gpu渲染资源的正常释放与切换，延时5ms执行下部视频的播放
+            if(!CompositingManager::get().composited()) {
+                QTimer::singleShot(5, [=]() {
+                    playNext(false);
+                });
+            } else {
+                playNext(false);
+            }
         }
         break;
     }


### PR DESCRIPTION
修复在播放完第一段视频的时候，自动播放第二段视频的刚开始会出现断层画面
Bug: https://pms.uniontech.com/bug-view-234981.html 
Log: 修复winId方式渲染视频时，在播放完第一段视频的时候，自动播放第二段视频的刚开始会出现断层画面