### PR TITLE
feat(mpv): prioritize gpuinfo VO recommendation in AUTO decode mode

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -209,11 +209,13 @@ void MpvProxy::initGpuInfoFuns()
     if(!SysUtils::libExist("libgpuinfo.so")) {
         qWarning() << "libgpuinfo.so not found - GPU info functions will be unavailable";
         m_gpuInfo = NULL;
+        m_gpuInfoVo = NULL;
         qDebug() << "DEBUG: Exiting MpvProxy::initGpuInfoFuns due to missing libgpuinfo.so."; // Add exit log
         return;
     }
     QLibrary mpvLibrary(SysUtils::libPath("libgpuinfo.so"));
     m_gpuInfo = reinterpret_cast<void *>(mpvLibrary.resolve("vdp_Iter_decoderInfo"));
+    m_gpuInfoVo = reinterpret_cast<const char* (*)(void)>(mpvLibrary.resolve("gpuinfo_get_vo"));
     qInfo() << "GPU info functions initialized successfully";
 }
 
@@ -636,6 +638,16 @@ mpv_handle *MpvProxy::mpv_init()
             my_set_property(pHandle, "hwdec", "vaapi");
             my_set_property(pHandle, "vo", "vaapi");
             m_sInitVo = "vaapi";
+        }
+
+        // gpuinfo VO: if matched, use gpuinfo's recommendation (AUTO mode only)
+        if (m_gpuInfoVo) {
+            const char* vo = m_gpuInfoVo();
+            if (vo && vo[0] != '\0') {
+                qInfo() << "gpuinfo recommended vo:" << vo;
+                my_set_property(pHandle, "vo", vo);
+                m_sInitVo = vo;
+            }
         }
     } else if (DecodeMode::HARDWARE == m_decodeMode) { //3.设置硬解
         qDebug() << "DEBUG: Decode mode set to HARDWARE. Checking specific hardware.";
@@ -1939,6 +1951,7 @@ void MpvProxy::initMember()
     m_freeNodecontents = nullptr;
     m_pConfig = nullptr;
     m_gpuInfo = nullptr;
+    m_gpuInfoVo = nullptr;
 }
 
 void MpvProxy::play()

--- a/src/backends/mpv/mpv_proxy.h
+++ b/src/backends/mpv/mpv_proxy.h
@@ -450,6 +450,7 @@ private:
     mpvinitialize m_initialize;
     mpv_freeNode_contents m_freeNodecontents;
     void *m_gpuInfo; //解码探测函数指针
+    const char* (*m_gpuInfoVo)(void); //gpuinfo_get_vo函数指针
 
 
     MpvHandle m_handle;                    //mpv句柄


### PR DESCRIPTION
Use gpuinfo_get_vo() from libgpuinfo to get recommended video output for current GPU, overriding heuristic result in AUTO decode mode.

在自动解码模式下，优先使用gpuinfo提供的VO配置，覆盖硬件启发式判断。

Log: 自动解码模式优先使用gpuinfo的VO配置
PMS: BUG-356131
Influence: 当gpuinfo数据库中配置了GPU的推荐VO时，自动解码模式将优先使用该配置，提升特定GPU的兼容性。

## Summary by Sourcery

Prioritize libgpuinfo's recommended video output (VO) in mpv's AUTO decode mode when available.

New Features:
- Use gpuinfo_get_vo from libgpuinfo to set the initial VO in AUTO decode mode when a recommendation exists.

Enhancements:
- Initialize and manage a new gpuinfo VO function pointer alongside existing GPU info integration to support VO recommendations.