### PR TITLE
fix: skip deleted files when loading playlist

### DIFF
--- a/src/libdmr/playlist_model.cpp
+++ b/src/libdmr/playlist_model.cpp
@@ -742,6 +742,16 @@ void PlaylistModel::loadPlaylist()
     for (int i = 0; i < keys.size(); ++i) {
         auto url = cfg.value(QString::number(i)).toUrl();
         if (indexOf(url) >= 0) continue;
+
+        // Check if file exists before adding to avoid adding deleted files
+        if (url.isLocalFile()) {
+            QFileInfo fi(url.toLocalFile());
+            if (!fi.exists()) {
+                qInfo() << "Skipping non-existent file in playlist:" << url.toString();
+                continue;
+            }
+        }
+
         urls.append(url);
     }
     cfg.endGroup();


### PR DESCRIPTION
Re-enabled file existence check in loadPlaylist() to prevent adding deleted files to the playlist. This fixes the issue where deleted files would still appear in the playlist and could not be played normally after being restored.

log: fix bug

Bug: https://pms.uniontech.com/bug-view-355613.html

## Summary by Sourcery

Bug Fixes:
- Avoid adding deleted or missing local files back into the playlist when reloading from configuration.