### PR TITLE
fix: 处理play会跳下一个视频问题

### DIFF
--- a/src/libdmr/player_engine.cpp
+++ b/src/libdmr/player_engine.cpp
@@ -587,6 +587,7 @@ void PlayerEngine::makeCurrent()
 void PlayerEngine::play()
 {
     if (!_current || !_playlist->count()) return;
+    if (_playingRequest) return;
 
     if (state() == CoreState::Paused &&
             getBackendProperty("keep-open").toBool() &&
@@ -594,7 +595,7 @@ void PlayerEngine::play()
         stop();
         next();
     } else if (state() == CoreState::Idle) {
-        next();
+        playByName(_playlist->currentInfo().url);
     }
 }
 


### PR DESCRIPTION
处理play会跳下一个视频问题

Bug: https://pms.uniontech.com/bug-view-318755.html
Log: 处理play会跳下一个视频问题

## Summary by Sourcery

Prevent unintentional skipping to the next video when calling play by guarding against duplicate play requests and explicitly playing the current video in the idle state.

Bug Fixes:
- Abort play() early if a play request is already in progress to avoid unintended skips.
- In the Idle state, invoke playByName on the current video's URL instead of calling next() to resume the correct video.