### PR TITLE
fix: Adjust coordinates to keep the app logo centered.

### DIFF
--- a/src/backends/mpv/mpv_glwidget.cpp
+++ b/src/backends/mpv/mpv_glwidget.cpp
@@ -546,7 +546,7 @@ namespace dmr {
         qDebug() << "DEBUG: Loaded deepin-movie icon for splash.";
 
         QPainter painter(&pixmap);
-        painter.drawPixmap(98,127,pixmap2);
+        painter.drawPixmap(102,126,pixmap2); // 参数102 126，在界面上保持居中
         m_imgBgDark=pixmap.toImage();
         m_imgBgDark.setDevicePixelRatio(qApp->devicePixelRatio());
         qDebug() << "DEBUG: Dark splash image prepared.";
@@ -564,7 +564,7 @@ namespace dmr {
         qDebug() << "DEBUG: Loaded deepin-movie icon for light splash.";
 
         QPainter painter1(&pixmap3);
-        painter1.drawPixmap(98,127,pixmap4);
+        painter1.drawPixmap(102,126,pixmap4); // 参数102 126，在界面上保持居中
         m_imgBgLight = pixmap3.toImage();
         m_imgBgLight.setDevicePixelRatio(qApp->devicePixelRatio());
         qDebug() << "DEBUG: Light splash image prepared.";


### PR DESCRIPTION
When playback starts, the interface is rendered by OpenGL. To ensure the app logo rendered by OpenGL remains centered and consistent with the original interface.

fix: 调整坐标使得应用logo保持居中

开始播放时，界面由opengl进行绘制，要使得opengl绘制的应用logo保持居中，和原始界面保持一致。

Bug: https://pms.uniontech.com/bug-view-330217.html （参考自v20）