### PR TITLE
fix: 修复兆芯右键硬解不能旋转

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -449,6 +449,11 @@ mpv_handle *MpvProxy::mpv_init()
                 my_set_property(pHandle, "vo", "vaapi");
                 my_set_property(pHandle, "hwdec", "vaapi");
                 m_sInitVo = "vaapi";
+
+                if (version >= 21) {    // bug: 285669
+                    my_set_property(pHandle, "vo", "gpu");
+                    m_sInitVo = "gpu";
+                }
             } else {
                 my_set_property(pHandle, "vo", "gpu");
                 m_sInitVo = "gpu";


### PR DESCRIPTION
修复兆芯右键硬解不能旋转

Log: 修复兆芯右键硬解不能旋转
Bug: https://pms.uniontech.com/bug-view-285669.html