### PR TITLE
fix: 不同平台下，睡眠后播放状态不一致的问题

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -4538,7 +4538,7 @@ void MainWindow::sleepStateChanged(bool bSleep)
     }
     if (bSleep && m_pEngine->state() == PlayerEngine::CoreState::Playing) {
         m_bStartSleep = true;
-        //requestAction(ActionFactory::ActionKind::TogglePause);
+        requestAction(ActionFactory::ActionKind::TogglePause);
     } else if (!bSleep && m_pEngine->state() == PlayerEngine::CoreState::Paused) {
         m_bStartSleep = false;
         m_pEngine->seekAbsolute(static_cast<int>(m_pEngine->elapsed()));      //保证休眠后不管是否播放都不会卡帧
@@ -4561,7 +4561,7 @@ void MainWindow::lockStateChanged(bool bLock)
         QTimer::singleShot(500, [=](){
             //龙芯5000使用命令sudo rtcwake -l -m mem -s 20, 待机唤醒后无dBus信号“PrepareForSleep”发出,加入seek保证解锁后播放不会卡帧
             m_pEngine->seekAbsolute(static_cast<int>(m_pEngine->elapsed()));
-            requestAction(ActionFactory::ActionKind::TogglePause);
+            // requestAction(ActionFactory::ActionKind::TogglePause); //需求变更，唤醒后不恢复播放
         });
     }
 }
@@ -4747,7 +4747,7 @@ void MainWindow::onSysLockState(QString, QVariantMap key2value, QStringList)
         requestAction(ActionFactory::TogglePause);
     } else if (!key2value.value("Locked").value<bool>() && m_bStateInLock) {
         m_bStateInLock = false;
-        requestAction(ActionFactory::TogglePause);
+        // requestAction(ActionFactory::TogglePause); //需求变更，唤醒后不恢复播放
     }
 }
 

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -4459,7 +4459,7 @@ void Platform_MainWindow::lockStateChanged(bool bLock)
         QTimer::singleShot(500, [=](){
             //龙芯5000使用命令sudo rtcwake -l -m mem -s 20, 待机唤醒后无dBus信号“PrepareForSleep”发出,加入seek保证解锁后播放不会卡帧
             m_pEngine->seekAbsolute(static_cast<int>(m_pEngine->elapsed()));
-            requestAction(ActionFactory::ActionKind::TogglePause);
+            // requestAction(ActionFactory::ActionKind::TogglePause); //需求变更，唤醒后不恢复播放
         });
     }
 }
@@ -4645,7 +4645,7 @@ void Platform_MainWindow::onSysLockState(QString, QVariantMap key2value, QString
         requestAction(ActionFactory::TogglePause);
     } else if (!key2value.value("Locked").value<bool>() && m_bStateInLock) {
         m_bStateInLock = false;
-        requestAction(ActionFactory::TogglePause);
+        // requestAction(ActionFactory::TogglePause); //需求变更，唤醒后不恢复播放
     }
 }
 


### PR DESCRIPTION
dbus信号不可控，不同平台使用的代码不同，platform_mainwindow上在休眠和锁定情况下都会切换状态，dbus信号异常时，状态也会异常。 而mainwindow中只会在锁定情况下切换状态，所以不会异常，该提交没有同步到platform_mainwindow。

log: 统一不同平台表现，及变更需求为：待机重启后，暂停播放。

bug: https://pms.uniontech.com/bug-view-291039.html