### PR TITLE
fix: remove duplicate m_pViewProgBar assignment

### DIFF
--- a/src/widgets/platform/platform_toolbox_proxy.cpp
+++ b/src/widgets/platform/platform_toolbox_proxy.cpp
@@ -1491,7 +1491,6 @@ void Platform_ToolboxProxy::initMember()
     m_pTimeLabel = nullptr;
     m_pTimeLabelend = nullptr;
     m_pViewProgBar = nullptr;
-    m_pViewProgBar = nullptr;
     m_pProgBar = nullptr;
     m_pPreviewer = nullptr;
     m_pPreviewTime = nullptr;

--- a/src/widgets/toolbox_proxy.cpp
+++ b/src/widgets/toolbox_proxy.cpp
@@ -1639,7 +1639,6 @@ void ToolboxProxy::initMember()
     m_pTimeLabel = nullptr;
     m_pTimeLabelend = nullptr;
     m_pViewProgBar = nullptr;
-    m_pViewProgBar = nullptr;
     m_pProgBar = nullptr;
     m_pPreviewer = nullptr;
     m_pPreviewTime = nullptr;


### PR DESCRIPTION
Log: remove duplicate m_pViewProgBar assignment

## Summary by Sourcery

Clean up duplicate m_pViewProgBar assignment in two initMember functions

Enhancements:
- Remove redundant m_pViewProgBar initialization in initMember of Platform_ToolboxProxy
- Remove redundant m_pViewProgBar initialization in initMember of ToolboxProxy