### PR TITLE
fix: 迷你模式下规避防止窗管菜单可以改变大小

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -3638,10 +3638,6 @@ void Platform_MainWindow::moveEvent(QMoveEvent *pEvent)
     QPoint relativePoint = mapToGlobal(QPoint(0, 0));
     m_pToolbox->updateSliderPoint(relativePoint);
     updateGeometryNotification(geometry().size());
-    xcb_generic_event_t *event = xcb_wait_for_event(QX11Info::connection());
-    if((event->response_type & ~0x80) != XCB_CONFIGURE_NOTIFY) {
-        m_bMouseMoved = false;
-    }
 }
 
 void Platform_MainWindow::keyPressEvent(QKeyEvent *pEvent)
@@ -4262,6 +4258,7 @@ void Platform_MainWindow::toggleUIMode()
         QRect deskGeom = qApp->desktop()->availableGeometry(this);
         move((deskGeom.width() - this->width()) / 2, (deskGeom.height() - this->height()) / 2); //迷你模式下窗口居中 by zhuyuliang
         resize(geom.width(), geom.height());
+        setFixedSize(geom.size());
 
         m_pMiniPlayBtn->move(sz.width() - 12 - m_pMiniPlayBtn->width(),
                              sz.height() - 10 - m_pMiniPlayBtn->height());
@@ -4269,6 +4266,7 @@ void Platform_MainWindow::toggleUIMode()
         m_pMiniQuitMiniBtn->move(14, sz.height() - 10 - m_pMiniQuitMiniBtn->height());
     } else {
         m_pCommHintWid->setAnchorPoint(QPoint(30, 58));
+        setMaximumSize(INT_MAX, INT_MAX);
         setEnableSystemResize(true);
         if (m_nStateBeforeMiniMode & SBEM_Maximized) {
             //迷你模式切换最大化时，先恢复原来窗口大小


### PR DESCRIPTION
迷你模式下规避防止窗管菜单可以改变大小

Bug: https://pms.uniontech.com/bug-view-293145.html
Log: 迷你模式下规避防止窗管菜单可以改变大小