### PR TITLE
fix: Special customization for GPUs of the FTG340 model.

### DIFF
--- a/src/libdmr/compositing_manager.cpp
+++ b/src/libdmr/compositing_manager.cpp
@@ -377,6 +377,12 @@ bool CompositingManager::isZXIntgraphics() const
     return m_bZXIntgraphics;
 }
 
+bool CompositingManager::isFtg340Gpu()
+{
+    QDir ftg340Dir("/sys/bus/platform/drivers/ftg340");
+    return ftg340Dir.exists();
+}
+
 bool CompositingManager::runningOnNvidia()
 {
     static bool s_runningOnNvidia = false;

--- a/src/libdmr/compositing_manager.h
+++ b/src/libdmr/compositing_manager.h
@@ -92,6 +92,9 @@ public:
     }
     bool isZXIntgraphics() const;
 
+    // 处理BXC NF301B机器（GPU: FTG340）的情况
+    static bool isFtg340Gpu();
+
     PlayerOptionList getProfile(const QString &name);
     PlayerOptionList getBestProfile(); // best for current platform and env
     static void detectPciID();


### PR DESCRIPTION
For scenarios where the GPU is FTG340, hwdec (hardware decoding) should use vaapi, and vo (video output) should also use vaapi. The existing process directly resorts to software decoding, resulting in video playback stuttering.

fix: 针对GPU为FTG340的特殊定制。

针对GPU为FTG340的场景，hwdec要使用vaapi，vo要使用vaapi。现有流程会直接走软解，导致视频播放卡顿。

Bug: https://pms.uniontech.com/bug-view-333489.html

## Summary by Sourcery

Add special handling for FTG340 GPUs by detecting them and enforcing VAAPI for both hardware decoding and video output to resolve playback stuttering.

Bug Fixes:
- Force vaapi decoding and video output on FTG340 GPUs to eliminate playback stuttering by preventing fallback to software decoding.

Enhancements:
- Introduce CompositingManager::isGtg340Gpu() to detect FTG340 GPUs via the sysfs path.
- Override MpvProxy initialization and refresh routines to apply hwdec and vo properties as “vaapi” when FTG340 is detected.
- Treat FTG340 GPUs as hardware-decode capable in isSurportHardWareDecode() to avoid false software fallback.