### PR TITLE
fix: save volume when restart after wakeup

### DIFF
--- a/src/common/mainwindow.h
+++ b/src/common/mainwindow.h
@@ -501,6 +501,7 @@ private:
     void mircastSuccess(QString name);
     void exitMircast();
     void saveWindowGeometry();
+    void saveVolume();
 
     /**
      * @brief 使用dbus获取当前机器CPU型号


### PR DESCRIPTION
Extract volume saving logic to saveVolume() method and call it before restarting app after wakeup to preserve volume settings. This fixes the issue where volume settings were not synchronized when the app restarts after sleep state changes.

Log: fix bug

Bug: https://pms.uniontech.com/bug-view-330849.html

## Summary by Sourcery

Extract saveVolume method and invoke it on application close and before restart after wakeup to ensure volume settings are preserved.

Bug Fixes:
- Preserve global volume setting when the application restarts after the system wakes from sleep

Enhancements:
- Refactor volume-saving logic into a dedicated saveVolume() method
- Call saveVolume() in closeEvent and sleepStateChanged to unify behavior