### PR TITLE
fix: build error

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -16,7 +16,9 @@
 #include "movie_configuration.h"
 #endif
 #include <mpv/client.h>
+#ifdef DTKCORE_CLASS_DConfigFile
 #include <DConfig>
+#endif
 
 #include <random>
 #include <QtWidgets>

--- a/src/libdmr/compositing_manager.cpp
+++ b/src/libdmr/compositing_manager.cpp
@@ -7,7 +7,9 @@
 #include "compositing_manager.h"
 #include "utils.h"
 #include "dmr_settings.h"
-#include <dconfig.h>
+#ifdef DTKCORE_CLASS_DConfigFile
+#include <DConfig>
+#endif
 #ifndef _LIBDMR_
 #include "options.h"
 #endif


### PR DESCRIPTION
modify:
    #ifdef DTKCORE_CLASS_DConfigFile
    #include <DConfig>
    #endif

Log: as title

## Summary by Sourcery

Guard inclusion of DConfig to fix missing symbol build errors

Bug Fixes:
- Wrap DConfig include in compositing_manager.cpp behind DTKCORE_CLASS_DConfigFile
- Wrap DConfig include in mpv_proxy.cpp behind DTKCORE_CLASS_DConfigFile