### PR TITLE
chore: Bump version to 6.5.6

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.5.1
+  version: 6.5.6.1
   kind: app
   description: |
     movie for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-movie-reborn (6.5.6) unstable; urgency=medium
+
+  * fix: Fixed playback issues(Bug: 306447)
+  * fix: Fixed custom mode exceptions
+
+ -- renbin <renbin@uniontech.com>  Thu, 06 Mar 2025 19:54:28 +0800
+
 deepin-movie-reborn (6.5.5) unstable; urgency=medium
 
   * chore: New version 6.5.5.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.5.1
+  version: 6.5.6.1
   kind: app
   description: |
     movie for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.5.1
+  version: 6.5.6.1
   kind: app
   description: |
     movie for deepin os.


### PR DESCRIPTION
Bump version to 6.5.6

Log: Bump version to 6.5.6

## Summary by Sourcery

Chores:
- Bump version to 6.5.6.1 in linglong.yaml files.