### PR TITLE
chore: update changelog

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.24.1
+  version: 6.5.25.1
   kind: app
   description: |
     movie for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-movie-reborn (6.5.25) unstable; urgency=medium
+
+  * chore: update version 6.5.25
+
+ -- xiepengfei <xiepengfei@uniontech.com>  Mon, 18 Aug 2025 15:37:48 +0800
+
 deepin-movie-reborn (6.5.24) unstable; urgency=medium
 
   * chore: Add Lao translation support for deepin-movie

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.24.1
+  version: 6.5.25.1
   kind: app
   description: |
     movie for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.24.1
+  version: 6.5.25.1
   kind: app
   description: |
     movie for deepin os.


### PR DESCRIPTION
update changelog

Log: Update changelog

## Summary by Sourcery

Update deepin-movie package version and refresh changelog

Chores:
- Bump deepin-movie version from 6.5.24.1 to 6.5.25.1 in arm64, loong64, and generic package manifests
- Update debian/changelog accordingly