### PR TITLE
fix: Window resizing issue in mini mode

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -526,7 +526,8 @@ protected:
             if (!m_bEnabled) return false;
             QMouseEvent *pMouseEvent = static_cast<QMouseEvent *>(pEvent);
             setLeftButtonPressed(true);
-            if (pMainWindow->insideResizeArea(pMouseEvent->globalPos()) &&
+            // 迷你模式下，不允许resize
+            if (!pMainWindow->getMiniMode() && pMainWindow->insideResizeArea(pMouseEvent->globalPos()) &&
                     lastCornerEdge != Platform_CornerEdge::Platform_NoneEdge)
                 m_bStartResizing = true;
 
@@ -655,7 +656,14 @@ skip_set_cursor:
             }
             break;
         }
-
+        case QEvent::Resize: {
+            // 迷你模式下，不允许resize
+            if (pMainWindow->getMiniMode()) {
+                qDebug() << "Could not resize window in mini mode";
+                return true;
+            }
+            break;
+        }
         default:
             break;
         }


### PR DESCRIPTION
1. Disable mouse events that attempt to resize the window in mini mode.
2. Disable window manager events that attempt to resize the window in mini mode.

In mini mode, the window size is fixed and cannot be resized.

fix: 迷你模式下窗口被修改尺寸

1. 屏蔽迷你模式下鼠标尝试修改尺寸的事件
2. 屏幕窗管尝试修改尺寸的事件

迷你模式下，窗口尺寸是固定大小，不允许修改尺寸。

Bug: https://pms.uniontech.com/bug-view-293145.html