### PR TITLE
fix: [settings] Saved with incorrect fields stored in the data.

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -2924,7 +2924,7 @@ void MainWindow::handleSettings(DSettingsDialog *dsd)
             QProcess::startDetached(qApp->applicationFilePath(), QStringList() << "--restart");
         } else {
             if (decodeType != 3) {
-                Settings::get().settings()->setOption("base.decode.select", decodeMode);
+                Settings::get().settings()->setOption("base.decode.select", decodeType);
             }
             Settings::get().settings()->setOption("base.decode.Decodemode", decodeMode);
             Settings::get().settings()->setOption("base.decode.Videoout", voMode);

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -2926,7 +2926,7 @@ void Platform_MainWindow::handleSettings(DSettingsDialog *dsd)
                     QProcess::startDetached(qApp->applicationFilePath(), QStringList() << "--restart");
                 } else {
                     if (decodeType != 3) {
-                        Settings::get().settings()->setOption("base.decode.select", decodeMode);
+                        Settings::get().settings()->setOption("base.decode.select", decodeType);
                     }
                     Settings::get().settings()->setOption("base.decode.Effect", effectMode);
                     Settings::get().settings()->setOption("base.decode.Decodemode", decodeMode);


### PR DESCRIPTION
Log: as title

## Summary by Sourcery

Bug Fixes:
- Fixes incorrect value being assigned to the 'base.decode.select' setting.