### PR TITLE
fix: [libmpv] crash when app exit

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -10,7 +10,6 @@
 #include "compositing_manager.h"
 #include "player_engine.h"
 #include "hwdec_probe.h"
-#include "sysutils.h"
 
 #ifndef _LIBDMR_
 #include "dmr_settings.h"

--- a/src/backends/mpv/mpv_proxy.h
+++ b/src/backends/mpv/mpv_proxy.h
@@ -13,6 +13,7 @@
 #include <xcb/xproto.h>
 #undef Bool
 #include "../../vendor/qthelper.hpp"
+#include "sysutils.h"
 
 typedef mpv_event *(*mpv_waitEvent)(mpv_handle *ctx, double timeout);
 typedef int (*mpv_set_optionString)(mpv_handle *ctx, const char *name, const char *data);
@@ -44,8 +45,9 @@ class MpvHandle
         explicit container(mpv_handle *pHandle) : m_pHandle(pHandle) {}
         ~container()
         {
-            mpv_terminateDestroy func = (mpv_terminateDestroy)QLibrary::resolve("libmpv", "mpv_terminate_destroy");
-            func(m_pHandle);
+            mpv_terminateDestroy func = (mpv_terminateDestroy)QLibrary::resolve(SysUtils::libPath("libmpv.so"), "mpv_terminate_destroy");
+            if (func)
+                func(m_pHandle);
         }
         mpv_handle *m_pHandle;
     };


### PR DESCRIPTION
crash caused by unable to find symbol

Log:  as title

Bug: https://pms.uniontech.com/bug-view-312559.html

## Summary by Sourcery

Fix a potential crash when exiting the application by dynamically resolving the libmpv library path

Bug Fixes:
- Resolve a crash caused by inability to find the libmpv symbol during application exit

Enhancements:
- Improve library path resolution for libmpv using a system utility function