### PR TITLE
chore: Update package URLs and digests in linglong.yaml files

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     movie for deepin os.

--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -92,25 +92,25 @@ sources:
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-event-log/deepin-event-log-daemon_2.1.2-1_arm64.deb
-    digest: fae82486dfb7274746774a006111dcbb87c5994db0a79e3e49184a6e1486c025
+    digest: 06922785a98f97eb174d2f0c283bf757fc79fa0baef7a7e52c34abfc031e9d5e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-event-log/deepin-event-log_2.1.2-1_arm64.deb
-    digest: 3c495842c1929ad48e40ee9b31a5390d66287ec10ad1149433d508c84063bd57
+    digest: 9478253b373d2d0941240de667c80a3df544dc13fce57aec0885f655682530de
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
     digest: 11a42f07b2feefb7669441c3a67176cc32dc857c7d21b3290c464795fc514448
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
-    digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
+    digest: 8b3ec535c58fd4041effcff798c688ab1f4a36b6c2ac5989412020686c7607f7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin3_arm64.deb
-    digest: 81d1a53d75115f01e303fcf8337493bc2850614b0a2e30b06b9e0fa67d0d5a80
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin4_arm64.deb
+    digest: 395526d8605c5a34c3bea89d6c32781d3a5625eae82b77f598835c09524f51cb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.14.2-6_arm64.deb
-    digest: aa64934dbf43b0dd0ffee2b7fbcce324b50b957b0a4f04c10d062a85d8847d8e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_arm64.deb
+    digest: bedadcad1a6b77ae2842cb308003cfae181d382ee416ccbd9c35e309f1991d19
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.14.2-6_arm64.deb
-    digest: 91c105d210849f97151c436e0cf9b77910bbc58ea9bbd40da4077219def10994
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_arm64.deb
+    digest: 6d7e0dca9ca1599c9950826e6c25918a3b30e7a37222ef980ae64fff2db42535
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
@@ -160,8 +160,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/i/ibus/gir1.2-ibus-1.0_1.5.29~rc1-1_arm64.deb
     digest: 43380cd00e9a71b7ce92d46098860e8c726649e9119234f813ec5dcccd85852b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/icu-devtools_74.2-1deepin1_arm64.deb
-    digest: 7951e556c907a2b6439e3f760389339766b4c1d538817c4db6bcc4d7fa26e13f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/icu-devtools_74.2-1deepin4_arm64.deb
+    digest: 19dc116ae37865faeab88a4a8053c39990b50d8ee85a49d93086a263a69afe02
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/i/iso-codes/iso-codes_4.16.0-1_all.deb
     digest: acd8d976f1a757da000d9ea9405fdf80194a6275fc93fc472e1df1dfa5b301a5
@@ -169,8 +169,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/abseil/libabsl20220623_20220623.1-3_arm64.deb
     digest: 4e7d08584337a95ccbb5167513fa590d5fe4614eb17860b743e190a49bdf9541
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-1_arm64.deb
-    digest: 51808064361bdae539f985645eaee59b53c703b293174f761d996b27f2b8d860
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-3_arm64.deb
+    digest: ea023a815c9257d7d4f2028037d8d2b19009d9e36d6ae7d6cd5b20ad38e90565
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/aom/libaom3_3.9.1-1_arm64.deb
     digest: 2ac174ee086466df9fc130a81c5f9aed2932b8de1b40ef60bd116a549d4af57f
@@ -211,35 +211,35 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/liba/libavc1394/libavc1394-0_0.5.4-5_arm64.deb
     digest: f4c42a206e22196ffae860df9721e1b1dd22a1a90e6879ec47e0f02e4215ce70
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec-dev_6.1.1-2deepin0_arm64.deb
-    digest: 83c6a24d4241e6370217c5e64fee07c51a4702c883412a4348b8fd6b8f272391
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec-dev_6.1.1-2deepin5_arm64.deb
+    digest: c34e375b3df36c4e8d01e5420988dabbe33fe109f3779dc5ad7ef837009a5284
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin0_arm64.deb
-    digest: bf6905458722a383dbdd69c2fe894b4d7d842d309713d21af9a8bb6a06aba779
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin5_arm64.deb
+    digest: d3925e1b4b6293bccb43b9ba984854fc1efd476d7876dc0ea9641b5063694d8d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice-dev_6.1.1-2deepin0_arm64.deb
-    digest: 3fae4a84e6dfe139ca709df8cb9e9cc339e4d441c8665e43785d754e60068010
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice-dev_6.1.1-2deepin5_arm64.deb
+    digest: f1e54725131a1505214706983520e22ac51eae1f3f3dee0eb56b447334df21df
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin0_arm64.deb
-    digest: 6d7ccc33fe58f373bfaff5a85c8e2bb21b3edd79c808dad0c1d05b66c01f0588
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin5_arm64.deb
+    digest: ffa544c8190db95bf29d1c0ed7fcfda63fe1646b35cfdb48fd8c9dc7c294ef0c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter-dev_6.1.1-2deepin0_arm64.deb
-    digest: 3e3398a6df0361ed77548d71466807fb36fbfe0ea7df41a551e2dfc9c5dafebb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter-dev_6.1.1-2deepin5_arm64.deb
+    digest: 6e556f99b08177033ce246aa6a58c26af84ab4c5d120c9c53e6fcbbd615179c5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin0_arm64.deb
-    digest: 5b4fd7c461f9c6cd228e238f1a4587b336ef3428c7d824a4548daeef1d0044bb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin5_arm64.deb
+    digest: 44c9517263c348c927e8e03abb3889209b91c8acf76850dd6491b4a073a6065c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat-dev_6.1.1-2deepin0_arm64.deb
-    digest: a4002f92ed4fa95538f098a3091a817b06e55fee12254c418f81c69656389628
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat-dev_6.1.1-2deepin5_arm64.deb
+    digest: 88e538790858a363c342d68d6969c613cf4c037552b918dadd259f4c788be560
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin0_arm64.deb
-    digest: c19ead041d82536839e168daa2739df61394046648736559ff840c42f328f08e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin5_arm64.deb
+    digest: 59e2e608181be0f63c16d36e35f6cae96e5d18754b78f0777f2b6e66380cf89b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil-dev_6.1.1-2deepin0_arm64.deb
-    digest: ba6646eeff6cadbf174105dd83dbb24806ccf92556772928f9d3a06d9e90ac3c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil-dev_6.1.1-2deepin5_arm64.deb
+    digest: 02ba334e27f5ee91d7ba4ffc56c207f61b92f909318e05c0f9b2caebb6359d33
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin0_arm64.deb
-    digest: 4f26322eb48a311324e5473896ed167ad1f281d7266b4a35034fee1c56f4f62b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin5_arm64.deb
+    digest: add697813f2bba7bb8fc228999ba8e42b66ac641fef1269f492144ed496a99e6
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
     digest: cac541f3cf746d006b71a08f88364b6743222b8956fda9a7cbd35ffb1cf32ed9
@@ -307,8 +307,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap2/libcap2_2.66-5_arm64.deb
     digest: 6f196062b90716256bf2a57e919d18c74eb6cc19d98f1cf88e603cbd8d68b188
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/capstone/libcapstone4_4.0.2-3-deepin1_arm64.deb
-    digest: d0b09968beb885bb5386216c43308a721db3ea07f4cfe558e977979ea1624589
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/capstone/libcapstone5_5.0.3-1_arm64.deb
+    digest: 69c419efd4b58c93eadb583e4d1465b9d91355a3eb599c3d6ac0dcfacb685d8d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcdio-paranoia/libcdio-cdda-dev_10.2+2.0.0-deepin1_arm64.deb
     digest: 7bc342fbd66a85f7e3cb6ab76a427958f852e6cfbda353b1afac377cee9ce04e
@@ -331,8 +331,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_arm64.deb
     digest: 39486fac0b8bd52f8641e2586befaa00aeb6a03106f3b6c99e64039c8e7b4a6e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cjson/libcjson1_1.7.15-1_arm64.deb
-    digest: 2dae901869e9a50f832d6168942a0c8fe6e643e4f9f56f161cb212a6ad59c233
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cjson/libcjson1_1.7.18-3_arm64.deb
+    digest: 8ba115a3752e7445e5c684614ae1a057419721a601c4017ee0cd442414a3231f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_arm64.deb
     digest: 544520612dc6697c5165126dab9ec2cabae88d42678aaa5a762674559a6ace92
@@ -358,23 +358,29 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf0_2.41-6deepin7_arm64.deb
     digest: bab638b4aed73a4a9420a17ec27f3120ff10404c3d3e6e1a66fe023fa8a44121
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_arm64.deb
-    digest: 1557184d0ba255ee05b5c929396c4c925e10782f9cba74f3514f96d3bf581ca1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_arm64.deb
+    digest: a72f4563335d016cf4a0f8bbf5d26b0ed90f554a8ff2e6b9701967daa114569b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin1_arm64.deb
-    digest: e9754a238fed47dac0e3e6255697563494f6ca4b58313bc7f6183d4d0995d32f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin2_arm64.deb
+    digest: 534a9ba35f69f93d103edbe1736a7ffe7f2b84a8e3746889d78feadfaa507d22
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_arm64.deb
-    digest: d0a1e93cb1b63e0040b50c924c8a7c9464494ef3547447913584d0a62999590a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_arm64.deb
+    digest: 01509b9730896972e09e937a3d27ae4c9cea9b536b0296db37af464314490934
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_arm64.deb
-    digest: 12003d3e5acd0a1c379f81e075b6171fb784666763813528fd18189beea9735d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_arm64.deb
+    digest: 24db7f1a3f57d436a532a215e32df71a9df3ff19731d81c7988c0d77df86b692
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_arm64.deb
+    digest: 4fcab53e5e791e65cd9160e0e77eacec106bce0f5ea0567bcb1387b362101488
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdatrie/libdatrie1_0.2.13-2_arm64.deb
     digest: e0c2cfe68451fc2f325066806a0e158eda7d61a2ffacf988e248f8cd61844738
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dav1d/libdav1d6_1.2.1-2deepin1_arm64.deb
     digest: ed96097c7b23c3224e448f430d8a6bee10a2ec736088eca565b99146b72d82d5
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/davs2/libdavs2-16_1.7.1-1+dde_arm64.deb
+    digest: 1a7dd44072b582c34e49f0972fb97c2e9b861ee03ae04c660678c09266b9afce
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_arm64.deb
     digest: ee20a140ab90ce9fa2ab045eab6195b426d5c441459a788e15966687a1d57221
@@ -403,8 +409,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
     digest: 78e9245e377c8f61009cc60d2b55001aaddd7b656fceb916b3ba8f07344251b7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin3_all.deb
-    digest: 71989ccb16cfcc04aa5a86f06e4dff837a4fa755d04d17d5f0cf329fc09dda04
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
+    digest: 569373a35267f9cf2e8d0ee6d42c9047f50fa2174a0ac72fa77f494a0f0a9d1b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_arm64.deb
     digest: ea011d2a1b77d97ea5d538786dc3aece9a24e317489827cf5e4dfc6032cb61f4
@@ -433,35 +439,38 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm2_2.4.123-1_arm64.deb
     digest: 6c900feb79b1e5f847a5b9f53c6bda3f6aa12a9abfcf106f872a3812ef78bbc4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.25_arm64.deb
-    digest: b8693fdd024188f811597e28d7d7e03dba17e811711883716b7ff76376801e02
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_arm64.deb
+    digest: c9472936e80c216fd09a2e9c5123ca1cedea9432294261178883d8a952c7f99b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.25_arm64.deb
-    digest: 3442eb4010d5176f27e5062d6fb07f1d8afca80c59375f9c37aa65eea62a727c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.38_arm64.deb
+    digest: e8a717160caa08f795f1f567ec57d2b661814e8084fe8d860d94f56a3e05ea47
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_arm64.deb
-    digest: 5b30d2ade934bf6b80f4fd6e9eecf7549d44e9df70c8e97266b720811c90ffb3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_arm64.deb
+    digest: a80d44bf31660feda6ed1208ff5521335b7fb201da93956945359b0549a8f7b8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.25_arm64.deb
-    digest: 34a82a6a255c9d9ea99e12432c047cf0efafd61101a90ef319689d4940fa9767
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.38_arm64.deb
+    digest: 1594a4003d6dfee6d91d2ed7a0af502f4ea38504631401f3a1baa5860c70cbb6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.2_arm64.deb
-    digest: 0e714a576b19f5a920d224ef1a1877e93c4b8aea1e49eba99df7316c72319910
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_arm64.deb
+    digest: 0d2a9910f59a67a92ae67c644d2a78df0476a710a1bd4284869a3e3a993d9734
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.2_arm64.deb
-    digest: 67e687906a183922d6e510666f7637c45946e68f61bc4f0ce7fc2a840aaff3e0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.4_arm64.deb
+    digest: 01a779e198b225da4069a480677d4e7c816f04309c3ce70829411b4bbe8b3a96
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_arm64.deb
-    digest: d77647f1b8ddc312041ad612cf3c1343bd3fbd8193b2a72e8bfae9ba64d4053b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_arm64.deb
+    digest: f1743536d71c1610937a548699d0bd40692b3ce34ce5ea591c4ad919d6ae1b6b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.25_arm64.deb
-    digest: 146b21a131932f6ced35c1b74c912ae9794b9bdadbdceff37babece4c9eb90bb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.38_arm64.deb
+    digest: 85c4766d67def86998b406625bc1a22eacf910a131bf1006735af2897efe3e1b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_arm64.deb
-    digest: 11cf667515ce2bcbc7ac6ae27bafc324f6cea17772d8e7aa43cfda6288713e67
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_arm64.deb
+    digest: 766177ea4c8c2a5cfdeb1b3eee5b31b62b72be9aa06744dd7a6542cc888c494c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.5_arm64.deb
-    digest: b468b48c1f8fe5b98f4294edbe3b757726fcefbfdfb79ab54d3adffc293d17cb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.18_arm64.deb
+    digest: a34538990a42f2be5b28b198b3b75d96ab6edfc9b850824c8ee222305f42c699
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/duktape/libduktape207_2.7.0-2_arm64.deb
+    digest: 514955337167c41ebe2aec0cab0cf30ebf6f47cb7893b0ae1db20590c3d29ad9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdvdnav/libdvdnav-dev_6.1.1-1_arm64.deb
     digest: ba2d0887d12252f6fa0cebef72b5f60668fe0fb3518c8106370189ef3df4cc4a
@@ -484,14 +493,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libedit/libedit2_3.1-20230828-1_arm64.deb
     digest: ba394c531b520e3ee365d29c127505bce3554df15885dd53dbe9a9deee191326
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl-dev_1.7.0-1_arm64.deb
-    digest: 1ebda9bd16604157f00d04520998885f6a1b74ab2ac39dd1246ad454ef4fb3c3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl-dev_1.7.0-1deepin1_arm64.deb
+    digest: caeaa157bb5a9d082de8a3841c14a56754b8fdadc01b590d42cde141f92e8cce
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin1_arm64.deb
-    digest: 1242d431d868c4ab91b1eac197b65ad7fff15b43b723870cfd9f5fe3b6e4711c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_arm64.deb
+    digest: 426be89c01067a002f4d4873688297fa1444a5a3048baba3eba418febf47d143
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1_arm64.deb
-    digest: e545d436bd07777713063cbbafcb75c2e2581d2f04ec697862380caf2074c471
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_arm64.deb
+    digest: 0b59eeb273489ae76f00c5192fac7d4fd7ca4db31b0f77b1424cbe6a70fa20f8
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/e/elfutils/libelf-dev_0.191-1deepin2_arm64.deb
     digest: 132d2caf11349e92c22cf07add6230f743167c27920ed019d950e3137074fa25
@@ -505,11 +514,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_arm64.deb
     digest: fbbe2a51d531e25bc6bd01b2a732ea480411f065940a2b581d47dcd98ec7fcc3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.5.0-2_arm64.deb
-    digest: 06c39c3e78aba8616d2c7b43d7cc33cd60bcbfb7bc362e997b2bce1b24fd7460
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.7.1-1_arm64.deb
+    digest: c0b33ae628f9f7a2be567fc237b7c3f3c2ca1ef33360eff1718977c72d414a38
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.5.0-2_arm64.deb
-    digest: 2c66c6eb5bb8e1f8dbb6449e3948e3a75add01415561c10a89ac1b238a9a24b1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.7.1-1_arm64.deb
+    digest: 5cb7b15a898bfb29141bc121435c82871d5ac497035fae132c37df32e69eb388
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
     digest: 44b6f1a9aceead0cac121cfd13cdd9a529eb2b60522f8482c7dc4f67432d1904
@@ -535,14 +544,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_arm64.deb
     digest: 65fdd731df6fc44891d7c77da9d16717fd23df0d4251085dc0c43b4313e903eb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.14.2-6_arm64.deb
-    digest: d965d2bee11b03bb0b86e876a78f5f3b3f5ae3b66ed3f74a8baed4f1a2edb058
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_arm64.deb
+    digest: bbbc845e4a6ade7d6fe9d7147e9891f1bcb60c971ef8d0ab7c253d7089fc1f8b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1-dev_2.14.2-6_arm64.deb
-    digest: 6a01f4bc5a0369c10ce0021b23b3a4985c54672a05714b17b736f364f37805fb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1-dev_2.15.0-2.3deepin1_arm64.deb
+    digest: 9c78753391c48f96ee3f099ad88d28c262f96c1b0f295c7d04e4c941d0e588e9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.14.2-6_arm64.deb
-    digest: 2088236fc9be4b0b363707d88c00eac4c082aa64f00c10f869c33884dee5772b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_arm64.deb
+    digest: 82b4c63adda13ee062e7cac011f49859d31b911c5e64678d8d1404e5da3a92da
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_arm64.deb
     digest: 222148f71812a1026457b2d86edfe68eac087f0063ab5e8159439e3d11793425
@@ -559,11 +568,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fribidi/libfribidi0_1.0.8-2_arm64.deb
     digest: 270c9b8a81001d31d84760347ddae209ac6d952e7e6b3a7c0b3ecebec2a7838c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm-dev_24.3.0-1deepin1_arm64.deb
