### PR TITLE
fix: wayland下防止resize时改变窗口坐标，由窗管自己完成

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -2114,7 +2114,7 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
             if (m_bMaximized) {
                 showMaximized();
             } else {
-                if (m_lastRectInNormalMode.isValid() && !m_bMiniMode && !isMaximized()) {
+                if (!utils::check_wayland_env() && m_lastRectInNormalMode.isValid() && !m_bMiniMode && !isMaximized()) {
                     setGeometry(m_lastRectInNormalMode);
                     move(m_lastRectInNormalMode.x(), m_lastRectInNormalMode.y());
                     resize(m_lastRectInNormalMode.width(), m_lastRectInNormalMode.height());
@@ -3686,7 +3686,7 @@ void MainWindow::resizeEvent(QResizeEvent *pEvent)
     QRect geoRect = geometry();
     QRect deskRect = QApplication::desktop()->availableGeometry(geoRect.topLeft());
 
-    if(!deskRect.intersects(geoRect)) {
+    if(!utils::check_wayland_env() && !deskRect.intersects(geoRect)) {
         move(deskRect.x(), deskRect.y());
     }
 }


### PR DESCRIPTION
wayland下防止resize时改变窗口坐标，由窗管自己完成

Bug: https://pms.uniontech.com/bug-view-300849.html
Log: wayland下防止resize时改变窗口坐标，由窗管自己完成