### PR TITLE
chore: Bump version to 6.5.12

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.11.1
+  version: 6.5.12.1
   kind: app
   description: |
     movie for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-movie-reborn (6.5.12) unstable; urgency=medium
+
+  * fix: [libmpv] crash when app exit(Bug: 312559)
+
+ -- renbin <renbin@uniontech.com>  Thu, 17 Apr 2025 13:06:59 +0800
+
 deepin-movie-reborn (6.5.11) unstable; urgency=medium
 
   * chore: New version 6.5.5.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.11.1
+  version: 6.5.12.1
   kind: app
   description: |
     movie for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.11.1
+  version: 6.5.12.1
   kind: app
   description: |
     movie for deepin os.


### PR DESCRIPTION
Bump version to 6.5.12

Log: Bump version to 6.5.12

## Summary by Sourcery

Chores:
- Update version number in linglong.yaml configuration files for arm64, loong64, and main platforms