### PR TITLE
fix: Adapt to dconfig

### DIFF
--- a/assets/org.deepin.movie.minimode.json
+++ b/assets/org.deepin.movie.minimode.json
@@ -11,6 +11,26 @@
           "description": "Mini mode special handling, like Huawei",
           "permissions": "readwrite",
           "visibility": "private"
-      }
+      },
+      "compositedHandling": {
+        "value": "Default",
+        "serial": 0,
+        "flags": ["global"],
+        "name": "composited Handling",
+        "name[zh_CN]": "混合模式判断",
+        "description": "composited mode judgment",
+        "permissions": "readwrite",
+        "visibility": "private"
+    },
+      "playConfigHandling": {
+        "value": "",
+        "serial": 0,
+        "flags": ["global"],
+        "name": "Play config Handling",
+        "name[zh_CN]": "播放配置",
+        "description": "Play config Handling",
+        "permissions": "readwrite",
+        "visibility": "private"
+    }
   }
 }

--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,5 @@ override_dh_auto_configure:
 	  -DQT_VERSION=6
 
 override_dh_install:
-	dh_install --exclude=usr/share/dsg/configs/org.deepin.movie \
-		   --exclude=usr/lib/uos-ai-assistant/functions
+	dh_install --exclude=usr/lib/uos-ai-assistant/functions
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(Qt6 COMPONENTS Gui Widgets DBus LinguistTools Network Concurrent Sq
 
 if (Qt6_FOUND)
     # Qt6 environment
+    find_package(Dtk6 REQUIRED COMPONENTS Core)
     pkg_check_modules(Dtk REQUIRED IMPORTED_TARGET dtk6widget)
     pkg_check_modules(Dtk REQUIRED IMPORTED_TARGET dtk6gui)
     pkg_check_modules(Dtk REQUIRED IMPORTED_TARGET dtk6core)
@@ -107,6 +108,13 @@ if (Qt6_FOUND)
         RENAME deepin-movie.svg)
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/assets/deepin-movie DESTINATION ${CMAKE_INSTALL_DATADIR}/deepin-manual/manual-assets/application/)
     install (FILES ${CMAKE_SOURCE_DIR}/com.deepin.movie.service DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/services/)
+
+    set(APPID org.deepin.movie)
+    set(configFile ${PROJECT_SOURCE_DIR}/assets/org.deepin.movie.minimode.json)
+    if (DEFINED DSG_DATA_DIR)
+        message("-- DConfig is supported by DTK")
+        dtk_add_config_meta_files(APPID ${APPID} FILES ${configFile})
+    endif()
 
     # 加速编译优化参数
     if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "mips64")

--- a/src/libdmr/utils.cpp
+++ b/src/libdmr/utils.cpp
@@ -7,11 +7,15 @@
 #include <QtDBus>
 #include <QtWidgets>
 #include <QPainterPath>
+#include "dtkcore_config.h"
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <QDesktopWidget>
 #else
 #include <QScreen>	
+#endif
+#ifdef DTKCORE_CLASS_DConfigFile
+#include <DConfig>
 #endif
 
 namespace dmr {
@@ -598,6 +602,22 @@ QString ElideText(const QString &text, const QSize &size,
 
 void getPlayProperty(const char *path, QMap<QString, QString> *&proMap)
 {
+    Q_UNUSED(path);
+#ifdef DTKCORE_CLASS_DConfigFile
+    Dtk::Core::DConfig *dconfig = Dtk::Core::DConfig::create("org.deepin.movie","org.deepin.movie.minimode");
+    if(dconfig && dconfig->isValid() && dconfig->keyList().contains("playConfigHandling")){
+        QString compositedHandling = dconfig->value("playConfigHandling").toString();
+        QStringList confList = compositedHandling.split(";", Qt::SkipEmptyParts);
+        if (!confList.isEmpty()) {
+            foreach (QString item, confList) {
+                QStringList confItem = item.split("=", Qt::SkipEmptyParts);
+                if (confItem.size() == 2) {
+                    proMap->insert(confItem.first(), confItem.last());
+                }
+            }
+        }
+    }
+#else
     QFileInfo fi(path);
     if ((fi.exists() && fi.isFile()) && fi.isReadable()) {
         QFile file(path);
@@ -622,6 +642,7 @@ void getPlayProperty(const char *path, QMap<QString, QString> *&proMap)
     } else {
         qWarning() << __func__ << "file path error!!!!!";
     }
+#endif
 }
 }
 }


### PR DESCRIPTION
Adapt to dconfig

Task: https://pms.uniontech.com/task-view-374683.html
Log: Adapt to dconfig

## Summary by Sourcery

Adapt the application to use DConfig for configuration management, replacing previous configuration methods

New Features:
- Integrate DConfig for dynamic configuration handling in the movie application

Enhancements:
- Replace QGSettings with DConfig for more flexible configuration management
- Add support for platform-specific configuration handling

Build:
- Update CMake configuration to support DTK6 and DConfig integration

Chores:
- Add DConfig JSON configuration file for minimode settings