### PR TITLE
chore: Bump version to 5.10.44

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-movie-reborn (5.10.44) unstable; urgency=medium
+
+  * New version 5.10.44
+  * fix: Crash when switching mini mode on Wayland.(Bug: 241865)
+
+ -- renbin <renbin@uniontech.com>  Mon, 05 Feb 2024 13:50:00 +0800
+
 deepin-movie-reborn (5.10.43) unstable; urgency=medium
 
   * New version 5.10.43


### PR DESCRIPTION
Bump version to 5.10.44
PR:
* https://github.com/linuxdeepin/deepin-movie-reborn/pull/418

Log: Bump version to 5.10.44