### PR TITLE
fix: User interface freezes during software decoding with high CPU us…

### DIFF
--- a/src/backends/mpv/mpv_proxy.h
+++ b/src/backends/mpv/mpv_proxy.h
@@ -393,6 +393,7 @@ protected slots:
 private:
     mpv_handle *mpv_init();   //初始化mpv
     void processPropertyChange(mpv_event_property *pEvent);
+    void processPropertyChange(const QString &name);
     void processLogMessage(mpv_event_log_message *pEvent);
     QImage takeOneScreenshot();
     void updatePlayingMovieInfo();


### PR DESCRIPTION
…age.

When software decoding with high CPU usage occurs, the event callback loop in mpv runs for a relatively long time, causing the UI thread to wait for an extended period. Now, we asynchronously execute the time-consuming MPV_EVENT_PROPERTY_CHANGE event to alleviate thread blocking.

fix: 高CPU占用的软件解码时，界面卡死

高CPU占用的软件解码时，mpv的事件回调循环执行较久，导致UI线程等待较久。现在我们把耗时较久的MPV_EVENT_PROPERTY_CHANGE事件异步执行，以缓解线程阻塞。

Bug: https://pms.uniontech.com/bug-view-333489.html

## Summary by Sourcery

Offload MPV_EVENT_PROPERTY_CHANGE processing to the Qt event loop to prevent UI blocking under high CPU load

Bug Fixes:
- Prevent UI thread from freezing during heavy software decoding by executing property change events asynchronously

Enhancements:
- Use QTimer::singleShot and QPointer to defer event callbacks and guard against destroyed MpvProxy instances