### PR TITLE
fix: prevent crash during restart by removing qApp->exit()

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -4740,13 +4740,13 @@ void MainWindow::sleepStateChanged(bool bSleep)
         if (dconfig->value("RestartAfterWakeUp").toBool()) {
             const auto &movieInfo = engine()->playlist().currentInfo().mi;
             PlayerEngine::CoreState state = engine()->state();
+            dconfig->setValue("PausedOnPlay", state == PlayerEngine::Paused);  // 休眠时会暂停，所以这里恒为true
             if (state != PlayerEngine::Idle) {
                 Settings::get().settings()->setOption("set.start.crash", "2");
-                qApp->exit();
-                qWarning() << movieInfo.filePath;
+                m_pEngine->savePlaybackPosition();
+                qInfo() << "restart deepin-movie and continue --- " << movieInfo.filePath;
                 QProcess::startDetached(qApp->applicationFilePath(), QStringList() << "--restart" << movieInfo.filePath);
             }
-            dconfig->setValue("PausedOnPlay", state == PlayerEngine::Paused);  // 休眠时会暂停，所以这里恒为true
         }
     }
     delete dconfig;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,7 +155,7 @@ void killOldMovie()
     for (const QString &line : lines) {
         QStringList parts = line.split(QRegExp("\\s+"), QString::SkipEmptyParts);
         if (parts.size() < 3) continue;
-        if (!parts[6].startsWith("deepin-movie")) continue;
+        if (!parts[6].contains("deepin-movie")) continue;
 
         int pid = parts[0].toInt();
         if(QCoreApplication::applicationPid() == pid) continue;
@@ -339,12 +339,10 @@ int main(int argc, char *argv[])
     }
     if (singleton && !runSingleInstance()) {
         if (clm.isSet("restart")) {
-            sleep(2);
             qWarning() << "killOldMovie";
-            if (!runSingleInstance()) {
-                killOldMovie();
-            }
-
+            killOldMovie();
+            sleep(1);
+            runSingleInstance();
         } else {
             QDBusInterface iface("com.deepin.movie", "/", "com.deepin.movie");
             if (clm.isSet("functioncall")) {


### PR DESCRIPTION
- Replace qApp->exit() with direct process restart to avoid libdeepin-event-log assert failures
- Improve process detection using contains() instead of startsWith()
- Add playback position saving before restart
- Simplify restart flow and reduce sleep time

Fixes SEGV crash in libdeepin-event-log during restart.

log: fix bug

Bug:https://pms.uniontech.com/bug-view-325539.html https://pms.uniontech.com/bug-view-325537.html
https://pms.uniontech.com/bug-view-326445.html

## Summary by Sourcery

Prevent application crash during restart by replacing qApp->exit() with a direct process restart and streamlining the restart flow

Bug Fixes:
- Resolve SEGV in libdeepin-event-log by removing qApp->exit() on restart

Enhancements:
- Use contains() for more reliable deepin-movie process detection
- Add playback position saving before restart
- Simplify restart logic by removing redundant checks and reducing sleep duration