-    digest: a5c90597bcfdd5a1daabbc6b9b9e0ebbb1b61d555a8386394c6a57ea4eb4a485
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm-dev_24.3.0-1deepin4_arm64.deb
+    digest: 311fc1f43e6c64415d0831e8d91d924878b61d982a6a16ec11e2b26718ad15cd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin1_arm64.deb
-    digest: 0e6e5eb75926984f164fc7cab721af768f3e39a02e0fef08a80ca511e0932216
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_arm64.deb
+    digest: d16ede274574a5ede58f7f2318cf33f2b0074ca31845097ce633393b87b3caf0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_arm64.deb
     digest: 6ed2090f5c442f6dbccfc825cf0303e42954ee2db527d4605435c09862a43d57
@@ -589,26 +598,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_arm64.deb
     digest: 67fb7f1a7f5bf707a6dcead0b5b044c1704f454c2a51050fcb020ea9b1317913
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1_arm64.deb
-    digest: dc7f67af872323ece8087a4dfdd6106b9faa71d490447003ef964043066bb2e1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_arm64.deb
+    digest: ef605bf23fa580844d6a5faa61caf503f3825bc69acc9e30dab40689116a2627
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin1_arm64.deb
-    digest: bd784febc8b5b98a79ba8e2bd965a894cc684d01be1c1252e2d8af5996690a34
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_arm64.deb
+    digest: 9a47b3a7b9568d735534ae7c949ef5bed2ff18975f0812d71acbd163c6f5030c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1_arm64.deb
-    digest: 93917761c2f8cdc9dfec793a9e6aaedd05973aca3a19eb74f2d33e926c0d7c3e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_arm64.deb
+    digest: fb58114fedbd3864291f2a6c3d7d5d1b62476a3532e98926774727988411b3e4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin1_arm64.deb
-    digest: f5e97f18d419e19676b353c6c7b50fd07581e009ead603ce1b7129ba71a1e964
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_arm64.deb
+    digest: 82508b674b91518c3217f0d2f38ee78ed65a15fb6acb49420076d368e338af7e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles-dev_1.7.0-1_arm64.deb
-    digest: dcf24b7497da8536e6b6e8d5d528128f128e044f5266deb2b8af511a260e3b39
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles-dev_1.7.0-1deepin1_arm64.deb
+    digest: db84e9e6124a9913aa76d670daa7564a856006de84fcb62fdc8dbe3562e52582
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles1_1.7.0-1_arm64.deb
-    digest: 6152b728af9b2220e15d648925ad5f1c5312e972446627584010c937530c56ec
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles1_1.7.0-1deepin1_arm64.deb
+    digest: a675a69284b7508e4f977fafe6cba07c9bd8787cc7c326b1f68443464e910a49
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles2_1.7.0-1_arm64.deb
-    digest: 41fb972c5890ab20a3692075f8b3f2df391a4499094487a054ed8c8a4b1f7af6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles2_1.7.0-1deepin1_arm64.deb
+    digest: dbd2da3c6d7b7addc0a79c51645ee81d7be8c06549db038cfa45d202f2993b59
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_arm64.deb
     digest: bcd728365b170a9b2598f2c3a13a7b4b27bcbcc5c966610496f7a66c13d93394
@@ -625,17 +634,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_arm64.deb
     digest: 894d0a7818c905544b7114e8c7268a3c8dded4395d3d859bdcb774e546e7ac98
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1_arm64.deb
-    digest: 3eaae06ffb183872a95c2c966050099ab9824b50ccab6802c1fdc95a7f6b25d5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_arm64.deb
+    digest: d4371fcc299ddafc3230a139ecc4475dcd0b0dedb2746d46da1de9a951bf749a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1_arm64.deb
-    digest: ef37a90a94a9e4ba16352663b2703df57e3816e406eec0225e6339a91ad498fa
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_arm64.deb
+    digest: ff60370ae98f4515ea9eda99af3ab9d468b53b23bdd22f4b51abf8064655e810
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin1_arm64.deb
-    digest: 3dc940cbcf83fdae9499703bf42824b87be132d5130643c4845788ec878e923a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_arm64.deb
+    digest: 9388fddc0b068998f436342e6d562cc6f5553f34dbee9e86a51639a24d92dbaa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1_arm64.deb
-    digest: 41d194b986ca2e07171948e6b0d09b2b51f068117ae2f0bd11105e0c7cae8d7f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_arm64.deb
+    digest: 0e206a1e5b7a0a16abefac96b5774e2740c0446d988488ba3ca3af616a4eb3f6
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_arm64.deb
     digest: 6be533a6b6cb8b661664fedbe661b316edd0bee46f51fe598d300c2efaf95728
@@ -654,6 +663,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libgprofng0_2.41-6deepin7_arm64.deb
     digest: 640d2c1b93bfece28cb70c1213450ace0864adb34d288b00c6108bb5bc5cfdeb
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-gpuinfo/libgpuinfo_0.0.10_arm64.deb
+    digest: 8d29e12a3c043112258e4ae36724e001295bf28f33181c5cef1a52005fd9a1cc
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_arm64.deb
     digest: bf8f6e987ba71ddd6161066f0828663b4ffc4af78acbdbff04b71e5c2b1e207f
@@ -733,11 +745,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libice/libice6_1.0.10-1_arm64.deb
     digest: a1910186258a924c4367673da786e7200f32e54ea54f65e2b885e3e451197e0e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu-dev_74.2-1deepin1_arm64.deb
-    digest: 1400bc95db90ff7ce5eeb429806d917a39ce20eb3e00260cc26763940ceee204
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu-dev_74.2-1deepin4_arm64.deb
+    digest: b7c8cb9211519ac308269e2d25796258b3ff7926e7ec33da839c199b565bfd86
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin1_arm64.deb
-    digest: 42945fdc780c0d2259efde9403abec12c1c65f17f131a49c4a282b720e8cb2ee
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin4_arm64.deb
+    digest: d5bc8f5eb78bf50444fec39a361f43c52b13d13a9c2ea45c272b05d1c8afbb5c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libidn2/libidn2-0_2.3.2-2_arm64.deb
     digest: 66be80634fd2243b4741bc12bf02ae140d4af694da58e23415130322eb8e17cc
@@ -804,6 +816,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lcms2/liblcms2-dev_2.14-2_arm64.deb
     digest: e0454d960ef62b53fea41da4f5abb52173811dc4aac4c255f6938081a1d30e68
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_arm64.deb
+    digest: d055aef7a24526618a27b82b62d9a220e1fdb93f5cb0e49bc1b083693a43b607
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_arm64.deb
     digest: 1084fe140088878214dd72f6c8ebf4f4835b83f542ed443ce79cc2f43821d6d9
@@ -904,6 +919,18 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb
     digest: 94f6240b06e89b83e43b85f3ac482f57468f7b78b3a356f692a9a2508b4b62f2
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_arm64.deb
+    digest: a4a4ad6f2f5e0bf234331c7e22f12e13b7b5f52f6ee93188517427f88cda3b8f
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nghttp3/libnghttp3-9_1.4.0-1_arm64.deb
+    digest: d64740b68d9dafdb6c4cb6fbf944281d6e88036b8fb3bfc228c235b8f3ab25d7
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ngtcp2/libngtcp2-16_1.6.0-1_arm64.deb
+    digest: 510f2bd3d9d32bfcccbd68838d57698ec80337b5e2ca1ea1273d82733ff10c95
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.6.0-1_arm64.deb
+    digest: 6bbbeeb6977d1080858dfa0fa2d179c1e351cfa01afd661b6b3094c8dea59d76
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_arm64.deb
     digest: 06f3609b64811a80941b259736bb1f71a58633df1300b979a4458fd92a3d634e
   - kind: file
@@ -925,11 +952,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openal-soft/libopenal1_1.19.1-2_arm64.deb
     digest: f08db4bd3d80d68cfdc9a22608bd40f166fdc42636b75836bdb4f0fa3e77f546
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_arm64.deb
-    digest: 4183274244acfc897705999133091b52af3c9c1ec54ed4b67319e9b044281434
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_arm64.deb
+    digest: d52a6102a07d9cff9066f0e3ebd802ab14e119bd1f9a890999be8cfda4c2cdce
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1_arm64.deb
-    digest: 84392d66b03e40078cb2fc079e1a3b8bdcc5d6606e24e9846b552ee73e2ffb03
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_arm64.deb
+    digest: 74251d10b4940be8c9fe26be6c337af904a1f0494723882d50dd1bcb04189416
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openjpeg2/libopenjp2-7_2.5.0-2_arm64.deb
     digest: a7dd240a390ebad6e63a7b7ce985a54e2e3753d025f5a040c6c28727e6741461
@@ -988,11 +1015,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_arm64.deb
     digest: f09601fbb60184cf2257b12a7eec5e39ae0d8659ae517bb42de686abc791f5a4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin10_arm64.deb
-    digest: 8c5840595cd53c664c6439dfb45bb57f3d181c60d5825c305835909b0ed3eb19
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin15_arm64.deb
+    digest: d5f136292ca1de46965ae6493560fdc2dc6d0360650f5ae68db5d54e547f87d7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-dev_1.2.5-1deepin10_arm64.deb
-    digest: 88c5887aeaeee4aba2ac8272573d1ae39a29011e23221a76afc01e77fe5b5859
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-dev_1.2.5-1deepin15_arm64.deb
+    digest: 501690af9c5f857deb5e6e2d2e77e6ff9405eca1f7c82b1e27660021801e08b0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pixman/libpixman-1-0_0.42.2-1_arm64.deb
     digest: 7195e91186e69bd55b9c05269973f6351a3a09470ce297610cf3d22ef6cac45e
@@ -1015,14 +1042,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pocketsphinx/libpocketsphinx3_0.8+5prealpha+1-13_arm64.deb
     digest: 9523527a9becdf223c0c367aaaa04cb9db76cac405316314ee5216f991384fb5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc-dev_6.1.1-2deepin0_arm64.deb
-    digest: feb169df74ad5565d1b3a604151e206356fb235fe31771f2c5dd65b57490a942
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc-dev_6.1.1-2deepin5_arm64.deb
+    digest: 2a4c97e0e342845258183b3715ecb4dfaf718c8d8075462e47e194a3609be89b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin0_arm64.deb
-    digest: fd4cfe4e776eb26907c33a896dca9daf8e0c82ac834bd7e662605d1d8df6a86a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin5_arm64.deb
+    digest: dead175491c1ee86faacf68a361f8acc700ff340d008c99ce51cf7737c1ae438
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_arm64.deb
-    digest: 641e0a94a253612ff4e7be672d7ee28f5a9c98e263a5f065d9e4cf47dfe00681
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_arm64.deb
+    digest: c4961acabed64ea88a254ba89930110925ea89fb182f5d088e428503d9c531fe
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_arm64.deb
+    digest: 906e8192d44527cb25bcbfd2a90992b25acfc3698a6b0cc6536edc6e935d64e6
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_arm64.deb
     digest: 3c2fef66a85ca8d8219283c1402eb66500b8587fa4f4495d327515e12b71e710
@@ -1039,23 +1069,23 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_arm64.deb
     digest: 94be53c10a1ed8538483d1dbd426700ff5a79ffffc7632c3a3eee0cd9ba2e869
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.4-0deepin1_arm64.deb
-    digest: b7e82676b670321d2d402bf6cfd9f8b031d1e25711409981609d86c11ce66395
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_arm64.deb
+    digest: 6dc58f5d2bda46ed44cadb9a08729430975a9a4dc41eb28f6633c6be041f9085
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.4-0deepin1_arm64.deb
-    digest: 7aa6784e459332f64d348c4d2e8d2f78ce167651d2be6361bd4e993c0923aac4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_arm64.deb
+    digest: 73b9c0dcd766f4132d7aaff51f969d0ed8708f54355143d308aaa7033018d198
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: 3cf53c5a9172bc03c318cbfeb04a27c3a18864d36640fcb3f3bdb0067912f8bc
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin10_arm64.deb
+    digest: c37dc4bd7ab67dbbe3662f0b87355fe3de5a1bb760a59a183da62d7078c7b14c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 4487ef000bab280d24e5796107f266dbcc7bd98da9107fa46622ec2466c7b16e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 3ed642827043b354e44832524287cc3808804c996e5c9fcd18a3ed7b051f435c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 8e79cc85474e16b11086c3943e9f68ba2980cd02c25126441d5787a9cac9f126
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: b2ec9e16dd93f9fcc6db6a8213ada4c6a032263dc26ebaeaa518e1020587e33c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 7b23577876590b68e561e40905d17bdd102d05ec005bd3f3aa02085435f729c5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: f23850190fc6dcfcb2e9552ad18a861690f1c9d3a5b2ea8d7c1726ccb3d7ccd0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
     digest: 82c28b84f82cbf7e3d9098c0f856b955e811a65b1fd42c8515711aecd05fb894
@@ -1063,8 +1093,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
     digest: c183e82838d5b340b4273253e90667078512862e1f8e9781b72b7ce048bf54d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: fbc7604f9d54ffef67fac1b67eed229d14ca15d06a45984e316768b7c63bd930
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 865f2bc49642dca8ed4b823a6cd6e286e0e38922b94b333b3d1c6a135b068a0a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
     digest: d725d7423abfc45ea48abf3d9cc444b95af145636802254bb44565f31d4d4245
@@ -1075,17 +1105,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_arm64.deb
     digest: 4e437c832e71179df54f516e31c37fae3436b9c3b0c6900c2649b17c0030788c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 34ef8390fb279d048e66d691572247d54ea7e04222db0507c44ac113914c0cd8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: b4adf25025b9ac22a52f68777b8b0e35acb2259b0c5dbb6d21d1e390bf272246
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 2280d74bd82b5e9d3a065c9acaeedc7d9f3c222517588c7777a62de2b30ff51a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 14b464d8f9c3c54bb8adf97c276cb3862e37403897250d96dc3cd2918d2c4ce0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: d79ad717b4275bb2dec400e7fa3ae8045c4d93b38fbc5a9c5eece9e9d7d3d14b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: abc3d24f963cab39c953bb44b1f1d258a0cb06716345f71bebf7bb70deee3f17
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 0a2c121bca7a1b60607aed1855b50fd2c630622bbb2f4b9fe5362a4a187893eb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: ded05e7b5416ee5139309098046f51d68eeea2f646c234113f0c4b754e7c362b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 8c18da39ba69ceef945d4c64e3a0e62a1bdcbe2b41921ead0aa08f4cc52c459e
@@ -1102,11 +1132,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_arm64.deb
     digest: dfe144682ad4f6fc4c0ca580a9b578686cfc69b079e4ce4703d9f20e38abb01d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 1f084ff72c612db83096eb3dec73f6101af9fe977f3376badf680a07926ccaef
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: f7b98e59524a570d02433e2773cbac7cb14f1c2862bd5252b9decd75e8921489
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: b8b4da1591cec015ace3dd8953ccca06f19f3430ddfc39faadcc6a65eda21965
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: b9e0a5ee05c9c86e240c655e6e78b96ac25ab93b082f9ab04139be82dbe60327
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_arm64.deb
     digest: 9902fd043a3e62bba9f7d13edccd49a25d8d17ffa0ec5cdc761dd7a5c0d8b63a
@@ -1114,8 +1144,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_arm64.deb
     digest: 34f386ccca09b000fd6621ede73daa2fac0b94f8fd9af514767a94ed39a15bf7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: a69495c011e5db7fd0552ffbe180cfb43640c35271ffe21be3bcf44053ff72b8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 2ac2f2f94233663607c1664831330558c716de3f588ad4658b82f45085d5bd7b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
     digest: 75ef6edab7f429e473a3f73bed21049eaa774f3e6333cc583e55b1f6bda9f016
@@ -1123,11 +1153,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_arm64.deb
     digest: f4b2cfd1d6b0a4573939eee7d9a48133e1068fb741d0b4ec8dc18889bc24fb8a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 3f27c16a00798b99ae45f723331d3601e3c3741e6041a0ea4bbaec0ee7873c16
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 3b09263af197ed4bb2ca92e54db9b7e14e141d78de8f143a578e01bf707f4094
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: e1cdb4a74a5f30c6580796070a19e575e0f6c5f9467c5f1c9561bb113cf66d78
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 5336d29dac452ff7e4f227f421dcb52bb6278488d4ed2833663d109e85126f49
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_arm64.deb
     digest: d38dc8bd34b4cf0fe94e16797f662191b91eb9e16f9f0b44bbaaa9b4b4d736f4
@@ -1150,6 +1180,9 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libr/librsvg/librsvg2-2_2.58.0+dfsg-1_arm64.deb
     digest: ef6aca74556a5b9b40db979a33f9fdcb9332596e4deb617249c690746d1812f6
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_arm64.deb
+    digest: 06467b3c81e07336f2e7381ebde3b511f8a1d1dfa5c6ef8c74504589445a86fb
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rubberband/librubberband-dev_2.0.0-2deepin0_arm64.deb
     digest: f8149a869dc5dbf87ea792f0994e80f1abb2b2463611766c3278e73f9f60aa41
   - kind: file
@@ -1162,11 +1195,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0_0.2.2-1_arm64.deb
     digest: 84c039697e041663bd4b7de673b0755d8ea5375a7c026809a81d986c0a3f6683
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-2.0-0_2.30.11+dfsg-1_arm64.deb
-    digest: f6add35d991b2a757f20c96981b9f6880b6665b609a58ae274ca7af030908d63
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_arm64.deb
+    digest: 15b8585dbd98a84d43b18797fb0619363087f91bff7ca70f042a9d0a63c9060b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-dev_2.30.11+dfsg-1_arm64.deb
-    digest: 709cd49e46be084994828f060810f84e9e5c301cd4b21a7f405194001cad25ce
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_arm64.deb
+    digest: ff33028cb84a0712ccf76443ab69e9b52dfeeb33e2aa20a98c2f4a0a6ed97a4f
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-2.0-0_2.32.4+dfsg-1_arm64.deb
+    digest: 6bb46338c8142ca9a18905b3f688b85aa34fb2e193f66bc4b17f5bbb4d10054e
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-dev_2.32.4+dfsg-1_arm64.deb
+    digest: 6fd649b5121932096437214115295fa8013416db77d1c8148c3f4b9cf1d1a6fd
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_arm64.deb
     digest: aa09e909d7f1ba4c18ed4aac21d5aac26637731dbc0580e01cd76ee3cb8103c0
@@ -1243,11 +1282,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoxr/libsoxr0_0.1.3-4_arm64.deb
     digest: 57472a0be9bd78ef65aa7f486c6b1236c956798c2af1152d7fd71bcc71d73bd4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-dev_1.2.5-1deepin10_arm64.deb
