### PR TITLE
chore: update version to 6.5.45

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-movie-reborn (6.5.45) unstable; urgency=medium
+
+  * feat(mpv): prioritize gpuinfo VO recommendation in AUTO decode mode
+
+ -- Wang Yu <wangyu@uniontech.com>  Thu, 09 Apr 2026 21:50:29 +0800
+
 deepin-movie-reborn (6.5.44) unstable; urgency=medium
 
   * fix: add Linglong container path conversion for OpenDirectory action

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.44.1
+  version: 6.5.45.1
   kind: app
   description: |
     movie for deepin os.


### PR DESCRIPTION
- bump version to 6.5.45

Log : bump version to 6.5.45

## Summary by Sourcery

Chores:
- Update linglong package manifest to version 6.5.45.1.