### PR TITLE
fix: 应用层检测到屏幕后对应用进行移动

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -988,6 +988,16 @@ MainWindow::MainWindow(QWidget *parent)
                                          SLOT(slotProperChanged(QString, QVariantMap, QStringList)));
     qInfo() << "session Path is :" << path;
     connect(dynamic_cast<MpvProxy *>(m_pEngine->getMpvProxy()),&MpvProxy::crashCheck,&Settings::get(),&Settings::crashCheck);
+    if(utils::check_wayland_env()) {
+        connect(qApp, &QGuiApplication::screenRemoved, this, [=](){
+            QRect geoRect = geometry();
+            QRect deskRect = QApplication::desktop()->availableGeometry(geoRect.topLeft());
+
+            if(!deskRect.intersects(geoRect)) {
+                move(deskRect.x(), deskRect.y());
+            }
+        });
+    }
     //解码初始化
     decodeInit();
 }


### PR DESCRIPTION
应用层检测到屏幕后对应用进行移动

Bug: https://pms.uniontech.com/bug-view-252617.html
Log: 应用层检测到屏幕后对应用进行移动