### PR TITLE
fix: movie video playback affecting monitor's black screen operation

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -611,6 +611,7 @@ mpv_handle *MpvProxy::mpv_init()
     my_set_property(pHandle, "screenshot-template", "deepin-movie-shot%n");
     my_set_property(pHandle, "screenshot-directory", "/tmp");
     my_set_property(m_handle, "vd-queue-enable","no");
+    my_set_property(pHandle, "stop-screensaver", "no"); // 屏幕保护逻辑影院自己控制，不由mpv控制
 
 #ifndef _LIBDMR_
     if (Settings::get().isSet(Settings::ResumeFromLast)) {


### PR DESCRIPTION
Disable the screen saver policy of mpv and only use the movie's controlled screen saver policy to avoid continuous triggering of display activation caused by mpv.

fix: 影院播放视频影响显示器黑屏操作

取消mpv的屏幕保护策略，只使用影院控制的屏幕保护策略，避免mpv带来的持续触发显示器显示的行为。

Bug: https://pms.uniontech.com/bug-view-328327.html

## Summary by Sourcery

Bug Fixes:
- Set mpv property "stop-screensaver" to "no" so only the cinema's screensaver policy is used, avoiding unwanted display wake-ups.