### PR TITLE
fix: 暂停图标在最小化时仍显示

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -1186,6 +1186,7 @@ void Platform_MainWindow::onWindowStateChanged()
         if (m_pPlaylist->state() == Platform_PlaylistWidget::Opened) {
             m_pPlaylist->togglePopup(false);
         }
+        m_pAnimationlable->hide();
     }
     if (isMaximized()) {
         m_pAnimationlable->move(QPoint(QApplication::desktop()->availableGeometry().width() / 2 - 100
@@ -1276,7 +1277,7 @@ void Platform_MainWindow::onApplicationStateChanged(Qt::ApplicationState e)
 
 void Platform_MainWindow::animatePlayState()
 {
-    if (m_bMiniMode) {
+    if (m_bMiniMode || isMinimized()) {
         return;
     }
 


### PR DESCRIPTION
非组合模式下暂停图标设置了Tool标志，
调整为最小化时不触发动画，播放过程的
动画也隐藏。

Log: 修复暂停图标在最小化时仍显示的问题
Bug: https://pms.uniontech.com/bug-view-247791.html