### PR TITLE
fix: Fixed the volume bar issue

### DIFF
--- a/src/widgets/platform/platform_volumeslider.cpp
+++ b/src/widgets/platform/platform_volumeslider.cpp
@@ -340,10 +340,10 @@ void Platform_VolumeSlider::setThemeType(int type)
     Q_UNUSED(type)
 }
 
-void Platform_VolumeSlider::enterEvent(QEvent *e)
+void Platform_VolumeSlider::enterEvent(QEnterEvent *e)
 {
     m_mouseIn = true;
-    QWidget::leaveEvent(e);
+    QWidget::enterEvent(e);
 }
 void Platform_VolumeSlider::showEvent(QShowEvent *se)
 {

--- a/src/widgets/platform/platform_volumeslider.h
+++ b/src/widgets/platform/platform_volumeslider.h
@@ -63,7 +63,7 @@ public slots:
     void delayedHide();
 
 protected:
-    void enterEvent(QEvent *e);
+    void enterEvent(QEnterEvent *e);
     void showEvent(QShowEvent *se);
     void leaveEvent(QEvent *e);
     void paintEvent(QPaintEvent *);

--- a/src/widgets/volumeslider.cpp
+++ b/src/widgets/volumeslider.cpp
@@ -203,7 +203,7 @@ void VolumeSlider::popup()
 void VolumeSlider::delayedHide()
 {
     m_mouseIn = false;
-    DUtil::TimerSingleShot(100, [this]() {
+    DUtil::TimerSingleShot(200, [this]() {
         if (!m_mouseIn)
             hide();
     });
@@ -334,10 +334,10 @@ void VolumeSlider::setThemeType(int type)
     Q_UNUSED(type)
 }
 
-void VolumeSlider::enterEvent(QEvent *e)
+void VolumeSlider::enterEvent(QEnterEvent *e)
 {
     m_mouseIn = true;
-    QWidget::leaveEvent(e);
+    QWidget::enterEvent(e);
 }
 void VolumeSlider::showEvent(QShowEvent *se)
 {

--- a/src/widgets/volumeslider.h
+++ b/src/widgets/volumeslider.h
@@ -63,7 +63,7 @@ public slots:
     void delayedHide();
 
 protected:
-    void enterEvent(QEvent *e);
+    void enterEvent(QEnterEvent *e);
     void showEvent(QShowEvent *se);
     void leaveEvent(QEvent *e);
     void paintEvent(QPaintEvent *);


### PR DESCRIPTION
Fixed the volume bar issue

Bug: https://pms.uniontech.com/zentao/bug-view-306447.html
Log: Fixed the volume bar issue

## Summary by Sourcery

Fixes an issue where the volume bar was not working correctly. The fix involves adjusting the timer delay for hiding the volume slider and ensuring the mouseIn flag is correctly updated on enter events.

Bug Fixes:
- Fixes an issue with the volume bar.
- Ensures the mouseIn flag is correctly updated on enter events.