### PR TITLE
fix: 优化显示切换时内存泄漏，及时释放显示纹理资源

### DIFF
--- a/src/backends/mpv/mpv_glwidget.cpp
+++ b/src/backends/mpv/mpv_glwidget.cpp
@@ -861,7 +861,7 @@ namespace dmr {
                         m_vboCorners[i].release();
                     }
                 }
-
+                pGLFunction->glBindTexture(GL_TEXTURE_2D, 0);
                 pGLFunction->glDisable(GL_BLEND);
             }
 #ifdef __x86_64__


### PR DESCRIPTION
优化显示切换时内存泄漏，及时释放显示纹理资源

Bug: https://pms.uniontech.com/bug-view-287761.html
Log: 优化显示切换时内存泄漏，及时释放显示纹理资源