### PR TITLE
fix: 修复最大化/全屏切换时组件闪烁

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -1126,10 +1126,6 @@ void MainWindow::onWindowStateChanged()
                 resizeByConstraints(true);
             }
         }
-        //去除状态切换设置窗口大小代码，由窗管统一管理
-//        if (m_lastRectInNormalMode.isValid() && !m_bMiniMode) {
-//            setGeometry(m_lastRectInNormalMode);
-//        }
 
         m_bMovieSwitchedInFsOrMaxed = false;
     }

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -1173,10 +1173,6 @@ void Platform_MainWindow::onWindowStateChanged()
             }
         }
 
-        if (m_lastRectInNormalMode.isValid() && !m_bMiniMode) {
-            setGeometry(m_lastRectInNormalMode);
-        }
-
         m_bMovieSwitchedInFsOrMaxed = false;
     }
     update();
@@ -1638,14 +1634,10 @@ void Platform_MainWindow::setCurrentHwdec(QString str)
 
 void Platform_MainWindow::mipsShowFullScreen()
 {
-//    QPropertyAnimation *pAn = new QPropertyAnimation(this, "windowOpacity");
-//    pAn->setDuration(100);
-//    pAn->setEasingCurve(QEasingCurve::Linear);
-//    pAn->setEndValue(1);
-//    pAn->setStartValue(0);
-//    pAn->start(QAbstractAnimation::DeleteWhenStopped);
-
-    showFullScreen();
+    ensurePolished();
+    // 保留 WindowMinimized 旧状态标识
+    setWindowState(windowState() | Qt::WindowFullScreen);
+    setVisible(true);
 }
 
 void Platform_MainWindow::menuItemInvoked(QAction *pAction)
@@ -2068,17 +2060,19 @@ void Platform_MainWindow::requestAction(ActionFactory::ActionKind actionKind, bo
         m_pToolbox->closeAnyPopup();
 
         if (isFullScreen()) {
+            // 和 mainwindow.cpp 保持一致，在 mipsShowFullScreen() 时保留 Qt::WindowMaximized 的状态以正常切换。
+            setWindowState(windowState() & ~Qt::WindowFullScreen);
+
             if (m_bMaximized) {
-                showNormal();           //直接最大化会失败
                 showMaximized();
             } else {
-                setWindowState(windowState() & ~Qt::WindowFullScreen);
                 if (m_lastRectInNormalMode.isValid() && !m_bMiniMode && !isMaximized()) {
                     setGeometry(m_lastRectInNormalMode);
                     move(m_lastRectInNormalMode.x(), m_lastRectInNormalMode.y());
                     resize(m_lastRectInNormalMode.width(), m_lastRectInNormalMode.height());
                 }
             }
+
             if (m_pFullScreenTimeLable && !isFullScreen()) {
                 m_pFullScreenTimeLable->close();
             }


### PR DESCRIPTION
在X11部分场景下, 直接使用showMaximized()可能无效, X11
使用协议不理解全屏窗口(Qt帮助). 旧版代码在最大化前调用
showNormal(), 会导致窗口状态变更两次, 使得界面闪烁.
调整和 mainwindow.cpp 保持一致, 全屏时保留Maximized状态
信息, 以正常触发全屏的切换.
移除手动设置窗口大小, 由窗管统一管理.

Log: 修复最大化/全屏切换时组件闪烁问题
Bug: https://pms.uniontech.com/bug-view-239775.html