### PR TITLE
fix: resolve AV1 video decoding freeze issue on SW64 architecture

### DIFF
--- a/src/libdmr/filefilter.cpp
+++ b/src/libdmr/filefilter.cpp
@@ -281,6 +281,34 @@ FileFilter::MediaType FileFilter::typeJudgeByGst(const QUrl &url)
     return m_miType;
 }
 
+bool FileFilter::isFormatSupported(const QUrl &url)
+{
+    AVFormatContext *av_ctx = nullptr;
+
+    auto nRet = g_mvideo_avformat_open_input(&av_ctx, url.toLocalFile().toUtf8().constData(), nullptr, nullptr);
+
+    if(nRet < 0)
+    {
+        return false;
+    }
+    if(g_mvideo_avformat_find_stream_info(av_ctx, nullptr) < 0)
+    {
+        return false;
+    }
+
+#ifdef __sw_64__
+    for (int i = 0; i < static_cast<int>(av_ctx->nb_streams); i++)
+    {
+        AVStream *in_stream = av_ctx->streams[i];
+        if (in_stream->codecpar->codec_id == AVCodecID::AV_CODEC_ID_AV1) {
+            return false;
+        }
+    }
+#endif
+
+    return true;
+}
+
 void FileFilter::stopThread()
 {
     m_stopRunningThread = true;

--- a/src/libdmr/filefilter.h
+++ b/src/libdmr/filefilter.h
@@ -111,6 +111,9 @@ public:
      */
     MediaType typeJudgeByGst(const QUrl& url);
 
+    // 目前只用于sw架构下判断是否是av1格式，sw架构下高版本dav1d会卡死
+    bool isFormatSupported(const QUrl &url);
+
     static void discovered(GstDiscoverer *discoverer, GstDiscovererInfo *info, GError *err, MediaType *miType);
 
     static void finished(GstDiscoverer *discoverer, GMainLoop *loop);

--- a/src/libdmr/player_engine.cpp
+++ b/src/libdmr/player_engine.cpp
@@ -550,6 +550,12 @@ void PlayerEngine::requestPlay(int id)
     DRecentManager::addItem(item.url.toLocalFile(), data);
 
     if (_current->isPlayable()) {
+#ifdef __sw_64__
+        // 1.1.0以上版本的dav1d在多线程环境下会卡死，更换解码器使用
+        if(!FileFilter::instance()->isFormatSupported(item.url)) {
+            _current->setProperty("vd", "libaom-av1");
+        }
+#endif
         _current->play();
     } else {
         // TODO: delete and try next backend?


### PR DESCRIPTION
Log:
- Add isFormatSupported method to detect video format support
- Special handling for AV1 encoded videos on SW64 architecture
- Switch decoder from dav1d to libaom-av1 when AV1 format is detected
- Fix freeze issue caused by high version dav1d in multi-threaded environmen

Bug: https://pms.uniontech.com/bug-view-308167.html

## Summary by Sourcery

Address AV1 video playback freeze on SW64 architecture by detecting AV1 format and switching to a more compatible decoder.

Bug Fixes:
- Resolve AV1 video decoding freeze on SW64 architecture by switching decoder from dav1d to libaom-av1.

Enhancements:
- Add format detection logic to handle AV1 video streams on SW64 architecture.