### PR TITLE
fix: 修复消息提示框问题

### DIFF
--- a/src/widgets/platform/platform_notification_widget.cpp
+++ b/src/widgets/platform/platform_notification_widget.cpp
@@ -141,7 +141,6 @@ void Platform_NotificationWidget::popup(const QString &msg, bool flag)
     m_pMsgLabel->setText(msg);
 
     if (flag) {
-        if (!m_pMainWindow->isActiveWindow()) {
             QList<WId> currentApplicationWindowList;
             const QWindowList &list = qApp->allWindows();
 
@@ -179,6 +178,7 @@ void Platform_NotificationWidget::popup(const QString &msg, bool flag)
                     }
                 }
             }
+        if (!m_pMainWindow->isActiveWindow()) {
             m_pTimer->start(500);
         } else
             m_pTimer->start(2000);


### PR DESCRIPTION
窗口激活时同样判断窗口层叠，防止非顶层激活

Bug: https://pms.uniontech.com/bug-view-228787.html
Log: 修复部分已知问题