### PR TITLE
fix: correct typo in function name initMemeber -> initMember

### DIFF
--- a/src/widgets/platform/platform_toolbox_proxy.cpp
+++ b/src/widgets/platform/platform_toolbox_proxy.cpp
@@ -268,7 +268,7 @@ public:
    Platform_ViewProgBar(DMRSlider *m_pProgBar, QWidget *parent = nullptr)
     {
         qDebug() << "ViewProgBar constructor";
-        initMemeber();
+        initMember();
         //传入进度条，以便重新获取胶片进度条长度 by ZhuYuliang
         this->m_pProgBar = m_pProgBar;
         _parent = parent;
@@ -653,9 +653,9 @@ private:
         return span/* * (p.x())*/;
     }
 
-    void initMemeber()
+    void initMember()
     {
-        qDebug() << "ViewProgBar initMemeber";
+        qDebug() << "ViewProgBar initMember";
         m_pEngine = nullptr;
         _parent = nullptr;
 //        m_pViewProgBarLoad = nullptr;

--- a/src/widgets/toolbox_proxy.cpp
+++ b/src/widgets/toolbox_proxy.cpp
@@ -321,7 +321,7 @@ public:
     ViewProgBar(DMRSlider *m_pProgBar, QWidget *parent = nullptr)
     {
         qDebug() << "ViewProgBar";
-        initMemeber();
+        initMember();
         //传入进度条，以便重新获取胶片进度条长度 by ZhuYuliang
         this->m_pProgBar = m_pProgBar;
         _parent = parent;
@@ -704,9 +704,9 @@ private:
         return span/* * (p.x())*/;
     }
 
-    void initMemeber()
+    void initMember()
     {
-        qDebug() << "initMemeber";
+        qDebug() << "initMember";
         m_pEngine = nullptr;
         _parent = nullptr;
 //        m_pViewProgBarLoad = nullptr;


### PR DESCRIPTION
Fix spelling error in ViewProgBar and Platform_ViewProgBar classes across multiple files.

log: fix spelling error