### PR TITLE
fix: [libdmr] crash when create playerwidget

### DIFF
--- a/src/libdmr/player_widget.cpp
+++ b/src/libdmr/player_widget.cpp
@@ -13,7 +13,7 @@ namespace dmr {
 PlayerWidget::PlayerWidget(QWidget *parent)
     : QWidget (parent)
 {
-    auto forceBind = parent->property("forceBind");
+    auto forceBind = parent ? parent->property("forceBind") : QVariant(false);
     if (forceBind.isValid() && forceBind.toBool()) {
         CompositingManager::get().setProperty("forceBind", true);
     }


### PR DESCRIPTION
supplementary modification of d8b03d7b05e1c740ba53bc36c885018f3a8b1850

Log: as title

Bug: https://pms.uniontech.com/bug-view-311811.html

## Summary by Sourcery

Bug Fixes:
- Add a null check when accessing parent widget's property to prevent potential null pointer dereference