### PR TITLE
chore: Bump version to 5.10.47

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-movie-reborn (5.10.47) unstable; urgency=medium
+
+  * New version 5.10.47
+
+ -- renbin <renbin@uniontech.com>  Wed, 27 Mar 2024 15:51:03 +0800
+
 deepin-movie-reborn (5.10.46) unstable; urgency=medium
 
   * New version 5.10.46


### PR DESCRIPTION
Bump version to 5.10.47
PR:
* https://github.com/linuxdeepin/deepin-movie-reborn/pull/430
* https://github.com/linuxdeepin/deepin-movie-reborn/pull/431
* https://github.com/linuxdeepin/deepin-movie-reborn/pull/432

Log: Bump version to 5.10.47