### PR TITLE
fix: Window resizing issue in mini mode (composited=false)

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -5319,7 +5319,8 @@ void Platform_MainWindow::toggleUIMode()
 #endif
 
         move((deskGeom.width() - this->width()) / 2, (deskGeom.height() - this->height()) / 2); //迷你模式下窗口居中 by zhuyuliang
-        resize(geom.width(), geom.height());
+        // 迷你模式下，窗口大小固定，不可被修改
+        setFixedSize(geom.width(), geom.height());
 
         m_pMiniPlayBtn->move(sz.width() - 12 - m_pMiniPlayBtn->width(),
                              sz.height() - 10 - m_pMiniPlayBtn->height());
@@ -5328,6 +5329,11 @@ void Platform_MainWindow::toggleUIMode()
     } else {
         qDebug() << "!m_bMiniMode";
         m_pCommHintWid->setAnchorPoint(QPoint(30, 58));
+        // 非迷你模式下，窗口大小恢复可被修改状态
+        QRect tmpRect = m_lastRectInNormalMode; // 先备份，避免被setMinimumSize()影响，后面再恢复
+        this->setMinimumSize(614, 500);
+        this->setMaximumSize(QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX));
+        m_lastRectInNormalMode = tmpRect;
         setEnableSystemResize(true);
         if (m_nStateBeforeMiniMode & SBEM_Maximized) {
             //迷你模式切换最大化时，先恢复原来窗口大小


### PR DESCRIPTION
1. Use the setFixedSize() function to fix the window size in mini mode.
2. After exiting mini mode, set the maximum and minimum window sizes to restore adjustable resizing capabilities.

In mini mode, the window size is fixed and cannot be resized.

fix: 迷你模式下窗口被修改尺寸（非composited）

1. 迷你模式下使用setFixedSize()函数固定窗口尺寸
2. 退出迷你模式后，为窗口设置最大最小尺寸，恢复至可调整尺寸状态

迷你模式下，窗口尺寸是固定大小，不允许修改尺寸。

Bug: https://pms.uniontech.com/bug-view-293145.html （参考v20上的bug）

## Summary by Sourcery

Fix window resizing issue in mini mode by locking the window size when entering mini mode and restoring adjustable sizing when exiting mini mode

Bug Fixes:
- Use setFixedSize to enforce a fixed window size in mini mode and prevent unintended resizing
- Reset minimum and maximum window sizes after exiting mini mode to re-enable standard resizing