### PR TITLE
feat: 不参与合成器崩溃重连

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,6 +145,9 @@ QString getFunctionMovieName()
 
 int main(int argc, char *argv[])
 {
+    // Task 326583 不参与合成器崩溃重连
+    unsetenv("QT_WAYLAND_RECONNECT");
+
     //for qt5platform-plugins load DPlatformIntegration or DPlatformIntegrationParent
     if (!QString(qgetenv("XDG_CURRENT_DESKTOP")).toLower().startsWith("deepin")){
         setenv("XDG_CURRENT_DESKTOP", "Deepin", 1);


### PR DESCRIPTION
应用涉及 GPU 加速，目前合成器重连暂未完整支持，
移除 QT_WAYLAND_RECONNECT 环境变量，不参与合成
器崩溃重连。

Log: 规避部分已知问题
Task: https://pms.uniontech.com/task-view-326583.html