### PR TITLE
fix: [ui] Delayed volume display on loongarch machine

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -3495,6 +3495,27 @@ void Platform_MainWindow::slotVolumeChanged(int nVolume)
         m_pPresenter->slotvolumeChanged();
     }
 
+#if defined(_loongarch) || defined(__loongarch__) || defined(__loongarch64)
+    static bool firstInit = false;
+    if (!firstInit) {
+        QTimer::singleShot(50, [=](){
+            if (nVolume == 0) {
+                m_pCommHintWid->updateWithMessage(tr("Mute"));
+            } else {
+                m_pCommHintWid->updateWithMessage(tr("Volume: %1%").arg(nVolume));
+            }
+        });
+        firstInit = true;
+    } else {
+        if (nVolume == 0) {
+            m_pCommHintWid->updateWithMessage(tr("Mute"));
+        } else {
+            m_pCommHintWid->updateWithMessage(tr("Volume: %1%").arg(nVolume));
+        }
+    }
+    return;
+#endif
+
     if (nVolume == 0) {
         m_pCommHintWid->updateWithMessage(tr("Mute"));
     } else {


### PR DESCRIPTION
Log: as title

Bug: https://pms.uniontech.com/bug-view-317917.html

## Summary by Sourcery

Bug Fixes:
- Defer the first volume change hint on LoongArch architectures by adding a one-time 50 ms delay