-    digest: 41ab2e8807155b22ca1f562406fa6b73aab3fc8b3b924712e3752222b8db91f3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-dev_1.2.5-1deepin15_arm64.deb
+    digest: 798deba045567f0d9bac44f816057f394a8a66a6c7cc1d54bd587cd39b3e0ad6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin10_arm64.deb
-    digest: 6fd9b67263e80bb6785c55e36bc33cf204233450ff6d542ca56106ed4411c334
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin15_arm64.deb
+    digest: 77604d5bb598b39c05f8f400493e017026ac0e66ec7525a302ab14e79b35ccfd
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
     digest: ffeba610e1f0ffa299499d88562b65eece4f9865d8810d3a6194ff5d2cd02b38
@@ -1273,11 +1312,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_arm64.deb
     digest: 359f8bef6d4a77cd5875d210c50dad400ba3cb6625929fc9fbfa5d56d6027a02
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_arm64.deb
-    digest: 830239bef63460fabeb07413177ff1377da7b67edb62fb4710ee06c764f232c0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-4_0.11.2-1_arm64.deb
+    digest: f6ff61ff1705a16acee52e75507683c4e78666689e2e49320b3eac20d099aad6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin1_arm64.deb
-    digest: 91551d3d67e2ad04bc982b19c3c9b69da43bbd1ce0cceacbc98a3bbfe6e268e0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_arm64.deb
+    digest: 08093eb78fa9240413e29c306f3af7f2ce9cd2599d0905cbbc48166518849895
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin2_arm64.deb
+    digest: 52f865e7d1f3a927ba35308dd28a7aa3856dbda643b4976595519e652c7bf850
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_arm64.deb
     digest: 6afa3a2ae947564d05b220d89298c7e6e1f875cb05b4ed1a9a450be99a3ba47d
@@ -1288,23 +1330,23 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_arm64.deb
     digest: cc104e0d2a339b388906430c5ddde52273cf42871c3d5a1c488732d17647e782
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample-dev_6.1.1-2deepin0_arm64.deb
-    digest: f5f56c24271c5c3aa01a4b2fdd4a80100ba9508a25b1fe1c80255b98316ef015
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample-dev_6.1.1-2deepin5_arm64.deb
+    digest: 3d0d9e808cd90e28cc05f038b8a7cc85dd3b586aba4243964c143305bc4a3f9b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin0_arm64.deb
-    digest: 644fe45e5ec69ae506a241ecc35405367e96fc96a6415600303b5fa1cd21e36b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin5_arm64.deb
+    digest: b47fc42e5ffad34c8757033f03003ccc5015de52efc8c6662b0cc4d97ce30297
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale-dev_6.1.1-2deepin0_arm64.deb
-    digest: e7458c1e32a6af3cee157bbc6d6c100d0f81687c477ba93e92a40f82f317adf8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale-dev_6.1.1-2deepin5_arm64.deb
+    digest: 82c11a1fdcc6ad9fcfe4ac15b0864c91ce2d35219d0901805c121b4acc225392
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin0_arm64.deb
-    digest: 6ecc0d9b8a6bff03f7217a159c6642bd09481fc1cb164faaeb1c6f6995a1a3c7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin5_arm64.deb
+    digest: eb6fb17c3de6c25e75455e9cc789070d7e233c77755c5ff4e9aa901e0f1fee8e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
     digest: 41ff44785effab7f081c3d4744d9e9cf25e374c13a00ab8ef93052a0a4d57114
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin6_arm64.deb
-    digest: 1142621c30d6b43d1b0cb2d8dc020424ac3d52f7eae8f02b1d1e28a539cda2e2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_arm64.deb
+    digest: 694573210aea6173c54cc5084a8c29aa2001200e0a1e2144d6338463050f3979
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_arm64.deb
     digest: a193d7e19d36227ab39cc199ed2601bd6bbb91baddaa26dad3a2530288a57cab
@@ -1351,11 +1393,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/uchardet/libuchardet0_0.0.7-1deepin0_arm64.deb
     digest: 08e6350a1fa2f96b99505d8421a1df75df69e8eef71e8d59b30eb0e778b8b4f9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev-dev_255.2-4deepin6_arm64.deb
-    digest: d88ba061e845754311659b8a09213dc8304806dbd46ffc515ae747505b93b2cd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev-dev_255.2-4deepin11_arm64.deb
+    digest: d1cad5842de92817d400e8fce7df7f7f1ea1d786356f7f9b9169509030030fad
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin6_arm64.deb
-    digest: 1398b2595873521002eea280487c1bcce4a1c7463548f0af5d07f7dcbe8f14b6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin11_arm64.deb
+    digest: a6e7866b11d30f3c747d2b1a9cac9c4e9c8c233ff4c546946d75345fc3352aff
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libudfread/libudfread-dev_1.1.2-1_arm64.deb
     digest: 7ea60db70db9c9551c12a9e549c5042f68089dfa9f60b2c8969b23b1d56ece39
@@ -1494,6 +1536,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb
     digest: 82a1fcfe359eeb57e4c0dedd434719360650ed2423d08af807a06d0a0ba91bae
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xavs2/libxavs2-13_1.4.1-1+dde_arm64.deb
+    digest: 16865284f307e4c2a2fe25a00dd50b4a6d32d8079f9615f30a913f41aec36e37
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxaw/libxaw7_1.0.16-1_arm64.deb
     digest: e8d03a5b4a02695a7b99330d854c08717bc8b53653c52913434a50917b0d8c4b
@@ -1717,17 +1762,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_arm64.deb
     digest: 36724ed79e7cc83e5357ab2f3e8c2ca75362b5352611bf5bc3c54289191f3e02
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi-common_0.2.35-18_all.deb
-    digest: 1fc738c696936a298eab3f5a6061ae0189078abddbdf7ef3da2b39537d47aa85
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi-common_0.2.43-2deepin1_all.deb
+    digest: 8c4f70100c1fcb2755b08644f2326f0c42cf037e89c22cb69e4d0dd0798cae8f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi0_0.2.35-18_arm64.deb
-    digest: ca07a0b3834361af09936a24dfd36d16a41a3db8199cd41f666d979de8da902a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi0_0.2.43-2deepin1_arm64.deb
+    digest: accd5ecbd68485a1e997c1cf0a234f32aa21c87f39053af484c5e18a8211040a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
     digest: 467675c0f4007bad669a8fefe0ec4ab45f1d356f947afd7aabba2f17b88401fb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_23.01.01.22_arm64.deb
-    digest: 6c428b10b15ae8850c7084eee2ba403b7f2ae6106d63fc4fc28de33593cdc626
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_arm64.deb
+    digest: 7a770cbb690f79ec2702611e320d3eced7565598bd3db72ac9eb060c476979a2
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_arm64.deb
     digest: 0e32f0eef7e7f5effe89929ad9a1c14a2838e5033fa9142cf0b3e6bcb81f8573
@@ -1741,8 +1786,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/media-types/media-types_4.0.0_all.deb
     digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin1_arm64.deb
-    digest: 1ba8fd0166a175aadf6918c3b77560480c448988c97cd7f7955c0082da87f0d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_arm64.deb
+    digest: 60d8a9cf9d9fa0751184d40ff2771f8f832d3c27458af93be77c37f4e9c63b56
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
@@ -1753,8 +1798,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_arm64.deb
-    digest: 2411c1cc39eb107516938b83b1eb50c29e9a6deb232723d65e17cbf592df8609
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.3.3-1_arm64.deb
+    digest: 0bc26fc52fe1ee1f328e814871a257169d1844be51b74531ce255104ef6862be
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/patch/patch_2.7.6-7_arm64.deb
     digest: d69d6e60753f09647125fa0991f7bda438f75c33708a9ca01dd6f1b6b87a3bd7
@@ -1783,11 +1828,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
     digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.4-0deepin1_arm64.deb
-    digest: 836c3af36831db46782bf20488cac27e14f2ce63e4d186c9cd8972593dc47056
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_arm64.deb
+    digest: f646ff8063d6635c9df51bf873deecfda699a61dc0db1f51745f770d4f9ae0bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.4-0deepin1_arm64.deb
-    digest: 0ce1f946a32af79b183fdb194c49a21742209a5c4b123608de8f39443f9a57ab
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_arm64.deb
+    digest: 0d85d36c0e59a7b1986cfa894814256a7361d2ccb5818e623712faa65795fc44
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_arm64.deb
     digest: 18b254c8a2ea4801a79cab3d7946d9730e41360e251094765cf8c4928f448a23
@@ -1795,17 +1840,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
     digest: 2608678aef17e7c03c4b1fc3f3e8e10b91c7ec523471e4e4cd7790be50ef8a40
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qemu/qemu-user-static_8.2.0+ds-1deepin12_arm64.deb
-    digest: e64b5dc1d79dccf79c8e7d62ce01783175353b90cb7e7af606203b95f4b68201
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qemu/qemu-user-static_8.2.0+ds-1deepin15_arm64.deb
+    digest: 55e2c35946568735e4a644448f43482b0e8e44fa3aadddd14ac00167af6525a6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qemu/qemu-user_8.2.0+ds-1deepin12_arm64.deb
-    digest: 4974c5b67da363eb4d943d6182ec41e5833a966c5fca95da326415346891390d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qemu/qemu-user_8.2.0+ds-1deepin15_arm64.deb
+    digest: 5de313fef4619d871c8abb52b17193b009df347e43e15991256a4f9dba6f571b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 01b961cefebb3c8c0f30ffd65c461f0000340eb4413763f621a42b41418eb905
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: ce44156c4871fe1af1cf1c7113d623489f7789b0cca8ae63a3acba72ff176889
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 3b73805c92b8937fddc76aeaae447efca88be5c4edb906dbe86185adc47da0fb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: cc0a67ca33b3c44efeb4723a95d34b986eb989278c17e9d9c6dcfa21aeef9b73
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 3f2442b73e48918050635d141f1ea8112442ff9217e92bd998bc9155ad201411
@@ -1813,14 +1858,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 96f2f1d1953e3a48542911d7d13f179fc9e7766a462f5941a995f56455c9fc63
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: f1c60c7ab3ec69c9fd52a1d42fe8afdb1555e7e54bca71f417e48908b8868038
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 1789a73946e436fa2aaa758278d023c47ba8cc0cfe2547ac70c18f77058ba834
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 65ffeb095fc0fb17977dd797bb410d7a401f94e8dfb981813a3e6af39c54b7b2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: f86c153ce4628e34e8f59d66ecd3a001016cdc9cfa43e03756581a177be17e40
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 3c69f6dc4b35a09be2f9d76b42be9d47a633fa223a34119dbdf33baca1fed658
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 651905afd63f5427e9b9a14d9a667709ef7449d7dcd140ec62aa1fe05ed13828
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
     digest: 719086d3983481e4d78e4c7424a796831db3925c1ca6b3495513e9cde674565b
@@ -1834,8 +1879,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_arm64.deb
     digest: d024d7f1dc80124397a3d4a41f4d2015cc72819d7933c0e5ac1cc2331b1ae548
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 87651591e1fd396c4af3a4073c2ae33690e34706110f882a05d984bdd895a2f4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: b5dc6687475a84e1aa544d8fa3cc1eb80c13ada54c0c3b10625fc96a605c6518
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_arm64.deb
     digest: e6732e7d1132d2a84254c8868b2c4cbf36e2afc4db8f82859bd8e5b9f40bbc7c

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-movie-reborn (6.5.21) unstable; urgency=medium
+
+  * chore: Update package URLs and digests in linglong.yaml files
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 10 Jul 2025 16:59:44 +0800
+
 deepin-movie-reborn (6.5.20) unstable; urgency=medium
 
   * chore: Update deepin-manual resources

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     movie for deepin os.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -92,25 +92,25 @@ sources:
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-event-log/deepin-event-log-daemon_2.1.2-1_amd64.deb
-    digest: 499b9d830ee16b298e1de6c2a879d7b20fb58176d668590321b81ae834e378a6
+    digest: 30037f716885fe58a6f1c5f53533241d1aa8e77df91db24ca2dd5cf831d45eb3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-event-log/deepin-event-log_2.1.2-1_amd64.deb
-    digest: c175f1e1a44e482cbdb1fb796fa5860829f210c57ee8a66c4fc3bcff6110e67d
+    digest: 0dd5471ec1a5bbf443cd0082bd72bbb800c423483f3789fc50595003987e2ab2
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
     digest: f0e1fe7a35fc386fb5944eb9bc4325c4e2d8913f43639ab6791ed3ea6084f584
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
-    digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
+    digest: 8b3ec535c58fd4041effcff798c688ab1f4a36b6c2ac5989412020686c7607f7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin3_amd64.deb
-    digest: f9c758ed0204b1fe515c70b6419f80fdeb4773ac3f498a79ea1e6a6e6971157f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin4_amd64.deb
+    digest: 2837fb44598aa57a0fc7d2b477c6539b3c268a1312f2580d4fb227e83d023d9b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.14.2-6_amd64.deb
-    digest: ca239a17d79f439fc02525b3b3c83d6cdf0be1a90c6aa6ec6c19b2b92b0d6586
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_amd64.deb
+    digest: 70df7073f2ddecf0ecce688b92939d7bf31268d37d299a416243dd6a114a96ab
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.14.2-6_amd64.deb
-    digest: 1018476410ec372cb5f96e3a4d4b4d51781c613212eb71f91bcc939c2de0e8f2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_amd64.deb
+    digest: c3c6ce170d17d875a72e644f67be87e47ae19feb7682517eab59259591348441
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
@@ -160,8 +160,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/i/ibus/gir1.2-ibus-1.0_1.5.29~rc1-1_amd64.deb
     digest: bcd1078c7c91d44600db89542b353098fc937f7a4ef2fa9ad94e565bac548de1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/icu-devtools_74.2-1deepin1_amd64.deb
-    digest: b3e07d1b0cdf29183718e3ad1178a69744037be8adb222dc682ed8636c664a26
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/icu-devtools_74.2-1deepin4_amd64.deb
+    digest: 8b92d6873155948ce1a7925c25c0de19aea2350f8da9dad804d392774da333d4
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/i/iso-codes/iso-codes_4.16.0-1_all.deb
     digest: acd8d976f1a757da000d9ea9405fdf80194a6275fc93fc472e1df1dfa5b301a5
@@ -169,8 +169,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/abseil/libabsl20220623_20220623.1-3_amd64.deb
     digest: 23ce45fe62610dd94dd8df7f0237509622e65c12334ea84d21ceaefc901d195a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-1_amd64.deb
-    digest: f06e936eb913b8e9271c17e6d8b94d9e4f0aa558d7debdc324c9484908ee8dc8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-3_amd64.deb
+    digest: e7235d27da99795b0ca6c6bc5e8d6e84702335063fe9d08b19320c0bc965679c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/aom/libaom3_3.9.1-1_amd64.deb
     digest: 6cfd746dd55a96fca3e058faf82c7400ddf50017bff6f7cfed6ad1f6ee637ad0
@@ -211,35 +211,35 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/liba/libavc1394/libavc1394-0_0.5.4-5_amd64.deb
     digest: 27a869ad9b0f6673fe4c6e6dc6aae04f58b550fa9f2de4c9c9ba64cda6e9937a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec-dev_6.1.1-2deepin0_amd64.deb
-    digest: 8af2330b798a2170c1af0bb977a4994adee215082808038c33b57ee454e87ad4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec-dev_6.1.1-2deepin5_amd64.deb
+    digest: b0060af0eeb8747cc2c41354fdc1490fdec352ea44748aba72e89ac698422e3e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin0_amd64.deb
-    digest: 5c879f2bb5e245e3620f30fac20b046e2e1770b3db8d101fd3d77f1bf13374df
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin5_amd64.deb
+    digest: 21cfafe3e4985e50b51425b45a00b896b00d57022fdc139e4ba2e74b14e7a274
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice-dev_6.1.1-2deepin0_amd64.deb
-    digest: 42fff48f5269664ef2e2c11c689f7b105550790b9b39210a055841725d87cfa5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice-dev_6.1.1-2deepin5_amd64.deb
+    digest: 7a8bf1b88c85d9207c27a35353504eb37f09dd4bc808a4f5c000e7edfa17d7cd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin0_amd64.deb
-    digest: de142f9b5e109cab76bf89987b4d32a79a489e8644cbacb11ecc605c290d6024
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin5_amd64.deb
+    digest: d592c5f97dec2b6666d9a4e306b6838cdfc7033320f929227a6d11c1c2549b8a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter-dev_6.1.1-2deepin0_amd64.deb
-    digest: 1b0654d22444c8a51ebbca4cebf468e43c7c8a012ca2a501bb6111e1bf94e77a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter-dev_6.1.1-2deepin5_amd64.deb
+    digest: 8f9204d8ff272bc3f310ed071d9598cfe2ee4c4da32570a1c5094ae2ee7039f4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin0_amd64.deb
-    digest: c8716db260758b9dccd66343c82597ce5f239746288b24687d2c1dacf64d7760
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin5_amd64.deb
+    digest: 57d391b0feb1413978910cf3eb8a001a6cca2c765c9cb9df07e4c20d28809355
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat-dev_6.1.1-2deepin0_amd64.deb
-    digest: 9c7db47a9a14bdff9b5590452946818c5133ee56a0bd2740342ad1a6a866ef47
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat-dev_6.1.1-2deepin5_amd64.deb
+    digest: e416b01adca98fc622620bd7752a418f22a44ef3dc86a95d0bd9579d67ba1e3d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin0_amd64.deb
-    digest: 9744ea02284ee606bfa0ce6243399199a861f8c967d16f2cb23e5e834c375ade
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin5_amd64.deb
+    digest: 8a8253d05168ed6193594a300ff056afdc8b6a0be9603aaa27ea6517335cbd87
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil-dev_6.1.1-2deepin0_amd64.deb
-    digest: 330d381bda51be0dc9308f933868df9dbaa9802d43644e016664f5bdc3734215
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil-dev_6.1.1-2deepin5_amd64.deb
+    digest: 3bbddfb78cd8ae36264a924cfba2b6c1e93014da5f0ed2a97f88f66eb0795043
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin0_amd64.deb
-    digest: a85ec638e75deef12fd30204d63112620d4e21e9a4887ae267081cd7512a4846
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin5_amd64.deb
+    digest: 12ca2c24eb8bd3be76bc17c151625c897ee0e9d446673985bf945c850a99e9d1
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
     digest: ad82b2de93cc49cdf37c861b03275245318b1555255639e5e805cf612a40171e
