### PR TITLE
fix: right-click menu failure

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -4876,7 +4876,6 @@ void MainWindow::contextMenuEvent(QContextMenuEvent *pEvent)
         qDebug() << "insideToolsArea(pEvent->pos())";
         return;
     }
-        return;
 
     if (utils::check_wayland_env()) {
         qDebug() << "utils::check_wayland_env()";


### PR DESCRIPTION
Repaired a logical error in the previous code that caused the right-click menu to fail.

fix: 右键菜单失效

修复历史代码中存在的逻辑错误，导致的右键菜单失效问题。