### PR TITLE
fix: Frequent screen plugging and unplugging causing player anomalies.

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -1129,6 +1129,14 @@ MainWindow::MainWindow(QWidget *parent)
     connect(dynamic_cast<MpvProxy *>(m_pEngine->getMpvProxy()),&MpvProxy::crashCheck,&Settings::get(),&Settings::crashCheck);
     //解码初始化
     decodeInit();
+
+    connect(qApp, &QApplication::primaryScreenChanged, this, [&] (QScreen *screen) {
+        qWarning() << "primaryScreenChanged:" << screen->geometry();
+        // 拔掉屏幕，导致屏幕参数为空，概率性导致解码渲染异常。此时应该暂停播放。
+        if (screen->geometry().isEmpty() && m_pEngine->state() == PlayerEngine::CoreState::Playing) {
+            requestAction(ActionFactory::ActionKind::TogglePause);
+        }
+    });
 }
 
 void MainWindow::setupTitlebar()


### PR DESCRIPTION
1. Monitor the presence of the screen and pause video playback when the screen is not present.

When the screen is unplugged, the screen parameters become empty, which may lead to anomalies in the player's decoding and rendering processes. In such cases, playback should be paused. Pausing video playback when no screen is present also aligns with user expectations.

fix: 频繁插拔屏幕导致播放器异常

1. 监测屏幕是否存在，屏幕不存在的时候暂停视频播放

拔掉屏幕后，屏幕的参数为空，概率性导致播放器解码渲染异常。此时应该暂停播放，没有屏幕就暂停播放视频也符合用户的预期。

Bug: https://pms.uniontech.com/bug-view-325319.html