### PR TITLE
feat: restart application after hibernation resume on specified machine

### DIFF
--- a/assets/org.deepin.movie.restart.json
+++ b/assets/org.deepin.movie.restart.json
@@ -1,0 +1,26 @@
+{
+  "magic": "dsg.config.meta",
+  "version": "1.0",
+  "contents": {
+      "RestartAfterWakeUp": {
+          "value": 0,
+          "serial": 0,
+          "flags": ["global"],
+          "name": "Restart deepin-movie after Wake-up",
+          "name[zh_CN]": "休眠唤醒后重启",
+          "description": "Restart deepin-movie after wake-up on specific machines",
+          "permissions": "readwrite",
+          "visibility": "private"
+      },
+      "PausedOnPlay": {
+          "value": 0,
+          "serial": 0,
+          "flags": ["global"],
+          "name": "Pausing when playback starts",
+          "name[zh_CN]": "开始播放时暂停",
+          "description": "Pausing when playback starts",
+          "permissions": "readwrite",
+          "visibility": "private"
+      }
+  }
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,7 +103,10 @@ install(FILES ${PROJECT_SOURCE_DIR}/assets/deepin-movie.json DESTINATION /usr/li
 
 #hw机型增加DConfig配置
 set(APPID org.deepin.movie)
-set(configFile ${PROJECT_SOURCE_DIR}/assets/org.deepin.movie.minimode.json)
+set(configFile
+    ${PROJECT_SOURCE_DIR}/assets/org.deepin.movie.minimode.json
+    ${PROJECT_SOURCE_DIR}/assets/org.deepin.movie.restart.json
+)
 if (DEFINED DSG_DATA_DIR)
     message("-- DConfig is supported by DTK")
     dconfig_meta_files(APPID ${APPID} FILES ${configFile})


### PR DESCRIPTION
This commit implements the following features and optimizations:
    1. Added a new DConfig file org.deepin.movie.restart.json to support "Restart after wake-up" and "Pause on play" features, allowing flexible control of player behavior in specific scenarios or devices.
    2. Updated MainWindow to read and set these configuration options, enabling the player to automatically restart after system wake-up and restore the previous playback state (paused or playing).
    3. Enhanced the playback process to support automatic pause at the start of playback based on configuration, improving user experience.
    
    These changes improve the player's stability and user experience in sleep/wake scenarios and provide better configuration support for future feature extensions.
    
    log: Added "Restart after wake-up" and "Pause on play" features for improved usability in special scenarios
    
    Task: https://pms.uniontech.com/task-view-378843.html


## Summary by Sourcery

Implement a configurable restart-on-wake-up feature using os-config’s DConfig and enhance resume behavior by preserving pause state and seeking to the correct playback position.

New Features:
- Automatically restart the application after hibernation resume when enabled via DConfig
- Preserve and restore pause state on restart and apply pause-on-start to backend playback

Enhancements:
- Integrate DConfig “org.deepin.movie.restart” to manage RestartAfterWakeUp and PausedOnPlay options
- Ensure media seeks to correct position after resume to avoid stutter
- Reset “pause-on-start” backend property after play or resume

Build:
- Add new configuration schema file “org.deepin.movie.restart.json” and register it in CMake