@@ -307,8 +307,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap2/libcap2_2.66-5_amd64.deb
     digest: f4f581c5ed9c6576ff284117ee51ae8b4e47e6799d71fabc7c0aa2d3a260752a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/capstone/libcapstone4_4.0.2-3-deepin1_amd64.deb
-    digest: 6b82dd7f3f4ff2bc1c59d2cd7180600bc9cafa1ec8752689e301ab04dd4e9713
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/capstone/libcapstone5_5.0.3-1_amd64.deb
+    digest: 0e6b1c94b28127dbb067f7ded642625abd26fac8bce528aa9bad37e5b66836f8
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcdio-paranoia/libcdio-cdda-dev_10.2+2.0.0-deepin1_amd64.deb
     digest: 12eb4b37ac45b271644fa7d6da13906cb82b870fe8028d628471a9bfb4870217
@@ -331,8 +331,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_amd64.deb
     digest: 1ee2dbafa2c331d58cf10cdf546c760d7a734c5d9fab1b16d2e04e51f6e38623
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cjson/libcjson1_1.7.15-1_amd64.deb
-    digest: 57a3cfa5dc3847d978668e57cac797681cac10be5f6deb6ed3955f23fad0ac24
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cjson/libcjson1_1.7.18-3_amd64.deb
+    digest: e638d498f51d1c6b3a67b0463fb57269e996b572f59237b041d07ada88d7a69d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_amd64.deb
     digest: a34b10500cae17c2c122760901c453df850a968a32699978c2015cf355fd5580
@@ -358,23 +358,29 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf0_2.41-6deepin7_amd64.deb
     digest: c58e37fce60c661d023d37f46d1af34772c40783b2be220f0d11eb8e2d8029b4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_amd64.deb
-    digest: 45ca2c611835e500875ddd500f2618ec97d6bfa51735ec3d276a72fb110e544e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_amd64.deb
+    digest: 57726c5fbe502348eda3a0ba248978a0769eb7fd134d8998386e3216875e18d9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin1_amd64.deb
-    digest: e48aff0e7bd13a310516cfc5dcbdb68d789ef8e4c949afe7e638fb402a90f150
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin2_amd64.deb
+    digest: c3677b705c3b3214cec20cc24f7a4e4a05c975e1de8834e4647f5f2575b114e5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_amd64.deb
-    digest: 14f6bb47e2fb92849593a1440cd87393d7920f5b7a0fa1932165c6bc8c96e890
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_amd64.deb
+    digest: 94aabf445b3d15c635a2a1710066107e3f3860bcc15cdd982b3ae5581b132960
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_amd64.deb
-    digest: 7e35233d2f74d5344630efc3bb2f91d2efb8ba7e62f01d5b095bb6bacc3c7010
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_amd64.deb
+    digest: 35286abdab600d5aede3a3e77030ad9f65535287d63be8140f0959fa9e0641f8
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_amd64.deb
+    digest: c8fd9506ce9de38317bc40295bd9c673d332e444771e00c6bf249373e424b82d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdatrie/libdatrie1_0.2.13-2_amd64.deb
     digest: 07aa08beb07e987772c31ef3865ef65b8ea37069c7c840c8a2a56c6d0019df07
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dav1d/libdav1d6_1.2.1-2deepin1_amd64.deb
     digest: 258bd4678ba2f0f0a63f00e630c890efb34a1adf65e1017308e28a16ddd25eb5
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/davs2/libdavs2-16_1.7.1-1+dde_amd64.deb
+    digest: 7f8747a9b3a5322649d4cde69fb09fffb310ea0b02bca7df6f60db383484c1c4
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_amd64.deb
     digest: 98830ff429c7212767f0de4d239870f1936b37527ce365287de30eb8276a8330
@@ -403,8 +409,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
     digest: e6c6d028a74d0a752ae638ec19b8239f404c36d676c7569936f31000d25a75f4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin3_all.deb
-    digest: 71989ccb16cfcc04aa5a86f06e4dff837a4fa755d04d17d5f0cf329fc09dda04
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
+    digest: 569373a35267f9cf2e8d0ee6d42c9047f50fa2174a0ac72fa77f494a0f0a9d1b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_amd64.deb
     digest: f58eaae37579b2a3964f84993a8893fe00a05447b23f5e937102c30f64fead50
@@ -427,35 +433,38 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm2_2.4.123-1_amd64.deb
     digest: c2f1676c3335ab76ff829190951052abef661b735f2ddfefdb8d6c0698c41756
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.25_amd64.deb
-    digest: 8ceffb3810d88965cf8f4b9cff067f53011112dd32a211495e0c37a9a8a948bc
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_amd64.deb
+    digest: dc0e1738af9ccdb458d217b3d2eecb2ffbb49092f6247b6021f786b0548d12b0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.25_amd64.deb
-    digest: 60ed25c9a9cb998a21b97cbd0451f4df0f5bd9f3872eef1d809575eaa6048c9f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.38_amd64.deb
+    digest: 00964a07edce1826a9ca23dc820091f95c77da6950ff704aab34d59ace7bdc3b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_amd64.deb
-    digest: 9a7716eaa20196761a0f87a86035bfb1bb2b0be1bf485b0697a70927f60a99cf
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_amd64.deb
+    digest: 242c7b48aac3fe35579fdd2f52cfa88e12a8f0df5ed29926d042441e4d449471
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.25_amd64.deb
-    digest: 2c91aaf3f276058f1c190d355ccdccbe699c6c1b5999edf9256fee34b5343d66
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.38_amd64.deb
+    digest: 43302b4536ee242e84c461c32eff19e794a892636734c15ee2c8094ad77cd28d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.2_amd64.deb
-    digest: 203f1e94dcaa537929ad7df2c33f9ae6f006985fc56829a37c67dce2c11660c8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_amd64.deb
+    digest: f9e6c1e18e5166aea09e13367e954c527f0d8b7f5cbdcbd9493d933a65ec7fd1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.2_amd64.deb
-    digest: 4af48ee588e9a27ca3663193177c4fd2b4e455cff00dbff0aa5fc2ec4bdd24d5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.4_amd64.deb
+    digest: 4fecfdb38533bc2e6b9a16e559cb70c56ec50fa061b92b1124b606d28d7b3887
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_amd64.deb
-    digest: 34b0abc672d2c5af743d1a0836af2a258428422c3d1b87fb71507b0abc8073c5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_amd64.deb
+    digest: 4e0ae6248f9f3c03765a71c4cd4df02f2a7ff242c4e7bb45d1617c9d234084d0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.25_amd64.deb
-    digest: 2d4d30307bcc41eb6cef9608603ee999aabf3a81d4ba2a7008e6bfbc232e0689
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.38_amd64.deb
+    digest: 649ec642a62e9ac7aef520a41b14f0d3b09bccee17b4676790ea45ec15a37c1e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_amd64.deb
-    digest: 880d256182fe9891a7874473fdd1f18439e5c1625160214adb9167fdba3159da
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_amd64.deb
+    digest: c490431f2dcecb0bc945f62ce139994ed039098c4c803a14c39b37c65e6d0698
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.5_amd64.deb
-    digest: 75824b67ac4979f023f9a22ed326157e76f0c4d7739474145e4b51fdf55f83a0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.18_amd64.deb
+    digest: b68e4815cea197c703fe17fc8cd90206bd6cbd9a582edb909cf8f641ee1e313e
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/duktape/libduktape207_2.7.0-2_amd64.deb
+    digest: 03743b861cdfa66aa9a94608574f3c6c784fa0ede3264e70d436c2fc8e902b95
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdvdnav/libdvdnav-dev_6.1.1-1_amd64.deb
     digest: 43e1e3603ea9ab7d8c3a04dac3d0bc6570ee7becf616aba0545d44479ce1f5ca
@@ -478,14 +487,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libedit/libedit2_3.1-20230828-1_amd64.deb
     digest: 72d015604676696e4e10e238f4795fbdc3d7c0e241147d55c9782ea8baf9a03c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl-dev_1.7.0-1_amd64.deb
-    digest: 5c13bca1b3b20bd64dcb071163da1d24aba5010643ffb36329847437d16c8e6d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl-dev_1.7.0-1deepin1_amd64.deb
+    digest: 42e40389327d2d5807cd44b049c608986a7bf882526fd902cbd8919b66ad29b6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin1_amd64.deb
-    digest: 87279fae7f9248c2f9fbc9b4031062fe49b51d939203471601b704ffd00b26d8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_amd64.deb
+    digest: bb9a950bed0f7a14f62e0787bc8b650262a6094c5b244d7771ef9f4514a0dfc2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1_amd64.deb
-    digest: 8c883a493c299a9cc4bf8814dc98b8d22ef4902f2e29b84e47c05075807785b9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_amd64.deb
+    digest: 1675190466ac26b2ae0f64131a83aef2663c42ee1c1775aafb2ab6878df3f235
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/e/elfutils/libelf-dev_0.191-1deepin2_amd64.deb
     digest: 361398bf88821f790aeb9021f59f23b1f47b578c03b4c067a1bf511bcbe6913f
@@ -499,11 +508,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_amd64.deb
     digest: 48c0a7c73d835054b291645fa21fd597271e28a6eb98d8b22f2283e364e83893
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.5.0-2_amd64.deb
-    digest: 4d0a6ecc7857dc60dddbbd6872c2587f1081ce0d75b84c22ee8641a082fd6e24
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.7.1-1_amd64.deb
+    digest: 8dcb891102e9f4dd8a9903bffde5576f017d651927538d613b664c92c6130ab2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.5.0-2_amd64.deb
-    digest: 5be8be254b82a58e77549b1784520f1f7ebb395b57982f87524533e1f061f75a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.7.1-1_amd64.deb
+    digest: 5b7f0cea08bc334eb501726e90caa650c72fb86b2fdd09e653688ac0a184bbb3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
     digest: eadc61825e77bad028fd5eff398ac0e13da7a08870261058525d3f620d90cb7b
@@ -529,14 +538,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_amd64.deb
     digest: 63b2c4d61d1e41070896b399b52c4b38cd5cc529b66692394b4dbe7f5375dad4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.14.2-6_amd64.deb
-    digest: 1b8d5463ae362465a609408e932ad0bb6968737a59af9669c1c1d3801a31ef16
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_amd64.deb
+    digest: f24f727e6c0976f6f7a728eadc4c887c847c6fa241f40c72b0db90d53441fe75
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1-dev_2.14.2-6_amd64.deb
-    digest: b4851121202b85ff91dc5023277cbe9e0431744ef3c9e7a88aedb8f9e9c52d66
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1-dev_2.15.0-2.3deepin1_amd64.deb
+    digest: 361c9ce99546dc7c4ac638132521b5c01d8c52b7a619702fd4d357f510e34e4a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.14.2-6_amd64.deb
-    digest: c4c5fa416637a08cf925dd4ec0115631b69e4f2f5f46f2094f3239167f781085
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_amd64.deb
+    digest: bda58c37ad85fd9f7d0498483b11cdcf250eda86fff6e399d13105594737857e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_amd64.deb
     digest: 758a94a3acf10d671cc056981255d2bca91e42d74e46edb27f3c89b9c5d5d3cf
@@ -553,11 +562,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fribidi/libfribidi0_1.0.8-2_amd64.deb
     digest: cb0bd9ae5b3c84a26fa8de5a614b557caa3e312fb93b35c46e551c8135275e90
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm-dev_24.3.0-1deepin1_amd64.deb
-    digest: fe0c6c020de2ab202e9f264031b15eb698ab4b72c922f71ba0f82a5986b1e1bf
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm-dev_24.3.0-1deepin4_amd64.deb
+    digest: bc3b5bf6bac09e9de2553ff8da840de5e24bb77014a19d67e8b05137427673cf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin1_amd64.deb
-    digest: d5e8568bf4722ba1cb7c089828f86e3e7608640010fc85286859b62f207b060a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_amd64.deb
+    digest: 4022d612b88be490e20eea8ce8d3ee2862a2c3fd563e549a523eca14cee34639
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_amd64.deb
     digest: e70f1a5d9e15b85cc026d9a816064453dfb05a78fc4891a3da8b595a67debd9a
@@ -583,26 +592,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_amd64.deb
     digest: 6340c9628c7bcfda4c6826a49c52bc8bf28bfb8d12c163eb19ebde7b0ad61578
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1_amd64.deb
-    digest: 0682d06faaefd4fb61e5b8daf45ff4318d9bd96e279792bb4a6eb16b0cc61ba3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_amd64.deb
+    digest: 9555387119d2c7118202da7424f3d95a358843cb6e3369135979bf3fb1e7586e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin1_amd64.deb
-    digest: 273f9c7839bc622c553bc3659b1e1d29cf4d61cb307d0a7dc36937c5d523138d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_amd64.deb
+    digest: e98cff9eb0e1302ecc54f63bfedd21b9b1d96a9aa81f0c224363a26c7380755b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1_amd64.deb
-    digest: 1889b6be38cb7319734d330c232b64aff31845745c74732bf824fe39bcbfdb6e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_amd64.deb
+    digest: a80285158761a0fb609a7a27676b6ba15f9e30b12985012de34ffd84a8d03e95
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin1_amd64.deb
-    digest: 82afd7057adfa2e6a2642b81d319c4815c714bc44b914e0fd6984284f3887f15
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_amd64.deb
+    digest: 90ec3a2e108d28d421cb65fe9245dbeeb0cc923d81f1da45a1af6ec6be5d4024
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles-dev_1.7.0-1_amd64.deb
-    digest: 32aa7b352edbc74a419efa18206e6126665086f5f1228a195aabd33a4ca102fa
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles-dev_1.7.0-1deepin1_amd64.deb
+    digest: 18b7d6a1dabacfce2f40a36f5d5dfbc2719da9281589da6fae9b2e18c4f47199
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles1_1.7.0-1_amd64.deb
-    digest: 11ab498d36e8ef33d6ec0f6ba338416b53941b54bf0a673fa4ee0af1b056ea19
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles1_1.7.0-1deepin1_amd64.deb
+    digest: d8ad4299cecd3e56c1b56fa40d8cc48ee126e7b279b273fc39d4fbd5c8f14c9e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles2_1.7.0-1_amd64.deb
-    digest: de53fda16946bfb9d1ca33a3605c4184cb2a4d166ef3139a1822a4cf4da52ed7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles2_1.7.0-1deepin1_amd64.deb
+    digest: e544e4e863f9d0593900af5f884118f77c67f9f5d77542b3a8512efad736dcca
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_amd64.deb
     digest: 33857078b63370d9edfbceec5a4f8d159db6f75da9f486dd12c97711598f43de
@@ -619,17 +628,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_amd64.deb
     digest: f6e2df667c442e8ad0305ec62c85227aead61ff85d591ef32ec9de31d086a74e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1_amd64.deb
-    digest: dbc3b9a38a5527c8a02d8edf0f87779993272d61d9b24c3209df69d1ebf3e540
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_amd64.deb
+    digest: 58699e543f5a5135c84153224efd63d61c3312201debeb93430014dbd28f313b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1_amd64.deb
-    digest: 31a76ec3d0a13d2340d8f89769770655ead3d477c918082fe4fad249c6d51258
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_amd64.deb
+    digest: 5b8281d799f1b3844524c1baa475e4876665b4d6062800655e180586dc0015bf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin1_amd64.deb
-    digest: 7232cd85bfc774cdd093465273698eff1f1798442b301c462cd4daeb58fb8a96
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_amd64.deb
+    digest: ff5c14a729458868c87b7eaeca9e9dab4c06f2f5eec59d71382d36e36f79f3f3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1_amd64.deb
-    digest: 30197452c9ee62b7a7063d1a9f208ffae0eefec86800340a104a884543d133d0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_amd64.deb
+    digest: c7571d6a7a90722d85f06bda863fbae2a42ab73f0b4162ce89b5b6c87382dc59
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_amd64.deb
     digest: 6f185c6ac2987d5d8ac0f81be7f0377ac34c00ba45ba8d206ae7ef5888bbca00
@@ -648,6 +657,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libgprofng0_2.41-6deepin7_amd64.deb
     digest: bb74544850bc21a47d09919728769c419233639c8d9e8b1f07679d652b1549bf
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-gpuinfo/libgpuinfo_0.0.10_amd64.deb
+    digest: 74787e2bb8d1c31a044bef881a2f38bb2d8c528772c1fa0256a040e79b3463e1
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_amd64.deb
     digest: b4697179666eb012313127a7ff04d286f427b49523f50ada6d593694030c0b51
@@ -727,11 +739,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libice/libice6_1.0.10-1_amd64.deb
     digest: 03da9ec604f5bd9ba6526c4e6cf90c5b4266818b2c9a34110d74c42b9be87646
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu-dev_74.2-1deepin1_amd64.deb
-    digest: 0fbeaaab0e35f791b428839e260ca58ed9b3e9659144591c9306b70a7bd97744
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu-dev_74.2-1deepin4_amd64.deb
+    digest: 494d22bb9439e7f7e3ee3d71061916fe3f645ce8cc8e4411d191c47bf6c10302
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin1_amd64.deb
-    digest: 6e57a1e71d4e938663bfb064d370d1e8411dc5f4a5de828c24669f0dc95f6631
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin4_amd64.deb
+    digest: a1afb2975773d7ee675f61ea12720c79002d6bcb6b586a5e6975a997b60775fb
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libidn2/libidn2-0_2.3.2-2_amd64.deb
     digest: 0ac47209fe66a5906497d6fb1c76a2addaa8daa2becaa434b17d32b98dd057cc
@@ -798,6 +810,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lcms2/liblcms2-dev_2.14-2_amd64.deb
     digest: 129824080ce539c696a2696223de64ec2745031ed1a38d7915213aea370908bf
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_amd64.deb
+    digest: 35570c1c9b06d39aea8c6d2a149f420dfcd1d7503db10e6e5753e0245e1c681d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_amd64.deb
     digest: 9bf199c57795a3e4c8e7cce1ef1803e32e9d31fc7cb82b5db8275f654e19b655
