### PR TITLE
chore: Bump version to 6.5.14

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.13.1
+  version: 6.5.14.1
   kind: app
   description: |
     movie for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-movie-reborn (6.5.14) unstable; urgency=medium
+
+  * fix:  resolve AV1 video decoding freeze issue on SW64 architecture
+
+ -- zhangtingan <zhangtingan@uniontech.com>  Tue, 13 May 2025 14:15:28 +0800
+
 deepin-movie-reborn (6.5.13) unstable; urgency=medium
 
   * fix: Remove the description of the community edition.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.13.1
+  version: 6.5.14.1
   kind: app
   description: |
     movie for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.13.1
+  version: 6.5.14.1
   kind: app
   description: |
     movie for deepin os.


### PR DESCRIPTION
Bump version to 6.5.14

Log: Bump version to 6.5.14

## Summary by Sourcery

Chores:
- Update version field from 6.5.13.1 to 6.5.14.1 in arm64/linglong.yaml, linglong.yaml, loong64/linglong.yaml, and debian/changelog