### PR TITLE
fix: Video advances 1 frame on unlock while paused

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -4783,11 +4783,7 @@ void MainWindow::lockStateChanged(bool bLock)
         requestAction(ActionFactory::ActionKind::TogglePause);
     } else if (!bLock && m_pEngine->state() == PlayerEngine::CoreState::Paused && m_bStateInLock) {
         m_bStateInLock = false;
-        QTimer::singleShot(500, [=](){
-            //龙芯5000使用命令sudo rtcwake -l -m mem -s 20, 待机唤醒后无dBus信号“PrepareForSleep”发出,加入seek保证解锁后播放不会卡帧
-            m_pEngine->seekAbsolute(static_cast<int>(m_pEngine->elapsed()));
-            // requestAction(ActionFactory::ActionKind::TogglePause); //需求变更，唤醒后不恢复播放
-        });
+        //需求变更，唤醒后不恢复播放
     }
 }
 

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -4710,11 +4710,7 @@ void Platform_MainWindow::lockStateChanged(bool bLock)
         requestAction(ActionFactory::ActionKind::TogglePause);
     } else if (!bLock && m_pEngine->state() == PlayerEngine::CoreState::Paused && m_bStateInLock) {
         m_bStateInLock = false;
-        QTimer::singleShot(500, [=](){
-            //龙芯5000使用命令sudo rtcwake -l -m mem -s 20, 待机唤醒后无dBus信号“PrepareForSleep”发出,加入seek保证解锁后播放不会卡帧
-            m_pEngine->seekAbsolute(static_cast<int>(m_pEngine->elapsed()));
-            // requestAction(ActionFactory::ActionKind::TogglePause); //需求变更，唤醒后不恢复播放
-        });
+        //需求变更，唤醒后不恢复播放
     }
 }
 


### PR DESCRIPTION
remove "seekAbsolute"

Log: fix bug

Bug: https://pms.uniontech.com/bug-view-333251.html

## Summary by Sourcery

Bug Fixes:
- Remove seekAbsolute call on unlock to prevent video from advancing a frame while paused