### PR TITLE
fix: When a video is set to play on single loop, there is a chance th…

### DIFF
--- a/src/libdmr/playlist_model.cpp
+++ b/src/libdmr/playlist_model.cpp
@@ -874,6 +874,8 @@ void PlaylistModel::playNext(bool fromUser)
                 _current = _last;
                 tryPlayCurrent(true);
             } else {
+                // 等待播放状态的真正结束，避免时序问题
+                _engine->waitLastEnd();
                 // replay current
                 tryPlayCurrent(true);
             }


### PR DESCRIPTION
…at it will only play for 1 second when replayed.

1. Add a step to wait for playback to end in the single loop logic.

In the single loop logic, before replaying the current file, it is necessary to wait for the current playback state to truly end to avoid timing confusion that may lead to abnormal decoder states.

fix: 单曲循环播放视频，重新播放时概率性只播放1秒

1. 单曲循环逻辑中，增加等待播放结束操作

单曲循环逻辑中，在重新播放当前文件前，要等待本次播放状态的真正结束，避免产生时序混乱，导致解码器状态异常。

Bug: https://pms.uniontech.com/bug-view-325025.html