### PR TITLE
fix: 修复移动播放窗口后，点击还原按钮无响应

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -1157,7 +1157,9 @@ bool Platform_MainWindow::event(QEvent *pEvent)
     if (pEvent->type() == QEvent::WindowDeactivate) {
         m_pCommHintWid->hide();
     }
-
+    if (pEvent->type() == QEvent::Enter) {
+        m_bMouseMoved = false;
+    }
     return DMainWindow::event(pEvent);
 }
 
@@ -3636,6 +3638,10 @@ void Platform_MainWindow::moveEvent(QMoveEvent *pEvent)
     QPoint relativePoint = mapToGlobal(QPoint(0, 0));
     m_pToolbox->updateSliderPoint(relativePoint);
     updateGeometryNotification(geometry().size());
+    xcb_generic_event_t *event = xcb_wait_for_event(QX11Info::connection());
+    if((event->response_type & ~0x80) != XCB_CONFIGURE_NOTIFY) {
+        m_bMouseMoved = false;
+    }
 }
 
 void Platform_MainWindow::keyPressEvent(QKeyEvent *pEvent)


### PR DESCRIPTION
修复移动播放窗口后，点击还原按钮无响应

Bug: https://pms.uniontech.com/bug-view-293141.html
Log: 修复移动播放窗口后，点击还原按钮无响应