@@ -898,6 +913,18 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb
     digest: d19dd4ebabccc00232223b414732c26b63d4ee67f4147ad5a105795f4514382a
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_amd64.deb
+    digest: 9221a35b50f8c23ddb78e93ea4cc66ffaf96586d38503ce4b8b61f6995739847
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nghttp3/libnghttp3-9_1.4.0-1_amd64.deb
+    digest: c8c7b6f84833ae5fb50f7e6d127d07ad09a356f952b191edbf0542af500aa796
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ngtcp2/libngtcp2-16_1.6.0-1_amd64.deb
+    digest: 81438d30b8448343632bb615c15ac772214df4ffbeba7a4e5fc3e87afae28a45
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.6.0-1_amd64.deb
+    digest: 526bdadbb91c83e044e49e2f270684e1de60790897c9c912d3abdbef5c7c5796
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_amd64.deb
     digest: 5b552cdd40095bd94c6276021dfc5360f2a6289aa94f155ab3ab3daaef341c1d
   - kind: file
@@ -919,11 +946,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openal-soft/libopenal1_1.19.1-2_amd64.deb
     digest: 6519188f969234cbdc9e3cb8346d86339b1f766db083e2519cfdc68b917e00ae
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_amd64.deb
-    digest: b91f22b0ab692fa36eff6fe2acc7e5878ab99d56177f3983cec1db54bd9c7f72
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_amd64.deb
+    digest: 178ad33f72e1905c6d777a680fad42295608be7a6f8f95dfe5f2f27dbfcd5505
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1_amd64.deb
-    digest: 85398c86d394fb5d1c7b1f75cc6f3f3045424224493853cb94880a82baaddf8b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_amd64.deb
+    digest: 8cc2d909d52c3346a714c2eb5d0115db214f8aac5eebfb5e41bc91eb48f7f951
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openjpeg2/libopenjp2-7_2.5.0-2_amd64.deb
     digest: 1d7109a9c3f29c8bde7b4f92866d28860ee641dcfe3a718f4b730f845e63a4a4
@@ -982,11 +1009,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_amd64.deb
     digest: b8f9b921c681e6c08abd8d452489762dc8ec3234e058407757f4f383ba2a01c5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin10_amd64.deb
-    digest: 1313e2522efb090a838672ded2d427bbd3853251a2ecef715c406e899ba3837b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin15_amd64.deb
+    digest: 67994c9d88b4d119e50dcc776922af8d6a356bd5b38c144b16c99f07541d0264
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-dev_1.2.5-1deepin10_amd64.deb
-    digest: ebd711032f80fa839e228d4aae3022c8d5e8137469074975f8c42a548cdcb90d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-dev_1.2.5-1deepin15_amd64.deb
+    digest: 61367c562804c1f68819a452d59d72cd17c278d09b94bc77d74d1149de951258
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pixman/libpixman-1-0_0.42.2-1_amd64.deb
     digest: 61dfa0134fe4038b88e3e64081f7340277297771d3a7c1667277cb9b992d2d0a
@@ -1009,14 +1036,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pocketsphinx/libpocketsphinx3_0.8+5prealpha+1-13_amd64.deb
     digest: 300815c25c3d2b8aec8dfd4a03fe74da7d6bab832deb21fe5aa24a3a7e390885
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc-dev_6.1.1-2deepin0_amd64.deb
-    digest: 81ec1595276aaae2d51567e942a19779fcc81a5f69e199e1ad62a31474286282
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc-dev_6.1.1-2deepin5_amd64.deb
+    digest: 313a31be3cf0474a815557ececee164f94d9d08facce24d6239a28a120912047
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin0_amd64.deb
-    digest: dbfdde5ab37b0d154efbf5dc331f8e993f320f8cb31a2ae688ae3f0ef154e882
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin5_amd64.deb
+    digest: 6c5525e0cc7c8c9b719ad4ba0f4fad45e717029026fd6f8052990b8767a4695b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_amd64.deb
-    digest: 01182c680d643f335f63ae38016fef3d5f097ab718789f9aef79de42f00517d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_amd64.deb
+    digest: 4ad4360252e008b89ea7885a7c27e2df5af4a45e0aede319e08b17db3c3af932
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_amd64.deb
+    digest: 7a00b4f3ca191e7a887cbfc6b0ed619493bf5344b85c8e823577b115ec34f738
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_amd64.deb
     digest: 8be922fba920a96d098288da4fa5f1d5dfb778b362d7a26ed738014305aa3787
@@ -1033,23 +1063,23 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_amd64.deb
     digest: 7611dfe764b5a109e1fa516270c304d451aa2980190c480a83b90207a6b84158
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.4-0deepin1_amd64.deb
-    digest: fef2ce003db442a002e3c874de33656cae3ef4a6d00a2a72e267b386df647945
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_amd64.deb
+    digest: 452e6e2a18330944a7ab46303050baae3385ce7ad2f509a6526c211b077836d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.4-0deepin1_amd64.deb
-    digest: 192a53ec08eb4b356fcc157b8ba97a4d2e1e4a2d8e8d32e37a9d70ce5ff2ea22
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_amd64.deb
+    digest: fc43de68d925c6bfdf632afeeb053f1b28f4050b197ade1c93b701cfea5aaba7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: 3c7b32f481b4d44bc017945a73a0f92377ab0a11ffab36e162c768280fa4df5b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin10_amd64.deb
+    digest: 9c271d6dd6f7a6596ed2b700d513c7e0b1171c10190a0e052dfca40878b314b7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 2b27dda887d891e316750fb1b7bd56fafb097c1bcb0f03e7ae0062561da40a6f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 827f947abe65c18f979255506073b5d223d2c81e65a2528da21fefa11c9d1af8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: ebd40ac7c53cd6b669568467e3b9b010abbc030ea1201662a74e0cb95a49698c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: b6e687e6926547c0945ff5138495d025ca190f7991b42ea98193c29ef13ec08c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 54dc26fe98838334213678668a1cfd3c020f2f050ed8378c0b8924ec1af8cc31
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 9f7c4a6b688a3c61fd526f22a54959be1a9a5b550ef981a94bf06d7a91e1e4a0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
     digest: a6864707b38a192dc89ad51546e958fc2095ca3b45e6ee99e190d48ef54793ea
@@ -1057,8 +1087,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
     digest: 033f970ed9f2486fa265bf3a10332fc18fec0b9d0a83d74ba999007c4d647fc9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 41dd12c029ef2a97fc9524b773c007642948bb0968f71f6dd08538dd03f8d375
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 33eabd5595bcceca83cfd7747d0cf72a6a9fc6555e2ce3e2ee9c5f1abd23456c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
     digest: 18db346cbe4e81620934c3b232222482f5c1251725516d3fb620c10ef2bb2611
@@ -1069,17 +1099,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_amd64.deb
     digest: d754dd297c4bd2b2a93ef7d7bec5b1929a8f06a6b35ded515e01331633d1204d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: d8d2854d73ebeb2607bc90ba83cfa55b67cee62ac055bb1b6228bd426fea4363
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: ad1be661bc76e8c62bf7c5a89dedffc7e5e3203119d86e2fb9d5747eb93fe9db
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 7e1f0b187c5e82d45c06a8b3849fcb4e2a6cb6a31b950f7622ead3747009c54f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 093d158b5adf7efa268a719648907c412927df1ad770c15987bc8c0b48a8515c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: f87c83461bc1806acf203a7e52a8c47e32aa5e42ede0d26f0ecf8a26bc914576
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 9104c64aa25ec85a9f10a650ffdf1b03aae2321693ad4485d39b67c7bf68ea0a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 4c1a62bbfb23764fbfc250027bab219087940ba16fa680b1e7348dcf418906f4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: b91d897b49c277334fb8a68dd554e749c24e01b3d989b7e85d4c08eec327001c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 4f9d66873e7e085fb6909fd47be1fd50a41a8dd4b15b38bc77ab2dff42e43cf8
@@ -1096,11 +1126,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_amd64.deb
     digest: 73c0e26ebd541bd02158cf6265fcc55b16b7148f9db0a4130b7d7bb50a83978a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 528e27bb9f946d602265cd8a43853f56b2754f3c945ac7bd64a099d7cc589f34
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 1bfbb5f6771c285ef838eaaf429106eecbdd305baf365766ed05cfb7ac78ff3a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 105370dae395895df950cca059ee1d11aa5f6677a554c7331a83bc0da959ba52
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 7af38213ff2d557481dfe8ef0073da0fdc1ad1f70b22116ebd02f4d39bfb4292
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_amd64.deb
     digest: 0e43640fc49faf57d8454012338aac69b638356417a4a2361f3c0e47271ffbf1
@@ -1108,8 +1138,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_amd64.deb
     digest: ba29752fae4494fe62f5a4d3f139386078d8beb74e53eee1d7c673028a8adb97
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: ae45f73efa9232cbb98621c9ecc12488a7ebf687eaf9866c2e171aa37efd96c1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 9cc8d7cc8d4290b937bcdcf36c18e63293cbc32821a14bf78d69d336dde918e0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
     digest: 5a2a509181e35a92f6effe0f2ef107c7dfadccefde35548bb1ae568aea003fb3
@@ -1117,11 +1147,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_amd64.deb
     digest: 70486bbc5555f857aff3ca539dea86df4f800d20ad4e20b3cc5b62b9a6d75b21
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 4ba7721998329f33d49cc6f82add0a1a6819b59c4c8ba1e82dd084bfa3235ca6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 3ee17d593ce177df59677046e7f5a8b62e5f30143a824d6b7dadf327da631d24
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: d311d6a7a8cf93949f715bbbb271149e3396966a60611a086b05b125dd17c77d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 7ee33cd4857e0c72a6765d62d14d575ad3abe1e74436ff8615f0659c46e60d71
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_amd64.deb
     digest: 4b74d4425bcb1d23d7763e62cb1c9f2be712d9f92e46542151125ba96d623164
@@ -1144,6 +1174,9 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libr/librsvg/librsvg2-2_2.58.0+dfsg-1_amd64.deb
     digest: 2fbec23eb0a08c54ee112b5c11652ac78bdfd3391605882604c2a6003ca75c46
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_amd64.deb
+    digest: 9743d579d479e0e2ef99f984986b2d9d40d7e0a43b6f0f74b935f3fd2d5b6caa
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rubberband/librubberband-dev_2.0.0-2deepin0_amd64.deb
     digest: c9138102e779e850d8691898922130ba2ee1fc8ac9b19996a7a576c52d4a1391
   - kind: file
@@ -1156,11 +1189,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0_0.2.2-1_amd64.deb
     digest: 8ba9b50925d6722aad9a86f36483cc5cbf169c6199b21edd84f43bf142608cf5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-2.0-0_2.30.11+dfsg-1_amd64.deb
-    digest: 8367935b2d0835c876bf17b81f5b2991688c525ceecc476d1b7da6ddbbe9e22c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_amd64.deb
+    digest: 9ff9bfa155660e99d78ab3501392fd17381adcb90bdf2457bac8c3af296b3815
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-dev_2.30.11+dfsg-1_amd64.deb
-    digest: ab097723e9808ec42f285c6a11ec83c478f4faf0380296ef47fe3e8172794d18
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_amd64.deb
+    digest: f02625e8d695be6bc1aa9531c5177097ec906333b60a0fa15861a82ade617762
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-2.0-0_2.32.4+dfsg-1_amd64.deb
+    digest: 1b7f76a51ac9ec119bdaa143b6eda92006009566c28ec1b13f1aaaaffcea9ffa
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-dev_2.32.4+dfsg-1_amd64.deb
+    digest: 4c230db42a5ae38035a14ac5655443cf465797eedb7b36c943e4f45fc0575a76
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_amd64.deb
     digest: f7dfdd9e463828cff8e624ceda7f13cc68f2c9d2e72b27dc7e7315e1193b7d92
@@ -1237,11 +1276,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoxr/libsoxr0_0.1.3-4_amd64.deb
     digest: 9736df9018121b8368b482278a533284a82da09650baa3cb3541fa58cfbc09cd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-dev_1.2.5-1deepin10_amd64.deb
-    digest: 7eabac7aea47eab8cb61ad19199a5fb1c17707c476aab009cf2fa04b5bde71e3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-dev_1.2.5-1deepin15_amd64.deb
+    digest: d9a9bdf5f2bccc092d2b8f3b44d082c594dba0cda127cf8df4181e402368fc49
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin10_amd64.deb
-    digest: b59b38d5fc0284fb0082a4bebbdaea0bd36ef0ae00d520a02ce2ee0b442b7dd1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin15_amd64.deb
+    digest: 9fcc5140e096484a5a32d3dd3824ad7315d580a24e2e6ee7035a20608f0485ce
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
     digest: 44381cd9ad35fa6ffa7a0b3e27611011602bb32093efaf0c80117dc9f97a371b
@@ -1267,11 +1306,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_amd64.deb
     digest: cda4bbbcedb3ddd9b6722acabb811b95d1a6573a60ad7e6fedfbccac843bf8f2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_amd64.deb
-    digest: d24f878a3059bc9cfa70dc1053cb1a2aad772c63b8bc528d4ad47b089519c017
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-4_0.11.2-1_amd64.deb
+    digest: 5b8f66c4197a56ea3b044d57a7cdd5bce63804342a4eec719d5a8e0243f1a841
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin1_amd64.deb
-    digest: 9a4e8cc759832d24fa15edd6d45cd2c54b0aa619104969600da2bce5a3d9be02
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_amd64.deb
+    digest: 90258a13940712eca57406b2bb0d274fbdaaa2d62a45c1e60c5b123c4080d663
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin2_amd64.deb
+    digest: efe5ea0c1f74ce2ee8c760ba534276c01c0b347fb7eac4285f79b935bea8274c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_amd64.deb
     digest: b0e9783da04f53ba8da97660523021322c4477059c63d3684fab283b7f9aef9c
@@ -1282,23 +1324,23 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_amd64.deb
     digest: fbdb57f1b3b245ef8d92d7a29bd0b054fec010ffd245b1d633172674acbdd7cd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample-dev_6.1.1-2deepin0_amd64.deb
-    digest: 5433808e381ce031841801dbad1f5dbf31e7fb66e44c6b47b1e3d782d6577db9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample-dev_6.1.1-2deepin5_amd64.deb
+    digest: 3bc103bd08ab83d19b70d9afccbaca000e60c186dc6b01b1442341f4fe6d9278
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin0_amd64.deb
-    digest: dce0e6c6a5b69fedacb842be249acad0eef03fc1f76c97ded590dbe31cdacd45
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin5_amd64.deb
+    digest: 052fd947964de35c9251f47d1b41794a2897e20510eaeb329ad065f5b73cfac1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale-dev_6.1.1-2deepin0_amd64.deb
-    digest: 2feeab6d9f017096a152fe6de973d9a494305e0bad6151fe64d4e656fac2f056
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale-dev_6.1.1-2deepin5_amd64.deb
+    digest: dcae3fdbb6160a35e6c65b6362896bcb0782357f2e303e6690cefac0fe0a61d0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin0_amd64.deb
-    digest: 2f6e7a4c570e99b590b1d3a78c2cfd96bc4a665de3e631b292180336af31440a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin5_amd64.deb
+    digest: f2aeda13da0792eae2ed5a4ddaccf2bc358bee717cdc78fa041a9d6432644465
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
     digest: bbaacdcbf341e500cd8fbe0dfb75fc98156b0a5abf94e43105bb5f745c3168dd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin6_amd64.deb
-    digest: 3312bcba7313d337154903b622051f5fa06610a36921c40e3c35686c53dc4d2f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_amd64.deb
+    digest: 75f4b1c1d7e0caf4127313225fb3be35243b09df4cf93e0225f5fb27e6c4074d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_amd64.deb
     digest: 3f24f7a181f374bd6623bfdc7781e2cee5d948361a456d2f6216aa4ba5c44a2e
@@ -1345,11 +1387,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/uchardet/libuchardet0_0.0.7-1deepin0_amd64.deb
     digest: 8a09c59f9380ce99a5d18d8e3d4fcb1b9308a5f40789b1fb4323e0fb75c51a7d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev-dev_255.2-4deepin6_amd64.deb
-    digest: 539dd0c23cc3a017ee540c6384f14418ce66fb2836e02928485a204c0bf97f19
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev-dev_255.2-4deepin11_amd64.deb
+    digest: 248c864cdbddc655b53eaf7a8b3f930d888daf62b279da8506715fbed6e1129f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin6_amd64.deb
-    digest: 33a4c4b97e84007a18e94a6d0a860a493780cfba28d2f27b416931d8aa6979d6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin11_amd64.deb
+    digest: c7acf7afccba7ded43d8cbd42971a6277a597e1dc1190726cf38667369acad35
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libudfread/libudfread-dev_1.1.2-1_amd64.deb
     digest: 69a6b660d4789ab05cc3179db19a397b3d0f08b1de27a13462189a2fdb3af52a
@@ -1491,6 +1533,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb
     digest: 0d55ab9b5634a7b635ebe263526719f3c5c925d847c0f4cb927bc61584cf269b
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xavs2/libxavs2-13_1.4.1-1+dde_amd64.deb
+    digest: 09d132f43d700ef33f16c03354ae02d28a79755e92d3701f8e5bf15df0fa4ff1
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxaw/libxaw7_1.0.16-1_amd64.deb
     digest: 850216a2e3d4167d556be789f8d689fb149da9431ed747a3b189efeae83a06db
@@ -1714,17 +1759,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_amd64.deb
     digest: 2ea949de45dfe27832a6e7816a03103dae4ed45ba2b380669de5d5c89c361cc5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi-common_0.2.35-18_all.deb
-    digest: 1fc738c696936a298eab3f5a6061ae0189078abddbdf7ef3da2b39537d47aa85
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi-common_0.2.43-2deepin1_all.deb
+    digest: 8c4f70100c1fcb2755b08644f2326f0c42cf037e89c22cb69e4d0dd0798cae8f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi0_0.2.35-18_amd64.deb
-    digest: ccd6ac9289590f2fe84adb7cbe5f4aa0b6da77a316dc818c3244488daf098f48
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi0_0.2.43-2deepin1_amd64.deb
+    digest: da30868c3032f3dfb1f028b73f0613b781c331741fbba8938f9d1a52dbbb1677
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
     digest: 68fe4a526d73dd2ff6b75c593a5a4059486d1ec2535ec5e42cc52057a52744d2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_23.01.01.23_amd64.deb
