### PR TITLE
fix: Fix no sound issue

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -619,7 +619,7 @@ mpv_handle *MpvProxy::mpv_init()
 #endif
         if (utils::check_wayland_env()) {
             qInfo() << "V25 set ao auto";
-            my_set_property(pHandle, "ao", "auto");
+            my_set_property(pHandle, "ao", "sdl");
         }
 
         if (QFile::exists("/sys/bus/pci/drivers/ljmcore")) {


### PR DESCRIPTION
Fix no sound issue

Log: Fix no sound issue
Bug: https://pms.uniontech.com/bug-view-329601.html

## Summary by Sourcery

Bug Fixes:
- Switch mpv 'ao' property from 'auto' to 'sdl' under Wayland environments to restore audio playback