### PR TITLE
fix: [settings]  The actual decoding method does not match the settings

### DIFF
--- a/src/backends/mpv/mpv_proxy.h
+++ b/src/backends/mpv/mpv_proxy.h
@@ -98,7 +98,8 @@ class MpvGLWidget;
 enum DecodeMode {
     AUTO = 0,
     HARDWARE,
-    SOFTWARE
+    SOFTWARE,
+    CUSTOM
 };
 
 /**

--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -1170,7 +1170,7 @@ MainWindow::MainWindow(QWidget *parent)
         });
     }
     //解码初始化
-    //decodeInit();
+    decodeInit();
 }
 
 void MainWindow::setupTitlebar()
@@ -4339,8 +4339,8 @@ void MainWindow::decodeInit()
         return;
 
     //崩溃检测
-    bool bcatch = Settings::get().settings()->getOption(QString("set.start.crash")).toBool();
-    if (bcatch) {
+    int bcatch = Settings::get().settings()->getOption(QString("set.start.crash")).toInt(); // this value can be 0 1 2 after `Custom Decode mode`. 1:crash 2:restart
+    if (bcatch == 1) {
         pMpvProxy->setDecodeModel(DecodeMode::AUTO);
         Settings::get().settings()->setOption(QString("base.decode.select"),DecodeMode::AUTO);
     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -329,9 +329,8 @@ int main(int argc, char *argv[])
         dmr::Settings::get().settings()->setOption("base.decode.select", 0);
         dmr::Settings::get().settings()->setOption("base.decode.Decodemode", 0);
         dmr::Settings::get().settings()->setOption("base.decode.Videoout", 0);
+        dmr::Settings::get().crashCheck();
     }
-
-    dmr::Settings::get().crashCheck();
 
     bool singleton = !dmr::Settings::get().isSet(dmr::Settings::MultipleInstance);
     QString movieName = "";


### PR DESCRIPTION
Log: as title

Bug: https://pms.uniontech.com/bug-view-310515.html

## Summary by Sourcery

Fix decoding method configuration to match the actual settings in the media player

Bug Fixes:
- Corrected the decoding mode selection logic to properly match the user's selected decode mode settings
- Fixed crash detection handling to support multiple crash check states

Enhancements:
- Added a new CUSTOM decode mode to the DecodeMode enum to support more flexible decoding configurations

Chores:
- Refactored decode mode checking conditions in multiple methods to use more explicit comparisons