### PR TITLE
fix: Fixed the issue that it could not be exited

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -3726,8 +3726,13 @@ void Platform_MainWindow::closeEvent(QCloseEvent *pEvent)
         Settings::get().onSetCrash();
         needWait = true;
     }
-    if (needWait)
+    if (needWait) {
+        QTimer::singleShot(2000, this, [=](){
+            if (loop.isRunning())
+                loop.quit();
+        });
         loop.exec();
+    }
     m_pEngine->savePlaybackPosition();
 
     pEvent->accept();


### PR DESCRIPTION
Fixed the issue that it could not be exited

Bug: https://pms.uniontech.com/bug-view-309631.html
Log: Fixed the issue that it could not be exited

## Summary by Sourcery

Bug Fixes:
- Resolved an issue where the application could not be properly exited by adding a timeout mechanism to the close event handler