### PR TITLE
fix: compatibility with FFmpeg 7+

### DIFF
--- a/src/libdmr/playlist_model.cpp
+++ b/src/libdmr/playlist_model.cpp
@@ -341,7 +341,11 @@ struct MovieInfo PlaylistModel::parseFromFile(const QFileInfo &fi, bool *ok)
         mi.aCodeID = audio_dec_ctx->codec_id;
         mi.aCodeRate = audio_dec_ctx->bit_rate;
         mi.aDigit = audio_dec_ctx->format;
+#if LIBAVFORMAT_VERSION_MAJOR >= 60
+        mi.channels = audio_dec_ctx->ch_layout.nb_channels;
+#else
         mi.channels = audio_dec_ctx->channels;
+#endif
         mi.sampling = audio_dec_ctx->sample_rate;
 
 #ifdef USE_TEST
@@ -1706,7 +1710,11 @@ MovieInfo MovieInfo::parseFromFile(const QFileInfo &fi, bool *ok)
     mi.aCodeID = dec_ctx->codec_id;
     mi.aCodeRate = dec_ctx->bit_rate;
     mi.aDigit = dec_ctx->format;
+#if LIBAVFORMAT_VERSION_MAJOR >= 60
+    mi.channels = dec_ctx->ch_layout.nb_channels;
+#else
     mi.channels = dec_ctx->channels;
+#endif
     mi.sampling = dec_ctx->sample_rate;
 
     AVDictionaryEntry *tag = NULL;


### PR DESCRIPTION
Use `ch_layout` in favor of removed `channels` for new ffmpeg.

## Summary by Sourcery

Support both pre-FFmpeg 7 and FFmpeg 7+ by conditionally using ch_layout.nb_channels instead of the removed channels field

Bug Fixes:
- Replace removed audio_dec_ctx->channels with audio_dec_ctx->ch_layout.nb_channels for FFmpeg >=7
- Replace removed dec_ctx->channels with dec_ctx->ch_layout.nb_channels for FFmpeg >=7