### PR TITLE
fix: Improve FPS calculation precision with proper rounding

### DIFF
--- a/src/libdmr/playlist_model.cpp
+++ b/src/libdmr/playlist_model.cpp
@@ -323,7 +323,7 @@ struct MovieInfo PlaylistModel::parseFromFile(const QFileInfo &fi, bool *ok)
 #endif
 
         if (videoStream->avg_frame_rate.den != 0) {
-            mi.fps = videoStream->avg_frame_rate.num / videoStream->avg_frame_rate.den;
+            mi.fps = static_cast<int>(round(static_cast<double>(videoStream->avg_frame_rate.num) / videoStream->avg_frame_rate.den));
         } else {
             mi.fps = 0;
         }
@@ -1703,7 +1703,7 @@ MovieInfo MovieInfo::parseFromFile(const QFileInfo &fi, bool *ok)
     mi.strFmtName = av_ctx->iformat->long_name;
 #endif
     if (av_stream->avg_frame_rate.den != 0) {
-        mi.fps = av_stream->avg_frame_rate.num / av_stream->avg_frame_rate.den;
+        mi.fps = static_cast<int>(round(static_cast<double>(av_stream->avg_frame_rate.num) / av_stream->avg_frame_rate.den));
     } else {
         mi.fps = 0;
     }


### PR DESCRIPTION
Enhanced frame rate calculation by using double precision division and
 rounding to nearest integer, preventing truncation errors in FPS values.

Log: Fix FPS calculation accuracy with rounding
Bug: https://pms.uniontech.com/bug-view-322569.html

## Summary by Sourcery

Fix truncation errors in FPS computation by switching to double-precision division with rounding

Bug Fixes:
- Use round() on double-precision division when calculating FPS in PlaylistModel::parseFromFile
- Apply proper rounding for FPS calculation in MovieInfo::parseFromFile