-    digest: 910b0e2a76285993e3286050592628ec4c7286a4e7d39e438c3f89019db69a30
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_amd64.deb
+    digest: 46774d4ce9af0864f44fd0aed7cac874abe926c2ecda9845657acd3e68d1fe66
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_amd64.deb
     digest: d184d5fd7e340055beee8115e1f28663e539c024ede10773ac03f4ca3f86e343
@@ -1738,8 +1783,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/media-types/media-types_4.0.0_all.deb
     digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin1_amd64.deb
-    digest: 348ed9be3dcdf49e393c4a6071c60fb6c7d1f133db1bdf3a9843ab60828524fd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_amd64.deb
+    digest: 9f832c60e3739ceecc42e8d2609e6b0304060479a11d8a4703396b52081e7073
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
@@ -1750,8 +1795,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_amd64.deb
-    digest: 752849bcf3692f005746425ed4307477b665ce980135c7815538a2053e4cbfdf
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.3.3-1_amd64.deb
+    digest: c67aae5d49b31463ae5dd06443a83de69a926bc4b8090c875c25c34f4bec5f17
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/patch/patch_2.7.6-7_amd64.deb
     digest: 4bf340095bbde164d3ca33360e3b9d89a2f92bb1912cf2b4fb21a266c2ca250c
@@ -1780,11 +1825,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
     digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.4-0deepin1_amd64.deb
-    digest: ad3ff722bfadedaeea33599b5ee43e88f7cb0c3a5f9185348058d0ddb7c9830e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_amd64.deb
+    digest: 052de179f77f52e03dc62849e569130457275528003f3c66b1633aa46750a995
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.4-0deepin1_amd64.deb
-    digest: 5cf3eca309d9562d2c4b3102dc4fe89db6f670e634066d70f1d3c0af2843c852
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_amd64.deb
+    digest: a0ffedb8e24dfed01e29acc8a207b6e90d40a0b1b1ba39dc5c9c2c51ec7da796
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_amd64.deb
     digest: 3e3840ef15b198763d57c130ef9675a46fbdf534f2d5d721f8ddf91b6d743c1c
@@ -1792,17 +1837,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
     digest: 1ddd2f46a8e6b858e589bb011fcafb498ea673c78dd248283284b8a188cf996d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qemu/qemu-user-static_8.2.0+ds-1deepin12_amd64.deb
-    digest: 78772fd49d20c851ba18a744d0002680fb04dd33aac09c7a24a9e17502f9e05c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qemu/qemu-user-static_8.2.0+ds-1deepin15_amd64.deb
+    digest: a8e9ed497c034b25e1495a55c0bd81d275285e69db6955afc6d2c5dc7397fa20
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qemu/qemu-user_8.2.0+ds-1deepin12_amd64.deb
-    digest: a19fadc67b5de3c214ff2e4b77668a3006ba6e5dd2fc68cc08775248e31b70ce
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qemu/qemu-user_8.2.0+ds-1deepin15_amd64.deb
+    digest: 6f48417c4d65758f31385f5f5f56e3b58e3b366b3a35565a7ddb21a40067c858
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 2bd4061502b590e7e78fd5cfe089eb7e7fb173a15fed2ced98b50737549b8208
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 32c3245be7c5c0a778f7d6923c6d0f244fa4a297923d96d0583742477e61a540
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 17025348f2c9c6a1dd0742d8559771261dd4d297c9e3fc856ae8ba91a0ddb6bd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: c7bee095c8c3d51a32db1369e90aad0c63339217557b13e494c1ffec0a962abc
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 359f5fd7d83789deee753300437ea35ef2004a4ac03c5367249246addcafc210
@@ -1810,14 +1855,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_amd64.deb
     digest: dcef2b6339bb7f19c33a710f6817b5f0512824a6139ac038a1626f766c2d3b91
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 216615817367297df6cf55a42109f53ecedebdf973ad3ee5aca0a8335774c65a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 8b33f401a988b6afda0ffd807fcbdad2a4ed487aa3d81e66e62d499b1b7a4510
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 655b85be8e6045818776113a226aa32bd3b5aee2edd6db07ad86ea65e565b490
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 30382213970c6d9ef9d09b54dd5d3f6088e7e740382edaa457fa2915e8e527c1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 3fcdda184d430545018216f81c03df54de1f1a07d096cc6597b94e89d407441f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 5f61b34f7a74b35588afcdd2b362223b8bbb4696d29ae217b087b480158c3bf0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
     digest: b9e766a60ff54dc40cdd1307aead4f3c2c1997388e21fe36ec37650bcf650384
@@ -1831,8 +1876,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_amd64.deb
     digest: e49d551b49772f35ea9a4c524e58b523dea5c665b6ad96383da54a4ee9c7058d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 5264d118de60afa8f15122126da05a7663ed8cfe0b592bd9de18bf290f26d92b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 1e7728aaa16cb4ce8b9baad38f9dba7d047b54a87d3d3c130b3f76bb54ea4212
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_amd64.deb
     digest: 0acef551ad9074060268eabb8d0b2b4703b005b00672a23406346e19d7346de7

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     movie for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -95,25 +95,25 @@ sources:
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-event-log/deepin-event-log-daemon_2.1.2-1_loong64.deb
-    digest: 8452e39ca64a078107da91176eaac753155634b8716e0c99bb8c5ddcf733c4d3
+    digest: 8f1df92485304b3647da45199e99ee8f5cdf9417f37f7de620b7caa2d83489f4
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-event-log/deepin-event-log_2.1.2-1_loong64.deb
-    digest: 4ae92541b74704aee582e41c08cfa464a9e2f86ba7fd40f590425fa8c1af6967
+    digest: 7761bdc5732d47d3154ac4101e0d66b78d454a4c34404cce57a5761ad85f7fd0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
     digest: eab43bf5b5365d2839d6c319aa489eb239a581d8fadc3132920645bf20948a70
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
-    digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
+    digest: 8b3ec535c58fd4041effcff798c688ab1f4a36b6c2ac5989412020686c7607f7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin3_loong64.deb
-    digest: eea7a8587865789ec9f40ae9c3e5310f82a5c8c295b27d65e91627c86c107951
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin4_loong64.deb
+    digest: ed2c4a87410d3beea4622bbe835dab07b458a8e286be591ca34e97f2a6f6d730
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.14.2-6_loong64.deb
-    digest: 17c510572e0a51ecc5a4eba486a1cfcb55d2ac297c84f35bc7c58cbc31e6471b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_loong64.deb
+    digest: 06fd1e3b51d4e56571e9e974fd7936aa7010220f954b9a78b239b42bbf6e94fc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.14.2-6_loong64.deb
-    digest: 85fed3d569a4fc895efd890e842e276016aa92848ddc3419c6fdaabc02280c7f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_loong64.deb
+    digest: 383b6417f02a2850dc8dc08613ba4f188f63943deef4f707fb03b50e34627c30
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
@@ -163,8 +163,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/i/ibus/gir1.2-ibus-1.0_1.5.29~rc1-1_loong64.deb
     digest: fd5fbecb1c6697912a8cf691ed1a45f860b5ab5f0f1f5b8cf5d27800889f6575
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/icu-devtools_74.2-1deepin1_loong64.deb
-    digest: bd0810980b18f056dfba145cf242ad53070af276f89afe1891fa8284bf5c77fc
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/icu-devtools_74.2-1deepin4_loong64.deb
+    digest: 29bc31d34206b2ad29fa35e68acc54adc4ac8b94d19ad03e1ba96c8cb0cf0cdd
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/i/iso-codes/iso-codes_4.16.0-1_all.deb
     digest: acd8d976f1a757da000d9ea9405fdf80194a6275fc93fc472e1df1dfa5b301a5
@@ -172,8 +172,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/abseil/libabsl20220623_20220623.1-3_loong64.deb
     digest: 7b3e14e54d88c90cfd4ff6d206361aa991c6a14ea90924d901784f7be7c99445
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-1_loong64.deb
-    digest: 6a5d883c7ca1fb96e88290e5f80f2310b83e190d02133676ef19fcce44b5fc39
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-3_loong64.deb
+    digest: 7388773fe6ec2b0439e0383023e06d26dee49dc9a2adc9b0969c3e24a51f09e7
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/aom/libaom3_3.9.1-1_loong64.deb
     digest: 22bc30a8ead069539d5cad4100b0141198b3871fdcd5253189c5bfcffd14cced
@@ -205,8 +205,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libatomic1_13.2.0-3deepin4_loong64.deb
     digest: 1ed85dc548b54f63267a5fb8c81b8d90638df81de8bcca7448e087f994b31bc5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/attr/libattr1_2.5.1-1_loong64.deb
-    digest: 405e34b981984b1e6d04b5093fdaa36013459af4687c62c3a7dbdd0b42766ecb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/attr/libattr1_2.5.1-4_loong64.deb
+    digest: f9965bc423eee241336a5edf4851ebe8058fd76c5ef227d59d57a4e7accd55bf
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/avahi/libavahi-client3_0.8-5_loong64.deb
     digest: 9ccbd93fc9d06c9ddf2b4fa7a399f4695576f80624ce1742ecce86de1b31006e
@@ -220,35 +220,35 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/liba/libavc1394/libavc1394-0_0.5.4-5_loong64.deb
     digest: 1ed606d4b28e3d3e128353bffe960abe6a0abc3bc32198e8712a2aeff3fea287
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec-dev_6.1.1-2deepin0_loong64.deb
-    digest: be33b7eab08ea435c5858d47956aada390c573d31b69a5915894ce2bcc9a4086
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec-dev_6.1.1-2deepin5_loong64.deb
+    digest: a05c8f27ea5c612af73074fa38cd2a6d57633774439fd9aa3c7cc46b30cc4a0f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin0_loong64.deb
-    digest: 543e50cdead7c87bf1894f52be1b388336ee850095338db882d96f12b2c8ad44
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin5_loong64.deb
+    digest: 07f5f5b252e647f447c10dbc496e502e6c6e3e791f07a7ffc6bf1e11c30b1ca5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice-dev_6.1.1-2deepin0_loong64.deb
-    digest: ba1cc6b9096afb4ece4140624be5a1ceb8e9cadcbbc92792a4beaad682c29ed5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice-dev_6.1.1-2deepin5_loong64.deb
+    digest: 76c7f6a5d4179751890fd909458ff789558b4b155d526a6ab129275e311d1e7b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin0_loong64.deb
-    digest: ee9003a3a1ffa9bb998727e6090b1686fccf1708c0b98390e57a4a5aa1ce24e8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin5_loong64.deb
+    digest: 8b1a913fc29d5e761f9c6e81567357d7e283775782d873f966c0f0f61853cfcf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter-dev_6.1.1-2deepin0_loong64.deb
-    digest: 7abf4fcfb286d5549a66819705c6607fe74a3841d7fc46758d6c162ad8ed37ca
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter-dev_6.1.1-2deepin5_loong64.deb
+    digest: 102af47db2525afcabcc826af81b27fc329b251d59d9482baa87774674e7ce12
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin0_loong64.deb
-    digest: 8e8d2728c6445862f54cabd52a37d0236d9dfb999ff92a893fa2da685bc4e051
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin5_loong64.deb
+    digest: eeee76955e31ad70c90d0d9755c09615a160374df7434fabae703d4308b3ffcb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat-dev_6.1.1-2deepin0_loong64.deb
-    digest: 5fb5ae5404150c1d36ab0edb468d870e7f2f002432a8dc770b0ec1579987aad8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat-dev_6.1.1-2deepin5_loong64.deb
+    digest: 9c84a81ae426b7e618e3db6e4ceda6f1f2be466eaf8447f2b5f9ceaf502fcdbd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin0_loong64.deb
-    digest: d0c1b238e2fa1703331cacbbe76d2fcc68cb5b8c697954b955bb33c9479c7f92
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin5_loong64.deb
+    digest: 8b045a2001e0e3e10adfcbbc4a6eee767a1af5fec93c82543eea497141d3276d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil-dev_6.1.1-2deepin0_loong64.deb
-    digest: 7602c4d70d8ac3adf7d58770198d38378467ac9e4ea51c53002439b0ddb8ed4c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil-dev_6.1.1-2deepin5_loong64.deb
+    digest: c3864e737e7a2165253e4f0383447c43ada9f86ad18619ee7984b6c428c0e7ad
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin0_loong64.deb
-    digest: bb0f82a4c1e3c890b82eb3b0333ad5c23ab91eb92b4b603aedf50693642b631d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin5_loong64.deb
+    digest: 9dffa490932e29633146b2e971046d4dd38e83e9d72ee9e01202cf529346a232
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
     digest: 43c9bedf808d5c2b85351f73dab25e81c5674c499c293be875ac5250c4b8cca0
@@ -316,8 +316,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap2/libcap2_2.66-5_loong64.deb
     digest: d4cbe29713f415bd8679e79b2d4558a790c0749b1ee8f829ffa77cfc29695377
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/capstone/libcapstone4_4.0.2-3-deepin1_loong64.deb
-    digest: 5c67f7ba294a3e61363acabe2a65227be1e4efc0b31eb2fb3c529fb2dff3e922
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/capstone/libcapstone5_5.0.3-1_loong64.deb
+    digest: 9fc4dad13f7d8cd45e037e5f4bbc7aaf446e76cb583ef9fcab6c5618c4e5d6c9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcdio-paranoia/libcdio-cdda-dev_10.2+2.0.0-deepin1_loong64.deb
     digest: 2b64241acc99889ffd2177777de8565e371aed456c4d99bbf3ccb07799da989e
@@ -340,8 +340,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_loong64.deb
     digest: 23c1612c4842c5ea3315b25e15d859301a5f925f439fc377b3b989d1473d142c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cjson/libcjson1_1.7.15-1_loong64.deb
-    digest: a705b9b61cea069c289dde00f333e9ba88370aa2d770c2bda04c38f53f483cf0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cjson/libcjson1_1.7.18-3_loong64.deb
+    digest: 441206537dac908379f2e3512056745933ab830aadeccb3185a7349a3679f02a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_loong64.deb
     digest: 8a7e85de84804dd73ec433de1ad3fb61905c8c8a943365620cea7cedd44a6967
@@ -367,23 +367,29 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf0_2.41-6deepin7_loong64.deb
     digest: a594bca37501a18b322a46118883ed18bd99ef7d31eb5e5220a2d7c1adc4935d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_loong64.deb
-    digest: a6bcb173e61ad5273becf725933fff6bb10cfbe068d4a9a23af53b542b47cb78
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_loong64.deb
+    digest: 7452bfb8da2bf510f5095db334f7730c914a087571d313172392b1a2b12b986e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin1_loong64.deb
-    digest: f81c3066868743ee4c5cbf09088c1b7f8dfc38832b358012ebbeab92a1428051
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin2_loong64.deb
+    digest: 2215b8b403b997e7ce667895f92cafeb22ceafcec9dd468c6583aa2dbe83393c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_loong64.deb
-    digest: 51248257d36d6528d3cf0cd7f038c6da2cf929267029b18a13ecdde2213cfb25
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_loong64.deb
+    digest: 07c0d38b655ad9e1dc4d93ca4a858255adb25dc7b131ae1509781b83f1d2d133
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_loong64.deb
-    digest: 3c9ca124f4de35b207d02b042d1d25bacff0d4a642e0c34ace340d4667e7c037
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_loong64.deb
+    digest: 054a65c1507942291091fe19cbb3ca046ab48e734b4e8a2a77939fa427a89363
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_loong64.deb
+    digest: 1e92b0e84256009fa0d4afa40bc765076fb97a45ab25e4f27b29a18a8b3445d6
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdatrie/libdatrie1_0.2.13-2_loong64.deb
     digest: 2babee650b0a341ed5e23cb131ae40d3c21ee46ecaad54fba79b764111628591
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dav1d/libdav1d6_1.2.1-2deepin1_loong64.deb
     digest: 2aee3841500c6021eafb9bd0f6231ff1e814e73376d44b4a01d66b3cb6a1e358
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/davs2/libdavs2-16_1.7.1-1+dde_loong64.deb
+    digest: b5eb7f8d4bca07748ca52452a01a09aeb89013c49a6c8f72227aa4cf37f43195
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_loong64.deb
     digest: 976e0ae132630258702d76bc235bec36ea5820e506bc110585aee657fb487472
@@ -412,8 +418,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
     digest: 1cb1deef108f4163f884f564e9fcfd429adc315e9509c30ff3bcf936824ac543
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin3_all.deb
-    digest: 71989ccb16cfcc04aa5a86f06e4dff837a4fa755d04d17d5f0cf329fc09dda04
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
+    digest: 569373a35267f9cf2e8d0ee6d42c9047f50fa2174a0ac72fa77f494a0f0a9d1b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_loong64.deb
     digest: a26ef022dd15349da87ea50e9a8fa2799ab3f5287c93075bbf6c229c2eafd969
@@ -433,35 +439,38 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm2_2.4.123-1_loong64.deb
     digest: 9b28e3fcb6cff61e26352d3b426fe25b0c19961120d499fd5cb05f5177b411bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.25_loong64.deb
