### PR TITLE
fix: Switch from r_frame_rate to avg_frame_rate for FPS calculation

### DIFF
--- a/src/libdmr/playlist_model.cpp
+++ b/src/libdmr/playlist_model.cpp
@@ -322,8 +322,8 @@ struct MovieInfo PlaylistModel::parseFromFile(const QFileInfo &fi, bool *ok)
         mi.strFmtName = av_ctx->iformat->long_name;
 #endif
 
-        if (videoStream->r_frame_rate.den != 0) {
-            mi.fps = videoStream->r_frame_rate.num / videoStream->r_frame_rate.den;
+        if (videoStream->avg_frame_rate.den != 0) {
+            mi.fps = videoStream->avg_frame_rate.num / videoStream->avg_frame_rate.den;
         } else {
             mi.fps = 0;
         }
@@ -1702,8 +1702,8 @@ MovieInfo MovieInfo::parseFromFile(const QFileInfo &fi, bool *ok)
 #ifdef _MOVIE_USE_
     mi.strFmtName = av_ctx->iformat->long_name;
 #endif
-    if (av_stream->r_frame_rate.den != 0) {
-        mi.fps = av_stream->r_frame_rate.num / av_stream->r_frame_rate.den;
+    if (av_stream->avg_frame_rate.den != 0) {
+        mi.fps = av_stream->avg_frame_rate.num / av_stream->avg_frame_rate.den;
     } else {
         mi.fps = 0;
     }


### PR DESCRIPTION
Changed frame rate calculation to use average frame rate (avg_frame_rate) instead of real frame rate (r_frame_rate) for more accurate and stable FPS values in video stream analysis.

Log: Improve frame rate calculation accuracy
Bug: https://pms.uniontech.com/bug-view-322569.html