### PR TITLE
fix: User interface freezes during software decoding with high CPU us…

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -1201,24 +1201,38 @@ void MpvProxy::processPropertyChange(mpv_event_property *pEvent)
     QString sName = QString::fromUtf8(pEvent->name);
     if (sName != "time-pos") qInfo() << sName;
 
-    if (sName == "time-pos") {
+    // 使用 QPointer 检查对象是否还存在
+    QPointer<MpvProxy> self(this);
+    QTimer::singleShot(0, [this, sName, self]() {
+        if (self.isNull()) {
+            qWarning() << "MpvProxy obj is destroyed";
+            return; // 对象已被销毁
+        }
+
+        processPropertyChange(sName);
+    });
+}
+
+void MpvProxy::processPropertyChange(const QString &name)
+{
+    if (name == "time-pos") {
         emit elapsedChanged();
-    } else if (sName == "volume") {
+    } else if (name == "volume") {
         emit volumeChanged();
-    } else if (sName == "dwidth" || sName == "dheight") {
+    } else if (name == "dwidth" || name == "dheight") {
         auto sz = videoSize();
         if (!sz.isEmpty())
             emit videoSizeChanged();
         qInfo() << "update videoSize " << sz;
-    } else if (sName == "aid") {
+    } else if (name == "aid") {
         emit aidChanged();
-    } else if (sName == "sid") {
+    } else if (name == "sid") {
         emit sidChanged();
-    } else if (sName == "mute") {
+    } else if (name == "mute") {
         emit muteChanged();
-    } else if (sName == "sub-visibility") {
+    } else if (name == "sub-visibility") {
         //_hideSub = my_get_property(m_handle, "sub-visibility")
-    } else if (sName == "pause") {
+    } else if (name == "pause") {
         auto idle = my_get_property(m_handle, "idle-active").toBool();
         if (my_get_property(m_handle, "pause").toBool()) {
             if (!idle)
@@ -1230,8 +1244,8 @@ void MpvProxy::processPropertyChange(mpv_event_property *pEvent)
                 setState(PlayState::Playing);
             }
         }
-    } else if (sName == "core-idle") {
-    } else if (sName == "paused-for-cache") {
+    } else if (name == "core-idle") {
+    } else if (name == "paused-for-cache") {
         qInfo() << "paused-for-cache" << my_get_property_variant(m_handle, "paused-for-cache");
         emit urlpause(my_get_property_variant(m_handle, "paused-for-cache").toBool());
     }

--- a/src/backends/mpv/mpv_proxy.h
+++ b/src/backends/mpv/mpv_proxy.h
@@ -377,6 +377,7 @@ protected slots:
 private:
     mpv_handle *mpv_init();   //初始化mpv
     void processPropertyChange(mpv_event_property *pEvent);
+    void processPropertyChange(const QString &name);
     void processLogMessage(mpv_event_log_message *pEvent);
     QImage takeOneScreenshot();
     void updatePlayingMovieInfo();


### PR DESCRIPTION
…age.

When software decoding with high CPU usage occurs, the event callback loop in mpv runs for a relatively long time, causing the UI thread to wait for an extended period. Now, we asynchronously execute the time-consuming MPV_EVENT_PROPERTY_CHANGE event to alleviate thread blocking.

fix: 高CPU占用的软件解码时，界面卡死

高CPU占用的软件解码时，mpv的事件回调循环执行较久，导致UI线程等待较久。现在我们把耗时较久的MPV_EVENT_PROPERTY_CHANGE事件异步执行，以缓解线程阻塞。

Bug: https://pms.uniontech.com/bug-view-333489.html（参考v20）

## Summary by Sourcery

Offload MPV event property change handling to a zero-delay timer to avoid blocking the UI when software decoding is CPU-intensive, with a QPointer guard to ensure safety and a refactored QString-based handler.

Bug Fixes:
- Fix UI freezing during high-CPU software decoding by making MPV_EVENT_PROPERTY_CHANGE processing asynchronous.

Enhancements:
- Use QTimer::singleShot(0) with a QPointer guard to dispatch property change events off the UI thread.
- Introduce a new processPropertyChange(const QString&) overload to consolidate property change logic.