### PR TITLE
fix: Address timing issue with show/hide to prevent mini mode's Windo…

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -2142,7 +2142,7 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
         m_bWindowAbove = !m_bWindowAbove;
         if (!utils::check_wayland_env()) {
             my_setStayOnTop(this, m_bWindowAbove);
-            show();
+            //show(); // 原本就是show状态，不用再次调用
         } else {
             //wayland 置顶实现
             QFunctionPointer setWindowProperty = qApp->platformFunction("_d_setWindowProperty");
@@ -4390,8 +4390,8 @@ void MainWindow::toggleUIMode()
         showNormal();
         hide();
         QTimer::singleShot(100, [&] {
-            toggleUIMode();
             show();
+            toggleUIMode();
         });
         return;
     }
@@ -4560,7 +4560,6 @@ void MainWindow::toggleUIMode()
             } else {
                 resizeByConstraints();
             }
-            hide();
             // 由于时序问题，延迟最大化
             QTimer::singleShot(100, [&] {
                 showMaximized();

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -2169,7 +2169,7 @@ void Platform_MainWindow::requestAction(ActionFactory::ActionKind actionKind, bo
     case ActionFactory::ActionKind::WindowAbove: {
         m_bWindowAbove = !m_bWindowAbove;
         my_setStayOnTop(this, m_bWindowAbove);
-        show();
+        //show(); // 原本就是show状态，不用再次调用
         if (!bFromUI) {
             reflectActionToUI(actionKind);
         }
@@ -4408,8 +4408,8 @@ void Platform_MainWindow::toggleUIMode()
         showNormal();
         hide();
         QTimer::singleShot(100, [&] {
-            toggleUIMode();
             show();
+            toggleUIMode();
         });
         return;
     }
@@ -4518,7 +4518,6 @@ void Platform_MainWindow::toggleUIMode()
             } else {
                 resizeByConstraints();
             }
-            hide();
             // 由于时序问题，延迟最大化
             QTimer::singleShot(100, [&] {
                 showMaximized();


### PR DESCRIPTION
…wAbove feature from not working.

The WindowAbove logic must operate under the show state and will not take effect in the hide state, thus the timing of show/hide has been adjusted.

fix: 解决show/hide时序问题，避免迷你模式置顶不生效

置顶逻辑必须在show的状态下操作，在hide状态下不生效，所以调整了show/hide的时序。

Bug: https://pms.uniontech.com/bug-view-327605.html