### PR TITLE
fix: [display] Set the delay for the first time volume display to gen…

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -3495,7 +3495,6 @@ void Platform_MainWindow::slotVolumeChanged(int nVolume)
         m_pPresenter->slotvolumeChanged();
     }
 
-#if defined(_loongarch) || defined(__loongarch__) || defined(__loongarch64)
     static bool firstInit = false;
     if (!firstInit) {
         QTimer::singleShot(50, [=](){
@@ -3512,14 +3511,6 @@ void Platform_MainWindow::slotVolumeChanged(int nVolume)
         } else {
             m_pCommHintWid->updateWithMessage(tr("Volume: %1%").arg(nVolume));
         }
-    }
-    return;
-#endif
-
-    if (nVolume == 0) {
-        m_pCommHintWid->updateWithMessage(tr("Mute"));
-    } else {
-        m_pCommHintWid->updateWithMessage(tr("Volume: %1%").arg(nVolume));
     }
 }
 


### PR DESCRIPTION
…eral.

Log: as title

Bug: https://pms.uniontech.com/bug-view-317917.html

## Summary by Sourcery

Bug Fixes:
- Unify initial volume hint display logic across all platforms by delaying it 50ms instead of only on Loongarch