### PR TITLE
fix: 修复全屏后切换迷你模式，右键菜单中的全屏勾选状态显示错误

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -3916,6 +3916,11 @@ void Platform_MainWindow::contextMenuEvent(QContextMenuEvent *pEvent)
     resumeToolsWindow();
     QTimer::singleShot(0, [ = ]() {
         qApp->restoreOverrideCursor();
+        QList<QAction *> lstAct = ActionFactory::get().findActionsByKind(ActionFactory::ActionKind::ToggleFullscreen);
+        if(!lstAct.isEmpty()) {
+            QAction *pAct = lstAct.first();
+            if(pAct) pAct->setChecked(isFullScreen());
+        }
         ActionFactory::get().mainContextMenu()->popup(QCursor::pos());
     });
     pEvent->accept();


### PR DESCRIPTION
修复全屏后切换迷你模式，右键菜单中的全屏勾选状态显示错误

Bug: https://pms.uniontech.com/bug-view-262887.html
Log: 修复全屏后切换迷你模式，右键菜单中的全屏勾选状态显示错误