-    digest: 6c61509dbfa71c1bef66b405f76a18e4f68e62aed4d55626fb2fd2e2ac87c8cd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_loong64.deb
+    digest: 46b262c7a9142265d96ed03c896080b6be4931cd96881ee36d450593c1b23185
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.25_loong64.deb
-    digest: d637527e884ee0fdcf6683013c932de3230c7c357afc87a4d2e31e0250c76d84
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.38_loong64.deb
+    digest: 2a051f11ab21c3eb73382db4cb96c892e5c25be60b9ec7b1c436645df09237c4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_loong64.deb
-    digest: 7a16c5c6e9f9002a14350ca92bcd645a7b2fa0f1dc2fdf0ccece81628e65e530
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_loong64.deb
+    digest: 5c820da0d98e49b0cafcce328abc7b20f79a57fe8e9955eab7c86232ca4d217c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.25_loong64.deb
-    digest: 4ae1e9b1b54e2c23bcb5d1bbe82d9e8914d86c8f6bd849e564a72cf0401d6e47
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.38_loong64.deb
+    digest: 204e21dfba6edbcf36a22ffeb1317cfabed65d11eedb04cd53840dca04ba72ef
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.2_loong64.deb
-    digest: faecf60fdd232fce51578eee0380bfebfccc84cf7c00ae3d41af9a43572f2c0d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_loong64.deb
+    digest: 85431680f43cb35350110f025ab764f817a87ef8b87f8aaf1221cf92324a22d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.2_loong64.deb
-    digest: 9e03504ae093c9be1bec37e76dd97ef78bf4fe519320828ebb41096cebe47649
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.4_loong64.deb
+    digest: 5dd93e358d83fad8b4f44962845e07554f43f36f252c886f694cf165ad67a3d2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_loong64.deb
-    digest: 55fe88c9f524afdbbb25ca361b1bb5d508848d94c9fcf8add1f9559ae717812a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_loong64.deb
+    digest: 17e369876960256cc74b9a89b79f507944aa3f1965f443fc7d6fdbebafb60ea6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.25_loong64.deb
-    digest: 81a053ed14e32a37af815860e1a3f77c06c00956dbe840040b25098335b4e1de
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.38_loong64.deb
+    digest: 18fdea046e17f28b1ace921d4c27f8eeed9a28841c46824138307c9f47722cbd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_loong64.deb
-    digest: a33416dbd875dda49e387dce675dfbfe364eef8c0237ed869714535deb97987d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_loong64.deb
+    digest: 43b505fd21a6fe0c79ecd5c8140b1619d20bcd243d4d4576fb2c84c1644b85c1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.5_loong64.deb
-    digest: 7e6f8fa112dcfc39ddd784f68cb20629ac9fdf8a014035c4233fea7d3afeafc1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.18_loong64.deb
+    digest: fef371d4b3e03bf0e9ceb368698a63ac51243fe823d5d7bc19f1654836e5d81a
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/duktape/libduktape207_2.7.0-2_loong64.deb
+    digest: c46919dfca686178998927311123320eca3c995576736b5b4a0174f567289f13
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdvdnav/libdvdnav-dev_6.1.1-1_loong64.deb
     digest: 1dd6c1f08489f7514a5dfe5e523e8a72a6e3053a581d5117c66ef7169659925e
@@ -478,14 +487,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libedit/libedit2_3.1-20230828-1_loong64.deb
     digest: 851c5523af03e9dc081aa14afbeade7eeb1a21de5597226f13e0dcbed4a6ade7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl-dev_1.7.0-1_loong64.deb
-    digest: 06868926caed52eb854563d39ccbbf713184d8286dd39c1c74eb44c761db3bcc
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl-dev_1.7.0-1deepin1_loong64.deb
+    digest: 7c83088a79bf35093066048f4d6aacf97172ed76451efacf9620bc869ec66750
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin1_loong64.deb
-    digest: 3195c98434e274eb39ccd91f9afb6bed2c2ff6d3122d69d2e6bad9c1660efc4c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_loong64.deb
+    digest: 7877f5ac8d6ca3d585de64047278d3f6983e9213b31a3e2d4d8b03218474f4da
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1_loong64.deb
-    digest: bbc7f8773ad9b2cfa4a27a26d6ad4c276eada2db9b680d54bdf7eb59ee9e5012
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_loong64.deb
+    digest: e20c3e83c2e1e4d5787efcc5036312ebedbc4c0fedf0c2578ebb53041042e2e3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/e/elfutils/libelf1_0.191-1deepin2_loong64.deb
     digest: 16e47795eed490234214777685afc5c411a8ad0fdaf3508469e3105fb2b364df
@@ -496,11 +505,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_loong64.deb
     digest: f2f047f2363dda33826f748756c5b1c8a2bf809c981a66509876eb150583b278
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.5.0-2_loong64.deb
-    digest: 0e5c956c6ba2967eb8e61479c2bf56189c8bee0077ded44015b9240ab11ae4f6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.7.1-1_loong64.deb
+    digest: b766ee38f67bcbe9afec078d8fb2f5fb273e35b506a1d1a3c135c5ff4482121c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.5.0-2_loong64.deb
-    digest: 845317fb7d0fdc029f3aa98c870826391b9bdb530c6aee296fd1671ed5dd8429
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.7.1-1_loong64.deb
+    digest: 4b842b02c3c84ff64ef932b999fdc20e776a4f410cae4c065deed16e9ea5e99a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
     digest: 864ef36cd80bc0a9fadbdafca5a5ef05ff92458f945bc1c20753d7635d8f17b7
@@ -523,14 +532,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin0+rb1_loong64.deb
     digest: afa51b193209a8d67f9f610e43bc9dffadd90f61fd77112ca1f0cfb87a7bd269
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.14.2-6_loong64.deb
-    digest: 353ec48905f9c8553b1e46a60124deb598ff3a1c07ca6a0aff62b0c5ba5bae77
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_loong64.deb
+    digest: ae8860a596b6ef0831f0c600efca87de921427e30b2b706c6ba682ddbaa624b1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1-dev_2.14.2-6_loong64.deb
-    digest: fb7dc50d5c6f70b425b95cad47a9b57633b41fb814d06fb42c9a9022c2bf0ee2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1-dev_2.15.0-2.3deepin1_loong64.deb
+    digest: 2dab50fc7571096b965106cc36feaeeecfef3eb1d766a3bfc7456d8d559670d4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.14.2-6_loong64.deb
-    digest: db05b74e370f34d39ff896e5070fee3351a4cb938e86bc6dc852c624cc9534cb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_loong64.deb
+    digest: e4faee509dbabd22ea70b8d59aedef53701693356ca681d32eeb855026312c03
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_loong64.deb
     digest: 36450772f287a243ed0ff6c3b5e491021c7d63f6f68a9e71711fbb6e5884c868
@@ -547,11 +556,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fribidi/libfribidi0_1.0.8-2_loong64.deb
     digest: 16a5f333df8d58b5b343a3ae40067a9b1132eb7f3cdf1517b8cb88da6d5b0463
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm-dev_24.3.0-1deepin1_loong64.deb
-    digest: f0d931b4ce08a53f212c2c47088141f564b30f7ccb022061bdd8de6870d7450f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm-dev_24.3.0-1deepin4_loong64.deb
+    digest: 17a3903b5131c272c0ce55f4627461e5b647a5f439ea5e12469e8a85b6fe546c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin1_loong64.deb
-    digest: 10e0a5e6a07c0b34a622d1464bf739af4e4be459be5cb6b8589673d5ad887413
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_loong64.deb
+    digest: cc93c2d61fc3c6a93ba49cd4c6fac1caa03a6c330dc1900a43bbe4e747fc7eda
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_loong64.deb
     digest: 05d11e942b30ee6974be843ef2b8539426f3891c20bceb2e5bfc823e4c25b673
@@ -577,26 +586,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_loong64.deb
     digest: 02f892b6d38643410cd753637657b9803eb718268927eec5232e68045e81d13c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1_loong64.deb
-    digest: 34cc7650a8d538e59d44560580ff7d0819b2607877299a65585cb516d4136c03
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_loong64.deb
+    digest: 37a693f96d02d97be01c45d972836cbaaac0b9a5043174a04b2e2eeff251b30d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin1_loong64.deb
-    digest: f52657846cf6380d17182e22971638b9d1e617dd504dd345844f82cc34039101
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_loong64.deb
+    digest: 45cb2d6de8f6e7c898ff76bdbd5255d630d1df174a8cd028d28dcf441bca009e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1_loong64.deb
-    digest: 623a88c159a1e9eafc6316e91d3c55179c692fa950ecdd06f1955144813eb6b6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_loong64.deb
+    digest: b6dc7a60ae6e3530a6caa3e45d5869603685c43ac8937535062fae0b5c8863ca
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin1_loong64.deb
-    digest: 8cdbd33fdcfe76829fde63f112026b1e9f6b08544c2a0d13bd37b7b059c37771
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_loong64.deb
+    digest: 0fbe33c65fcd9f8d498846fc628c0fd65f86f0e8664618b83d325bad58b56a10
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles-dev_1.7.0-1_loong64.deb
-    digest: 6fe190013e056bb894aa6f0f4c6944bc49b0ce6a18b1b7187ce11c370a9fc2dc
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles-dev_1.7.0-1deepin1_loong64.deb
+    digest: 0c500aaa85096aeb3b3d5bc45d9b6413937834088fde2f07bde0ed20faa4d86a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles1_1.7.0-1_loong64.deb
-    digest: 50ad7aea0b7d7e8faa96153ef0b210b1e5b244b87c989b4a0780370d55cb0246
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles1_1.7.0-1deepin1_loong64.deb
+    digest: 76258a1bb7c5c5ec8b9f0bb24794d13a8c74d2eedb256a8ced5dce2af0de25e1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles2_1.7.0-1_loong64.deb
-    digest: f19e5dc54a62c2f5d7d9d51b522a2d9bcedf709903c8ef0dae2a9ec4f8da93c4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgles2_1.7.0-1deepin1_loong64.deb
+    digest: 04d16d58160ee54f0f7bba19718841117c83eba161a204dda02f806f1b053837
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_loong64.deb
     digest: 796a8a4bfcc14d204bc23914f524a0dcb3b0545611060b3056547eb281e277f4
@@ -613,17 +622,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_loong64.deb
     digest: 1828aa1e6fe842d0713e1ae545f874d2335ab0c683638eb5bb594dd76037cd87
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1_loong64.deb
-    digest: 4ac20b2ddbc5d3985d95befa3db331ebcf6bf9d8b9c13df462018e2e6fd91218
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_loong64.deb
+    digest: b3763b7b1910d2692fe39f0b76195b639acf92ea656d4ff61da867393422251f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1_loong64.deb
-    digest: bdb1eb7fd4e391c38fc5a21da29b1569afb19bf9594e46fef10311bd4d4f0441
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_loong64.deb
+    digest: 260b85824035f054f7e25e2b142ee5397c28953f77f463276203b0e5ed8d9bde
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin1_loong64.deb
-    digest: a54db44910df509a4b4b03466fae1d5118f27264cf0789dd638f04b2bbf65245
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_loong64.deb
+    digest: b219b07aeb0e70c94dcf3d2161fdbe5478a745b9bf8b660ef6cb8155f1e81e09
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1_loong64.deb
-    digest: 51e7ebb3d6b78cc5f420d864eb898e91a1ab386fea5c51548439231aa66d8232
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_loong64.deb
+    digest: 8b29582e04b7987e1b45b1e7229eb4b772bf6d8ba18b5499b22144108aa2b70a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_loong64.deb
     digest: 03512d70fb50bc97266e9f14dd56fc5577d455aed40072f0f2794056bdd6ac28
@@ -639,6 +648,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgpg-error/libgpg-error0_1.47-3_loong64.deb
     digest: 432b4819ad1edb46e6d8116596212dbc3a82d0d34c93c3574ded8db352188c8c
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-gpuinfo/libgpuinfo_0.0.10_loong64.deb
+    digest: 1360076b1b585d00716a329616981ad2860121379ec8957d02347e165ebceeb7
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_loong64.deb
     digest: 3fc95b46c6dc87a3991386255c381d00c68a6ae6bfb4390ccb05f8cc61949331
@@ -718,11 +730,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libice/libice6_1.0.10-1_loong64.deb
     digest: 71f07175fac63f8a51f001299a9329a38c4320df6b46e6bdda20768aa90a3456
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu-dev_74.2-1deepin1_loong64.deb
-    digest: 7d1b947d76748b16c18b40ddf9b6810281e7e8690d290a43a445b811f3936c10
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu-dev_74.2-1deepin4_loong64.deb
+    digest: 90ca2b00fbf2a39a59bc0f9f992eca99951ef6c0ab632c28c2ea9abb8849c16a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin1_loong64.deb
-    digest: 2ed8252419a84421d4df376a90e03cc9eb4d1a6d4ec4120a64ab4935f80e3ba8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin4_loong64.deb
+    digest: d60c34f7df7c6c7b8b950d3b2996bd1dda6ea510d77de2869bd13c614a1fe00a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libidn2/libidn2-0_2.3.2-2_loong64.deb
     digest: b235fca3fd81c2e6918d54b8d71f79757d6b818cf897fde7cb3826dc23ce85b3
@@ -789,6 +801,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lcms2/liblcms2-dev_2.14-2_loong64.deb
     digest: c3984f83fb1014fdc5eeaf79691e937c3c78f6de2ac26a689b3bdda9ebd6b8e2
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_loong64.deb
+    digest: 07c9253e9b743f0bc0f696c091a84d08a18f172e600311e0aadf508c494659a5
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_loong64.deb
     digest: c0a9c5a24ac81fd6e5641d36d47600df17b732fe3a5c024753da8e32679a1447
@@ -889,6 +904,18 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nettle/libnettle8_3.7.3-1_loong64.deb
     digest: b49e593029d91c73f2240ffb5f129e3a47f613aadbf8ab5f50d592b2a5abdc98
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_loong64.deb
+    digest: 73c2009828b2dbd6d42c3d6f2c48f38b6c0ba6887c71bf4bf10e997d4072ca08
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nghttp3/libnghttp3-9_1.4.0-1_loong64.deb
+    digest: 2f4801803d9f124c23da8511728b5ef3c46729dce1f3a546bc8a7fa9c2857cdc
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ngtcp2/libngtcp2-16_1.6.0-1_loong64.deb
+    digest: 59a844a4d9b530458f137a4ad44d01fb7ab1a92a693870fbea4dc788e207772b
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.6.0-1_loong64.deb
+    digest: 87540ce4f8f6865f114b3153ebcb0f623a912010d3cf1e361714e6489260c9ca
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_loong64.deb
     digest: b8ccd5bf943ded55cccdc92d59c8abb35a1fb65fc3425ebe35670d37b7bdad6f
   - kind: file
@@ -907,11 +934,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openal-soft/libopenal1_1.19.1-2_loong64.deb
     digest: 7ac233c2f743368fa3db292a6c04a824dbf1bc4817cb40f49fd457b96d51f33e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_loong64.deb
-    digest: 72259f4ed0b1127c554e3747b8763fc18659dc5178fc2fe32ada313357c1802a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_loong64.deb
+    digest: cd4ffaeb85402fdee4cd618e5d95b20857b2eb83f25d6109f8026b714b4af470
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1_loong64.deb
-    digest: c912f8a5180cda07f485be9334b8ca0c1bf779bc2449ec5fa08c347e5f18a132
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_loong64.deb
+    digest: 5ce97ab48242d9a6440c70f71408b84db1d2417a4e61007e08dfc3f748d1c4c9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openjpeg2/libopenjp2-7_2.5.0-2_loong64.deb
     digest: 575da3427fe1632f4dde973fd2cf3b4a15dac1a77d612bedebeae18d1968095e
@@ -970,11 +997,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_loong64.deb
     digest: 9b68dc19b458a678ae21f5eec1f27f011f0c8da502cf3cf234b5cf4f8e2b093d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin10_loong64.deb
-    digest: 03777c6ea09c72bcda9e69ee4cbb930d6d57703966f7b120ab29109e323febc2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin15_loong64.deb
+    digest: d3229500065d087f0eeb7a40dcd45e6bd793e1667694d56c329ff39870b86541
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-dev_1.2.5-1deepin10_loong64.deb
-    digest: 24f06ce5a66041d5e74e1c1117ee8eea9d0bd83e05dc96bea93a38092d6e4bbe
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-dev_1.2.5-1deepin15_loong64.deb
+    digest: 5e80f2e032c1991133c12cb20a21082bc199df608141f4f649c65cc5f3a6acb1
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pixman/libpixman-1-0_0.42.2-1_loong64.deb
     digest: 0b76c37a85a00b26233f17a3cc0e4459649ba286528614f121767c9b82c4d3a7
@@ -997,14 +1024,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pocketsphinx/libpocketsphinx3_0.8+5prealpha+1-13_loong64.deb
     digest: e8f253a5d32a8a0872ed67fc096d933401d73e9518d6c104d1c99c278bd9ff74
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc-dev_6.1.1-2deepin0_loong64.deb
-    digest: 4bfb37b6fe9e31224a0eed21f4c43e712b9ce24e38df3335be50b4368fc6de60
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc-dev_6.1.1-2deepin5_loong64.deb
+    digest: 8485e48986ec91a18a4a50e5a36467fa1866a72250c11ae6606ef5698c72a2a6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin0_loong64.deb
-    digest: bb3d14036e696499a14e7f3f0bef0569cc8a95e67f7fce254009ae60f9775f79
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin5_loong64.deb
+    digest: 6300c6ae6f8bcd6d0bef4a0d2007561ee359c7c23f9867a9cbfbcdb3a09c0292
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_loong64.deb
-    digest: 8c5d37ea50aeb08f936ee1e57b5f295cbc5d76690d92c265b26fbf0e14e687c6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_loong64.deb
+    digest: 450c63cece1053b61ad1db303e20cf3008cd130f59907df2610dee985a1ac250
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_loong64.deb
+    digest: 48076d0b45bdee001ab7b435296ab05853ab64402092af005e07437dcc838640
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_loong64.deb
     digest: 9d68b88d2e9de4c313b75ec6ebd8df51105856bf8998470dc7faf770308ddc40
@@ -1021,23 +1051,23 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_loong64.deb
     digest: fccfbd0ff96d62aa2476f942b4e819b2bdce28f714ea360e036da7a0b3732597
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.4-0deepin1_loong64.deb
-    digest: 759e427492a789316db477eb515bcf7c94f688f88e5ed2cbb5da033a06b33966
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_loong64.deb
+    digest: 1d472fc15c2ee3bd55b69219903a7ff8fb6a5b880cfc1f2506c8ebb459f9b0f7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.4-0deepin1_loong64.deb
-    digest: 86f63bfe267ae688785e96f5671516a53846e3459ff9ca54a4896f83968990e7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_loong64.deb
+    digest: 86eda0624899d0be7965e8bf0b2189986b67daa8d280ff596e736b50bc1bc4e5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: 5f41ab472678cfac09bca24a1d116bebb94d93710e266d8821f7f044d4aeabc3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin10_loong64.deb
+    digest: 01379ff92666bfde1747846a28d55d11a8027c0be777f118e5ea2521e8ad10ef
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: df1fb644c6f18c557df389f7c8caccb8041cdbcbb3ba64cc4bdf5bd9dfcf95f3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 27f9e657d136a934f173a715d878d3d055b4f380e81fbabc76aacb44b6fc94c9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 05d37808475216a0a62fb277a78a21045f6a3371c9771eb614a38e175c67d861
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 1523b859d621d9a86bca84826591ec2ca94247e2529e9c3a407fba06593552fa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: b4bf3ee86fcbc0055e09cddc5cf75dadf7f2d92f2991207c6a0c591d9ddcf3cd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 51e1362bb514f7878aff724ed92035df7451ef96fe7de71c4452057340d8d867
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
     digest: eefebd3f3d07b0f7d2f89e0ba469128aba20e0a1093ee0cc1853c3ddbdfa8616
