### PR TITLE
fix: Added a forced binding window mode

### DIFF
--- a/examples/test/window.cpp
+++ b/examples/test/window.cpp
@@ -10,6 +10,7 @@ Window::Window(QWidget *parent) : QWidget (parent)
 
     auto l = new QVBoxLayout(this);
 
+    dmr::CompositingManager::get().setProperty("forceBind", true);
     if (dmr::CompositingManager::get().composited()) {
     dmr::CompositingManager::get().overrideCompositeMode(false);
     }

--- a/src/libdmr/compositing_manager.h
+++ b/src/libdmr/compositing_manager.h
@@ -78,6 +78,9 @@ public:
     bool composited() const
     {
 #if defined (_LIBDMR_)
+        if (property("forceBind").isValid() && property("forceBind").toBool()) {
+            return false;
+        }
         return true;
 #endif
         return _composited;

--- a/src/libdmr/player_widget.cpp
+++ b/src/libdmr/player_widget.cpp
@@ -6,12 +6,16 @@
 #include "player_widget.h"
 #include "filefilter.h"
 #include <player_engine.h>
+#include <compositing_manager.h>
 
 namespace dmr {
 
 PlayerWidget::PlayerWidget(QWidget *parent)
     : QWidget (parent)
 {
+    if (parent->property("forceBind").toBool()) {
+        CompositingManager::get().setProperty("forceBind", true);
+    }
     utils::first_check_wayland_env();
     _engine = new PlayerEngine(this);
     auto *l = new QVBoxLayout;


### PR DESCRIPTION
Added a forced binding window mode

Log: Added a forced binding window mode

## Summary by Sourcery

Adds a mode to force binding a window, bypassing the compositing manager. This is achieved by setting the "forceBind" property, which is then checked by the compositing manager to determine whether to enable compositing.