### PR TITLE
fix: 全屏播放时存在裁剪圆角

### DIFF
--- a/src/backends/mediaplayer/qtplayer_glwidget.h
+++ b/src/backends/mediaplayer/qtplayer_glwidget.h
@@ -67,7 +67,8 @@ private:
 
     bool m_bPlaying;                   //记录播放状态
     bool m_bInMiniMode;                //是否是最小化
-    bool m_bDoRoundedClipping;         //
+    bool m_bUseCustomFBO;              // 使用自定的 QOpenGLFramebufferObject 进行绘制
+    bool m_bDoRoundedClipping;         // 裁剪圆角
 
     QOpenGLVertexArrayObject m_vao;    //顶点数组对象
     QOpenGLBuffer m_vbo;               //顶点缓冲对象

--- a/src/backends/mpv/mpv_glwidget.cpp
+++ b/src/backends/mpv/mpv_glwidget.cpp
@@ -463,8 +463,10 @@ namespace dmr {
 
 #ifdef _LIBDMR_
         if(utils::check_wayland_env()){
+            m_bDoRoundedClipping = true;
             toggleRoundedClip(true);
         }else{
+            m_bDoRoundedClipping = false;
             toggleRoundedClip(false);
         }
 #else
@@ -472,6 +474,9 @@ namespace dmr {
         connect(window()->windowHandle(), &QWindow::windowStateChanged, [=]() {
             QWidget* pTopWid = this->topLevelWidget();
             bool rounded = !pTopWid->isFullScreen() && !pTopWid->isMaximized();
+            // 全屏和最大化下不裁剪圆角
+            m_bDoRoundedClipping = rounded;
+
             //wayland
             if(utils::check_wayland_env()) {
                 rounded = true;
@@ -519,7 +524,7 @@ namespace dmr {
 
     void MpvGLWidget::updateMovieFbo()
     {
-        if (!m_bDoRoundedClipping) return;
+        if (!m_bUseCustomFBO) return;
 
         auto desiredSize = size() * qApp->devicePixelRatio();
 
@@ -535,7 +540,7 @@ namespace dmr {
 
     void MpvGLWidget::updateCornerMasks()
     {
-        if (!utils::check_wayland_env() && !m_bDoRoundedClipping) return;
+        if (!utils::check_wayland_env() && !m_bUseCustomFBO) return;
 
         for (int i = 0; i < 4; i++) {
             QSize sz(RADIUS, RADIUS);
@@ -717,7 +722,7 @@ namespace dmr {
 
         updateMovieFbo();
         updateVbo();
-        if (m_bDoRoundedClipping){
+        if (m_bUseCustomFBO){
             updateVboCorners();
         }
         qInfo() << "GL resize" << nWidth << nHeight;
@@ -726,7 +731,9 @@ namespace dmr {
 
     void MpvGLWidget::toggleRoundedClip(bool bFalse)
     {
-        m_bDoRoundedClipping = bFalse;
+        // 设置圆角时使用自定的FBO，但在全屏和最大化时，通过
+        // m_bDoRoundedClipping 设置是否实际应用圆角
+        m_bUseCustomFBO = bFalse;
         makeCurrent();
         updateMovieFbo();
         update();
@@ -739,7 +746,8 @@ namespace dmr {
         m_bPlaying = false;
         m_bInMiniMode= false;
 
-        m_bDoRoundedClipping=true;
+        m_bUseCustomFBO = true;
+        m_bDoRoundedClipping = true;
         m_pDarkTex = nullptr;
         m_pLightTex = nullptr;
         m_pGlProg = nullptr;
@@ -776,7 +784,7 @@ namespace dmr {
             QSize scaled = size() * dpr;
             int nFlip = 1;
 
-            if (!m_bDoRoundedClipping) {
+            if (!m_bUseCustomFBO) {
                 mpv_opengl_fbo fbo {
                     static_cast<int>(defaultFramebufferObject()), scaled.width(), scaled.height(), 0
                 };

--- a/src/backends/mpv/mpv_glwidget.h
+++ b/src/backends/mpv/mpv_glwidget.h
@@ -93,7 +93,8 @@ private:
 
     bool m_bPlaying;                   //记录播放状态
     bool m_bInMiniMode;                //是否是最小化
-    bool m_bDoRoundedClipping;         //
+    bool m_bUseCustomFBO;              // 使用自定的 QOpenGLFramebufferObject 进行绘制
+    bool m_bDoRoundedClipping;         // 裁剪圆角
 
     QOpenGLVertexArrayObject m_vao;    //顶点数组对象
     QOpenGLBuffer m_vbo;               //顶点缓冲对象


### PR DESCRIPTION
GL绘制代码中使用自定FBO和裁剪圆角部分绑定,
wayland下需要使用自定FBO以避免出现闪黑屏,
而全屏下不需要裁剪圆角。
为兼容两种场景，将自定FBO和绘制圆角改为两个
Flag变量控制，全屏/最大化时，使用自定FBO绘制
也不会绘制圆角，其它流程保持原样。
* 在(非)组合模式下，切换迷你模式、窗口模式、 全屏测试

关联Bug:
https://pms.uniontech.com/bug-view-225881.html
https://pms.uniontech.com/bug-view-196087.html

Log: 修复部分播放显示问题
Bug: https://pms.uniontech.com/bug-view-247735.html