### PR TITLE
fix: 修复从相机点击播放视频打开影院,窗口层级显示不对

### DIFF
--- a/src/common/dbus_adpator.cpp
+++ b/src/common/dbus_adpator.cpp
@@ -45,7 +45,7 @@ bool ApplicationAdaptor::openFile(const QString &sFile)
 //        m_oldTime = current;
         m_pMainWindow->play({url.toString()});
 //    }
-
+    Raise();//激活窗口
     return true;
 }
 

--- a/src/common/platform/platform_dbus_adpator.cpp
+++ b/src/common/platform/platform_dbus_adpator.cpp
@@ -44,6 +44,7 @@ void Platform_ApplicationAdaptor::openFile(const QString &sFile)
         m_oldTime = current;
         m_pMainWindow->play({url.toString()});
     }
+    Raise();//激活窗口
 }
 
 void Platform_ApplicationAdaptor::Raise()


### PR DESCRIPTION
修复从相机点击播放视频打开影院,窗口层级显示不对

Bug: https://pms.uniontech.com/bug-view-248689.html
Log: 修复从相机点击播放视频打开影院,窗口层级显示不对