### PR TITLE
fix: Fix app crash on loong64

### DIFF
--- a/deploy_dep
+++ b/deploy_dep
@@ -33,7 +33,7 @@ done
 # 获取依赖的所有文件
 for LDFILE in "$@"; do
 
-    # 判断文件是否以 .so 结尾
+    # 判断文件是否以 .so 或 *.so.? 结尾
     if [[ "$LDFILE" == *.so || "$LDFILE" == *.so.? ]]; then
         FILE_PATH="${PREFIX}/lib/${TRIPLET}/$LDFILE"
 

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -20,7 +20,8 @@ command:
 
 build: |
   # libxcb1-dev：解决构建失败
-  bash ./install_dep linglong/sources "${PREFIX}" "libxcb1-dev"
+  # libmpv.so 依赖于 libatomic.so.1，但 libatomic1 包只包含在 base develop 中
+  bash ./install_dep linglong/sources "${PREFIX}" "libxcb1-dev,libatomic1"
 
   # 调整头文件查找路径
   sed -i "s|/usr/include/glib-2.0|/runtime/include/glib-2.0|g" src/CMakeLists.txt
@@ -59,6 +60,8 @@ build: |
     libgstpbutils-1.0.so
     libffmpegthumbnailer.so
     ../libdeepin-event-log.so
+    # libmpv.so 依赖于 libatomic.so.1，但 libatomic1 包只包含在 base develop 中
+    libatomic.so.1
   )
 
   # 生成.install 文件


### PR DESCRIPTION
The crash is caused by the failure to load the libmpv.so library, because its dependency libatomic.so.1 is included in base develop module but not in binary module. The solution is to manually install the libatomic.so.1 library and its dependencies.

Log: Fix app crash on loong64