### PR TITLE
fix: 修复全屏后切换迷你模式窗口大小错误

### DIFF
--- a/src/common/mainwindow.h
+++ b/src/common/mainwindow.h
@@ -526,6 +526,7 @@ private:
     QImage m_imgBgLight;
     bool m_bMiniMode;                               ///记录迷你模式
     QRect m_lastRectInNormalMode;                   /// used to restore to recent geometry when quit fullscreen or minVolumeMonitoringi mode
+    QRect m_waylandRectInNormalMode;                /// wayland下记录切换迷你模式前默认窗口状态
     bool m_bInited;                                 /// the first time a play happens, we consider it inited.
     EventMonitor *m_pEventMonitor;                  ///x11事件处理器
     bool m_bMovieSwitchedInFsOrMaxed;               /// track if next/prev is triggered in fs/maximized mode


### PR DESCRIPTION
旧有流程在切换迷你模式后,缓存的normalGeometry
被最大化大小覆盖.
新增m_waylandRectInNormalMode变量以保留默认界面大小.
备注:此提交仅针对bug单提及流程,其它切换仍存在问题

Log: 修复部分界面问题
Bug: https://pms.uniontech.com/bug-view-249413.html