### PR TITLE
style: fix spelling error of SUCCEEDED

### DIFF
--- a/src/accessibility/ac-deepin-movie-define.h
+++ b/src/accessibility/ac-deepin-movie-define.h
@@ -88,7 +88,7 @@
 //#define SCREENSHOT_MENU_MENU QObject::tr("screenshotMenu")
 
 ////投屏界面
-#define MIRCAST_SUCCESSED          0
+#define MIRCAST_SUCCEEDED          0
 #define MIRCAST_EXIT              -1
 #define MIRCAST_CONNECTION_FAILED -3
 #define MIRCAST_DISCONNECTIONED   -4

--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -5855,7 +5855,7 @@ void MainWindow::slotUpdateMircastState(int state, QString msg)
 {
     qDebug() << "slotUpdateMircastState";
     switch (state) {
-    case MIRCAST_SUCCESSED: //投屏成功
+    case MIRCAST_SUCCEEDED: //投屏成功
     {
         qDebug() << "MIRCAST_SUCCESSED";
         mircastSuccess(msg);

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -5816,7 +5816,7 @@ void Platform_MainWindow::slotUpdateMircastState(int state, QString msg)
 {
     qDebug() << "Enter slotUpdateMircastState function";
     switch (state) {
-    case MIRCAST_SUCCESSED: //投屏成功
+    case MIRCAST_SUCCEEDED: //投屏成功
     {
         qDebug() << "MIRCAST_SUCCESSED";
         mircastSuccess(msg);

--- a/src/widgets/mircastwidget.cpp
+++ b/src/widgets/mircastwidget.cpp
@@ -359,8 +359,9 @@ void MircastWidget::slotGetPositionInfo(DlnaPositionInfo info)
         m_mircastState = MircastState::Screening;
         if (m_connectDevice.deviceState == Connecting) {
             m_connectDevice.deviceState = MircastState::Screening;
-            emit mircastState(MIRCAST_SUCCESSED, m_connectDevice.miracastDevice.name);
+
             qDebug() << "Miracast connection successful";
+            emit mircastState(MIRCAST_SUCCEEDED, m_connectDevice.miracastDevice.name);
         }
         ItemWidget *item = m_listWidget->currentItemWidget();
         if(item)
@@ -368,7 +369,7 @@ void MircastWidget::slotGetPositionInfo(DlnaPositionInfo info)
         m_attempts = 0;
     } else {
         if (duration > 0 && m_connectDevice.deviceState == Connecting) {
-            emit mircastState(MIRCAST_SUCCESSED, m_connectDevice.miracastDevice.name);
+            emit mircastState(MIRCAST_SUCCEEDED, m_connectDevice.miracastDevice.name);
         }
         qWarning() << "Miracast connection failed - Attempts:" << m_attempts;
         if (m_attempts >= MAXMIRCAST * 10) {

--- a/tests/deepin-movie/common/test_mainwindow.cpp
+++ b/tests/deepin-movie/common/test_mainwindow.cpp
@@ -1294,7 +1294,7 @@ TEST(ToolBox, slotUpdateMircast)
     ToolboxProxy *toolboxProxy = w->toolbox();
     PlayerEngine *engine = w->engine();
     w->m_pMircastShowWidget->show();
-    toolboxProxy->slotUpdateMircast(MIRCAST_SUCCESSED, "test");
+    toolboxProxy->slotUpdateMircast(MIRCAST_SUCCEEDED, "test");
     QTest::qWait(100);
     w->m_pMircastShowWidget->show();
     toolboxProxy->slotUpdateMircast(MIRCAST_EXIT, "test");
@@ -1318,7 +1318,7 @@ TEST(ToolBox, slotUpdateMircast)
     mircastWgt->setMircastState(MircastWidget::Screening);
     mircastWgt->show();
     engine->playByName(QUrl::fromLocalFile("/data/source/deepin-movie-reborn/movie/demo.mp4"));
-    toolboxProxy->slotUpdateMircast(MIRCAST_SUCCESSED, "test");
+    toolboxProxy->slotUpdateMircast(MIRCAST_SUCCEEDED, "test");
     QTest::qWait(500);
     mircastWgt->hide();
     engine->clearPlaylist();


### PR DESCRIPTION
The correct past tense and past participle of the verb ​​"succeed"​​ is ​​"succeeded"​​, not "succssed".

Log: fix spelling error