### PR TITLE
chore: Bump version to 5.10.49

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-movie-reborn (5.10.49) unstable; urgency=medium
+
+  * fix: Minimode display error after showfullscreen().(Bug: 249413)
+
+ -- renbin <renbin@uniontech.com>  Tue, 16 Apr 2024 16:41:52 +0800
+
 deepin-movie-reborn (5.10.48) unstable; urgency=medium
 
   * New version 5.10.48


### PR DESCRIPTION
Bump version to 5.10.49
PR:
* https://github.com/linuxdeepin/deepin-movie-reborn/pull/445

Log: Bump version to 5.10.49