### PR TITLE
fix: Adjust coordinates to keep the app logo centered.

### DIFF
--- a/src/backends/mpv/mpv_glwidget.cpp
+++ b/src/backends/mpv/mpv_glwidget.cpp
@@ -465,7 +465,7 @@ namespace dmr {
         pixmap2=pixmap2.fromImage(img1);
 
         QPainter painter(&pixmap);
-        painter.drawPixmap(98,127,pixmap2);
+        painter.drawPixmap(102,126,pixmap2); // 参数102 126，在界面上保持居中
         m_imgBgDark=pixmap.toImage();
         m_imgBgDark.setDevicePixelRatio(qApp->devicePixelRatio());
 
@@ -480,7 +480,7 @@ namespace dmr {
         pixmap4=pixmap4.fromImage(img2);
 
         QPainter painter1(&pixmap3);
-        painter1.drawPixmap(98,127,pixmap4);
+        painter1.drawPixmap(102,126,pixmap4); // 参数102 126，在界面上保持居中
         m_imgBgLight = pixmap3.toImage();
         m_imgBgLight.setDevicePixelRatio(qApp->devicePixelRatio());
     }


### PR DESCRIPTION
When playback starts, the interface is rendered by OpenGL. To ensure the app logo rendered by OpenGL remains centered and consistent with the original interface.

fix: 调整坐标使得应用logo保持居中

开始播放时，界面由opengl进行绘制，要使得opengl绘制的应用logo保持居中，和原始界面保持一致。

Bug: https://pms.uniontech.com/bug-view-330217.html