@@ -1045,8 +1075,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
     digest: 0cb93130f4822644f809425794909492760cee0cc6c3d5596883a07edfbf9993
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 6512d39f8b25de932f919e8c1c5f6819ca71277f4c8a2ce5590ae347b98ca552
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 0eb4ed0089c77f53f38c49e30098727c78489b0d390a2ced33cba5de167aa5f9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
     digest: f748a917685218c990c97766bd2e9cf73caea758ba095bde0c76aed5d8b2c14f
@@ -1057,17 +1087,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-multimedia/libqt6multimediawidgets6_6.8.0-0deepin_loong64.deb
     digest: 84bb00e7144d357bb9f52720eba503deadc3939f34cd4f1431d8abc6c9181194
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 32d4331abcf04409ac6526eb631f53c4d4d78e4c284441f6f22a468f17290dca
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 734dbb8e7e72a7e29fdcafa4d17f6dd1f2385c738b075858d68f3e7c06a8c8d9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: a3d00166167d5a06e1fbb75780ca2965eb064eee915591358584a7feef57968b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: ce9b72f2477ff977aa84f328fed1bb4f74f1eeb63487bce88634bd2ae819fcdc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 51d746486ddd8b214d7078de53fcc35701972f22cafd0248368176e06b80ea10
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 1756c764caeabe3b193dfd61c1d9f8f78e5cd8e63421c1c2e6c6c4d2adf00a20
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: c2cd48cbfdef345b85b35d08ada160aa696a1b23afe9f9a224ad2fd9ba7c17ec
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 6321e7ffab0c4908deb4c93b1ea695b9a8e001c3f15cdb1e83af3be2dec5d072
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 31feabbf3ad584c4c450c37b5abb61ee289e05b11bbf04533131075201387b35
@@ -1084,11 +1114,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-multimedia/libqt6spatialaudio6_6.8.0-0deepin_loong64.deb
     digest: 071bc2779dd4d67d41c836c3df87c7cf10e50ad7fa5aa8600422eeb345b85607
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: ac8528c19b56097b2476dce90edd35521971fab57e90fac1e44545866acf2e00
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 017f06d3ed3ed61c79b1305c5143cc23741d512d7e5bed5bb8afdf5409f9dd53
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 34291f35a8454f65214fa6ae65d31569edb74d581aed75bd502885f575e20915
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: f8f3e1362f96ce18bbf6ab415b4fca82bf4f057b122c26dc956f3f0bfbc3e571
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_loong64.deb
     digest: fc8cb023930b048f2caa531b913d991b4690a9f4692a9e4fbb423618ec67121b
@@ -1096,8 +1126,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_loong64.deb
     digest: 7a0239be93289e6b8d54806f5ffec75a9f4aea7cee0af219fc1932e64abde72e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 11eea51f1f01f37a4fecad877eaef15584bfd9792fa5cb6ed74bed8dce2119e2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 13e6c88915bb0c09c85a950bd41a150ecbab7b6bbac87d72900b3484e217055f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
     digest: a4651ca09a7927998b556155807a65a4b68d19a83f8a3a0907e4129f0ed983a3
@@ -1105,11 +1135,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_loong64.deb
     digest: 7637f2f08e271e14a5b05007e2fd18a8facc2c6fc3f29fe1ba5e2c5ea0d037c2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: d3aa28809160e26462914fc87cd6b4fcb84bb59c9a925d864811c0fc8ab4a1d1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 0904fa02b80b91fcce261f02f8aeeacbcb2e166edfc9fbb8e9804639c22e6a56
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 26a96679e3356a3214126b3f58b1c6a2cd448f955925733340fe6fc1627ca7b9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 529b35f3c63e834096085de61a2494f89aeb2103b184d5d8bf2e5035e60340aa
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_loong64.deb
     digest: bfc60cbd6ee84fd4a6ee2d1002c27389d58dd451f8ec8bfde0e74fc8dbcfbbf4
@@ -1132,6 +1162,9 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libr/librsvg/librsvg2-2_2.58.0+dfsg-1_loong64.deb
     digest: fd93daa92c7be19210c417596d4c9213d3c734eb2ccaa2de3244fb40b1deb1e9
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_loong64.deb
+    digest: 8809a7bd4cd047bccc1e7198bfb8e154716a647cc619ac7d49cbde13b7ebcb1b
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rubberband/librubberband-dev_2.0.0-2deepin0_loong64.deb
     digest: d874d27fd0020816fc344f91577626c9f27bbb82457b22a7f1f3ce1e006b629e
   - kind: file
@@ -1144,11 +1177,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsamplerate/libsamplerate0_0.2.2-1_loong64.deb
     digest: 923a9d2f3cf3cbd71aa95c2451e47021ba3c4b93789a8128b93b8df4f8090d82
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-2.0-0_2.30.11+dfsg-1_loong64.deb
-    digest: 7280e39f78429163ba7505a3bc674308f7a144463e0215e6c0da538f834869ec
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_loong64.deb
+    digest: 330cc540349e985f4837e68c0c021dede1939f25516cbbb1dc7016ca0595ce4f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-dev_2.30.11+dfsg-1_loong64.deb
-    digest: 091e6f9c7f3c32718d076e2a09a95895d23c4371a00a38b91cdab7735517aef4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_loong64.deb
+    digest: 5a7bd78f37915ec3255c7a90b6abff4e0ae332f3555ebcb3cf8fe78c6545de7d
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-2.0-0_2.32.4+dfsg-1_loong64.deb
+    digest: 16e9ec8a12d696494876d5ac369e13f07879fdd5bec2616de8eaab10804a9f30
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-dev_2.32.4+dfsg-1_loong64.deb
+    digest: 973f036b352c511853e781ffb068721ba79d4d4b2c298b8beed6ed0ac4df97d4
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_loong64.deb
     digest: 3560dfdbcf90fef6f1fe16715e1bc7543a4e84b8759c58f71db0d93054bb7d49
@@ -1225,11 +1264,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoxr/libsoxr0_0.1.3-4_loong64.deb
     digest: bb803883ea5a502ae59c3ee986680ce3612863406469d327009684d7377b27cc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-dev_1.2.5-1deepin10_loong64.deb
-    digest: d0b1ad2636e2cc25b86745abd3f13e2cb4c80a002c988f70d9fb7c6e9e406032
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-dev_1.2.5-1deepin15_loong64.deb
+    digest: 9f12af1e32ddc21c14b95a2f94dbfc2c40ee3750be0ed479742677de3bb80795
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin10_loong64.deb
-    digest: 15f0bbaa124781a3c4ee012bb0fb8b91d544c0043141181201c033554b913066
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin15_loong64.deb
+    digest: 121e4365dd28d2bf5f8a087ebd75cb090a49a66bf16b747c5e33cdd1faeaf3e0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_loong64.deb
     digest: 760ec85164e31b757b0e46274b5a1eafe5a6ce53ccd0e1c4c1d7e5338e93c31e
@@ -1255,11 +1294,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_loong64.deb
     digest: dea4a89cee5d7d70b6143ef55501595bfa963aee8777e0f1b10f46a78dc9e578
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_loong64.deb
-    digest: 55cc8ef205639767d2c5162b6424297d7866b3d77be3ec600b70ddf3345cd6d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-4_0.11.2-1_loong64.deb
+    digest: 88319c457cf55da790af61d2607fd89ebbce4e14ca4361f4d23461ad5fb41e75
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin1_loong64.deb
-    digest: 50a0de1226846d5adabf640c91d6fcd777d1feba9fd67e7c1cccf6013b62d0b8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_loong64.deb
+    digest: bb45ae77a9bd5170e8616a550c54e2c419435abce629ade62605dcf0aa544d11
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin2_loong64.deb
+    digest: 0ecb05782da1c411a407535eb0fe4a9118a0b635cf5577b496fc0698aa1f70fe
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_loong64.deb
     digest: d5528cf8ef1dcf19b1b3245d894851bbddc35132ef3fd22e8c399fd5af91a514
@@ -1270,20 +1312,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_loong64.deb
     digest: d402b79e3fbfa42586f89b0b86c376772ec033ff6252032e0ea7edb831a9bf2d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample-dev_6.1.1-2deepin0_loong64.deb
-    digest: cf508308ab2db7b6f381e0a201e51991c236be2b25ecba58ba3f2db3f827670f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample-dev_6.1.1-2deepin5_loong64.deb
+    digest: 4ad1494e6ff8cf49be63b33e86e5269d574167f9957df2fa216fac78aef96d7d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin0_loong64.deb
-    digest: 8eb5ae15892c3d3e93600e472e3ce69ab742f99b1622a1030d80a822e42989f9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin5_loong64.deb
+    digest: e720f4941d04c0107977e1fb4f7a8a72f85f1883deda6e0e7873068a35d26692
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale-dev_6.1.1-2deepin0_loong64.deb
-    digest: 97ab8207530f406e35d259bfa26b7b7d0d06f21d8e3147bc4452cb5a18d7a78b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale-dev_6.1.1-2deepin5_loong64.deb
+    digest: e86fbe106d49495cae30bc124830b64f1fb17d5fa4e12658549b396400170f12
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin0_loong64.deb
-    digest: 0dea4074d37171a31a99d1f773b67f88ed06d6027597da7c5cebae6352d8b478
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin5_loong64.deb
+    digest: fbc99b9f58a6f950d7e885668e20702b17ba88dd5886ffec4b9adf74ac992e82
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin6_loong64.deb
-    digest: 1001ece64a54d675835700a91c8b99228f766e3388c192f81d19c179df1ea601
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_loong64.deb
+    digest: 2e66a084ee5197d6ca309c766a7fb0d9a4b397359e21a5b7a920dce4695cfcf4
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_loong64.deb
     digest: 75dde4d8be25c4d18dcf4e27dffff588fabf9c2b365b3c22b2cbd12af97d90b3
@@ -1330,11 +1372,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/uchardet/libuchardet0_0.0.7-1deepin0_loong64.deb
     digest: 40bcfc76cd660dac09bd63c6296b828946c3367242e0e3c42fe5bd8c1cc33552
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev-dev_255.2-4deepin6_loong64.deb
-    digest: 8facad2318df260b70f07230376d9d42324272b54b1e2d7a2e23925880696780
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev-dev_255.2-4deepin11_loong64.deb
+    digest: bcd190055456a57ecb533f4906186fb0dee6e326adaac353e29a90d17095208c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin6_loong64.deb
-    digest: c38b8a0ff42b40be8af246363fb2a07a6cfe163d48201681f9e382612c998100
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin11_loong64.deb
+    digest: e60fd5fd032a8f940a703134978d2ff8ad7b702ad7f9d8419c0529a720759671
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libudfread/libudfread-dev_1.1.2-1_loong64.deb
     digest: 5629827181b4aca7700aff34121a595c5986bf6c044608fb80a7edf842f7e630
@@ -1470,6 +1512,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxau/libxau6_1.0.9-1_loong64.deb
     digest: 13a646d0cdb63a9a5025ab6f5f692e077b51b5735fb06a1300f6fd544d6496bc
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xavs2/libxavs2-13_1.4.1-1+dde_loong64.deb
+    digest: f71a806a15e1fd259ad7c67c41aca0543affe2673ed1bec8198813c62b3829eb
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxaw/libxaw7_1.0.16-1_loong64.deb
     digest: c20644145e433fdbedd548b45bf67cf79ec0b38157ececec0c37f0c2af187207
@@ -1696,17 +1741,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_loong64.deb
     digest: a4bae41cbfe530058e9c63f4b3c34294f1b4b726d8f022b9eca8f7e81833fe13
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi-common_0.2.35-18_all.deb
-    digest: 1fc738c696936a298eab3f5a6061ae0189078abddbdf7ef3da2b39537d47aa85
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi-common_0.2.43-2deepin1_all.deb
+    digest: 8c4f70100c1fcb2755b08644f2326f0c42cf037e89c22cb69e4d0dd0798cae8f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi0_0.2.35-18_loong64.deb
-    digest: c65295d36e1fb593d029ebda8348ae9a95f386a10e7689c1312a97cb769857a8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi0_0.2.43-2deepin1_loong64.deb
+    digest: 3a04740acd8957ba0e5eb2a4266d92ddf4bdc9c12b2c2a75ae868ef24f1cd189
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
     digest: e200be025cd227c34cb852eb20d4b7ad0d371095fdba7b7c4febc7ea7a2221e2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_23.01.01.24_loong64.deb
-    digest: 48957a988f750077b429a1e8b7f54ab5a6563931d4292f750220078741ed8ed9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_loong64.deb
+    digest: a594841362d365a0b93ae0462935964f0efbb0c90da4be064351388804154202
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_loong64.deb
     digest: a6b376c2fd149cc6cabd93cd94dea5c9793fe8e9b9773c22bb9a12812ac52cf4
@@ -1720,8 +1765,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/media-types/media-types_4.0.0_all.deb
     digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin1_loong64.deb
-    digest: 4011a3103fc4a1f79b11f08403b2e636eaa7f593fc5ceba3c2e00c2e774a5a18
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_loong64.deb
+    digest: df2142c0fe0e2665b0f4f7068f4c2aa5d4f5fcd564b2fa570b993c83598dd157
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
@@ -1732,8 +1777,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_loong64.deb
-    digest: 8569bcf5afca194968c0e49c3a71fbf106bdb5f6281db535142a5b8ea1a46e18
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.3.3-1_loong64.deb
+    digest: 7f3efc85c206a71b7442ee3e18dfe4f2dba6c0c62c28ab38b4960be5d28998ae
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/patch/patch_2.7.6-7_loong64.deb
     digest: 713a6fe43f8c66f410ed5eca4b57361868d6da0f05e2ef9f7300f7fe524ee2e5
@@ -1762,11 +1807,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
     digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.4-0deepin1_loong64.deb
-    digest: f90145024163b5f423db6765b8ced01439e819859419cfe9eb9fe7ffc6cfd0f7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_loong64.deb
+    digest: b4144ee10587be066eb49793ff81bdf1e6542b4398a99bce1f61660fee4bedfe
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.4-0deepin1_loong64.deb
-    digest: a003a420b5bda72fb4bbea54eaf3a3a3c74fea3c741ce8141646832b82140be0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_loong64.deb
+    digest: ea8a8be4b657b9b94b2a1e1fb27fff9a7fabd64a17007147088feaba6a7a970a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_loong64.deb
     digest: 2068886f43d893b3d801afe06bdbed2ac6cfbd3dd14b1d2b5658fb691d45615e
@@ -1774,17 +1819,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
     digest: 99aa344e806f799b1008841a76c4f83ad58f508aa7216f7df5adae3aa860fdbd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qemu/qemu-user-static_8.2.0+ds-1deepin12_loong64.deb
-    digest: 2476076d1e5e60842e054cd4d9e130f6e23d8916820e94cf36d9c248ee6e4495
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qemu/qemu-user-static_8.2.0+ds-1deepin15_loong64.deb
+    digest: 147a8ebede9ff9af80b530c3c602ef4f5bfec785f1379ba5352993af5856d94b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qemu/qemu-user_8.2.0+ds-1deepin12_loong64.deb
-    digest: 745d6cff2bd8a8ed6a66cc86630358c61e699591e8d0a78ca99f7acd88df07e4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qemu/qemu-user_8.2.0+ds-1deepin15_loong64.deb
+    digest: 0b03b9857d8b77e0ccdc3ffdc70a08035bb59756fa803cfc8a022c87789fc218
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: b2c23ea458f84eaf5df7f06ceeccf24047551cabc4abd35782060399cd2c8ad6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 339c762f9680d23b12e5ac41068c139b969cf6d035fd286bac37cb3dba4433f9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 4a50a0bec4830e8b4d5468af3ca9b8bb08bcea4892539c2133c6cfe8d06889de
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 8e412a2aa98348c58e7f528fd04c00feb90320acc2b6cbed873c3094890a49ec
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 352c93151474b4e0843755cf4248d5678df53a42e9058d07408427a848b52b08
@@ -1792,14 +1837,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 5bebc32a419c38803377c01265c89450b74b82ab8098a71593f9292962919432
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 2e76edf66678b456d8d2772efd47d38a50c140d74084a166fd2faf1a63da2b00
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 8bb4163c0c9da5c501f1937e79f1f9db15bc57b502de5d711f51239748d3c1ce
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 6cc78a068f206bc90e8cea49b01dac72ac0356213fe52643cec12a23f6b82353
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 61fa7ec1e9023d7c55286b469b6238769eb86b1fa2cfdd45aaa291fe2005e57a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 89d3909a21672e5f10a559a89e5d81efb9056f516935422e9b2dbcd0126503ea
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 3dea4403705fc32119023d852123e8327e56bd1a68f6aac8acb3c230351b769a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
     digest: cf6fafc95fdce9f99b2bfd283100163a1c316fc596dd6ab9da30821d1faeb0d5
@@ -1813,8 +1858,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-multimedia/qt6-multimedia-dev_6.8.0-0deepin_loong64.deb
     digest: b1199d84256f297e6dd6d3b3cfe173285df461da56b10742c9dcae91c616675a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 13e2e5d5ae5fbaa5b971f6e5d4b48c1d72cef2e77af4344e7b802e0f4170228b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 82c70661bd53c58e196bbfede69b23bd2bcbd36829aeafa838cdaa4627893a98
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_loong64.deb
     digest: 8d025380c93576e65ed0941ed9b0a568d366c9554497570335f4426be7068545


### PR DESCRIPTION
chore: Update package URLs and digests in linglong.yaml files

- Updated coreutils and cryfs package URLs and digests across all architectures.

log: Update package URLs and digests in linglong.yaml files

## Summary by Sourcery

Update Deepin Movie packaging to version 6.5.21.1 and refresh all dependency source entries across manifest files

Build:
- Bump application version in all linglong.yaml manifests to 6.5.21.1
- Refresh source URLs and checksums for dependency packages across architectures

Chores:
- Update package URLs and digests for dozens of dependencies in loong64, arm64, amd64 and generic YAML files
- Add and refresh sources for newly required packages such as libgpuinfo, libcurl, duktape, nghttp2/nghttp3/ngtcp2 and others to match latest daily builds