### PR TITLE
chore: Improve logging related to the configuration file play.conf.

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -1849,6 +1849,8 @@ void MpvProxy::play()
         my_set_property(m_handle, iter.key(), iter.value());
         iter++;
     }
+    qInfo() << "FINALLY, hwdec:" << my_get_property(m_handle, "hwdec").toString();
+    qInfo() << "FINALLY, vo:" << my_get_property(m_handle, "vo").toString();
 
     qInfo() << "Executing play command with args:" << listArgs << "and options:" << listOpts;
     my_command(m_handle, listArgs);

--- a/src/libdmr/utils.cpp
+++ b/src/libdmr/utils.cpp
@@ -709,7 +709,7 @@ void getPlayProperty(const char *path, QMap<QString, QString> *&proMap)
     QFileInfo fi(path);
     if ((fi.exists() && fi.isFile()) && fi.isReadable()) {
         QFile file(path);
-        if (file.open(QIODevice::ReadOnly) | QIODevice::Text) {
+        if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
             QByteArray t;
             int index = 0;
             while (!file.atEnd()) {
@@ -720,16 +720,18 @@ void getPlayProperty(const char *path, QMap<QString, QString> *&proMap)
                     QString temp = list.back();
                     temp = temp.mid(0, temp.length() - 1);//去除/n
                     proMap->insert(list.first(), temp);
-                    qDebug() << "Added property:" << list.first() << "=" << temp;
+                    qInfo() << "Read config line: key:" << list.first() << "value:" << temp;
                 } else {
-                    qWarning() << "Invalid config line:" << index << t;
+                    qWarning() << __func__ << QString("ERROR! config line: %1 (line No: %2)").arg(QString(t)).arg(index);
                     continue;
                 }
             }
+            file.close();
+        } else {
+            qWarning() << __func__ << "File open ERROR, file path:" << path;
         }
-        file.close();
     } else {
-        qWarning() << "Invalid file path or permissions:" << path;
+        qWarning() << __func__ << "File not exist, file path:" << path;
     }
 #endif
 }


### PR DESCRIPTION
Enhance the logging related to play.conf to facilitate problem analysis.

chore: 配置文件play.conf的日志完善。

完善与play.conf相关的日志，方便问题分析。

## Summary by Sourcery

Improve logging around reading the play.conf configuration file and augment playback debugging in mpv_proxy by fixing a file open flag, enriching info-level messages, and logging final hardware decoding and video output settings.

Bug Fixes:
- Fix file open mode by correctly combining QIODevice::ReadOnly and QIODevice::Text flags when opening play.conf.

Enhancements:
- Switch config line reads from qDebug to qInfo and include function names in warnings for invalid lines, file open errors, and missing files.
- Ensure the configuration file is closed immediately after successful reads.
- Add qInfo logs in mpv_proxy to report final hwdec and vo values before executing the play command.