### PR TITLE
fix(decode): restore user decode mode setting on startup

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -5097,7 +5097,9 @@ void MainWindow::decodeInit()
         Settings::get().settings()->setOption(QString("base.decode.select"),DecodeMode::AUTO);
     } else {
         qDebug() << "bcatch != 1";
-        if (Settings::get().settings()->option("base.decode.select")->value().toInt() == 3)
+        int decodeMode = Settings::get().settings()->option("base.decode.select")->value().toInt();
+        pMpvProxy->setDecodeModel(decodeMode);
+        if (decodeMode == 3)
             dmr::Settings::get().crashCheck();
     }
 }

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -5170,7 +5170,9 @@ void Platform_MainWindow::decodeInit()
         Settings::get().settings()->setOption(QString("base.decode.select"),DecodeMode::AUTO);
     } else {
         qDebug() << "bcatch != 1";
-        if (Settings::get().settings()->option("base.decode.select")->value().toInt() == 3)
+        int decodeMode = Settings::get().settings()->option("base.decode.select")->value().toInt();
+        pMpvProxy->setDecodeModel(decodeMode);
+        if (decodeMode == 3)
             dmr::Settings::get().crashCheck();
     }
     qDebug() << "Exiting decodeInit function";


### PR DESCRIPTION
Read saved decode mode from config and apply to MpvProxy during init, fixing the issue where user's software decode preference was lost after restart.

修复启动时未读取用户保存的解码模式设置，导致重启后软解
配置失效的问题。

Log: 修复重启后解码模式未正确初始化的问题
PMS: BUG-357633
Influence: 用户设置的软解/硬解/自定义解码模式在重启后能够正确生效。

## Summary by Sourcery

Bug Fixes:
- Fix loss of user-selected decode mode (software/hardware/custom) after application restart by applying the saved setting during decode initialization.