### PR TITLE
style: fix typo in MIRCAST_DISCONNECTIONED macro

### DIFF
--- a/src/accessibility/ac-deepin-movie-define.h
+++ b/src/accessibility/ac-deepin-movie-define.h
@@ -91,7 +91,7 @@
 #define MIRCAST_SUCCESSED          0
 #define MIRCAST_EXIT              -1
 #define MIRCAST_CONNECTION_FAILED -3
-#define MIRCAST_DISCONNECTIONED   -4
+#define MIRCAST_DISCONNECTED   -4
 
 
 

--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -5880,7 +5880,7 @@ void MainWindow::slotUpdateMircastState(int state, QString msg)
         slotExitMircast();
     }
         break;
-    case MIRCAST_DISCONNECTIONED://投屏丢失连接
+    case MIRCAST_DISCONNECTED://投屏丢失连接
     {
         qDebug() << "MIRCAST_DISCONNECTIONED";
         m_pCommHintWid->updateWithMessage(tr("Miracast disconnected"));

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -5841,7 +5841,7 @@ void Platform_MainWindow::slotUpdateMircastState(int state, QString msg)
         slotExitMircast();
     }
         break;
-    case MIRCAST_DISCONNECTIONED://投屏丢失连接
+    case MIRCAST_DISCONNECTED://投屏丢失连接
     {
         qDebug() << "MIRCAST_DISCONNECTIONED";
         m_pCommHintWid->updateWithMessage(tr("Miracast disconnected"));

--- a/src/widgets/mircastwidget.cpp
+++ b/src/widgets/mircastwidget.cpp
@@ -291,7 +291,7 @@ void MircastWidget::slotMircastTimeout()
         qDebug() << "Max Miracast attempts reached. Stopping timeout timer.";
         m_mircastTimeOut.stop();
         if (m_mircastState == MircastState::Screening)
-            emit mircastState(MIRCAST_DISCONNECTIONED);
+            emit mircastState(MIRCAST_DISCONNECTED);
         else
             emit mircastState(MIRCAST_CONNECTION_FAILED);
         qWarning() << "Miracast connection failed after" << MAXMIRCAST << "attempts";

--- a/tests/deepin-movie/common/test_mainwindow.cpp
+++ b/tests/deepin-movie/common/test_mainwindow.cpp
@@ -1303,7 +1303,7 @@ TEST(ToolBox, slotUpdateMircast)
     toolboxProxy->slotUpdateMircast(MIRCAST_CONNECTION_FAILED, "test");
     w->m_pMircastShowWidget->show();
     QTest::qWait(100);
-    toolboxProxy->slotUpdateMircast(MIRCAST_DISCONNECTIONED, "test");
+    toolboxProxy->slotUpdateMircast(MIRCAST_DISCONNECTED, "test");
     QTest::qWait(100);
     w->m_pMircastShowWidget->hide();
     //投屏加载音乐


### PR DESCRIPTION
- Rename MIRCAST_DISCONNECTIONED to MIRCAST_DISCONNECTED
- Fix spelling error in Miracast disconnection constant
- Update all references to use correct spelling

This commit corrects the typo in the Miracast disconnection macro name and updates all related code references for consistency.

log: fix spelling error