### PR TITLE
feat: allow bypassing the compositor when fullscreen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,10 @@ node_modules/
 # Task files
 # tasks.json
 # tasks/ 
+# ai
+CLAUDE.md
+AGENTS.md
+.cursor
+.trellis
+.claude
+.agents

--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -1921,8 +1921,15 @@ void MainWindow::mipsShowFullScreen()
     pAn->setEndValue(1);
     pAn->setStartValue(0);
     pAn->start(QAbstractAnimation::DeleteWhenStopped);
-
     setWindowState(windowState() | Qt::WindowFullScreen);
+
+
+    connect(pAn, &QPropertyAnimation::finished, this, [=](){
+        // 全屏时设置绕过合成器
+        if (windowHandle()) {
+            Utility::setBypassCompositor(windowHandle()->winId(), true);
+        }
+    });
 }
 
 void MainWindow::menuItemInvoked(QAction *pAction)
@@ -2506,6 +2513,11 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
 
         if (isFullScreen()) {
             qDebug() << "isFullScreen()";
+            // 取消全屏前，先取消绕过合成器
+            if (windowHandle()) {
+                Utility::setBypassCompositor(windowHandle()->winId(), false);
+            }
+
             setWindowState(windowState() & ~Qt::WindowFullScreen);
             if (m_bMaximized) {
                 qDebug() << "m_bMaximized";
@@ -2520,6 +2532,7 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
                         m_pTitlebar->setFixedWidth(m_lastRectInNormalMode.width());             //bug 39991
                 }
             }
+
             if (m_pFullScreenTimeLabel && !isFullScreen()) {
                 qDebug() << "m_pFullScreenTimeLabel && !isFullScreen(), close";
                 m_pFullScreenTimeLabel->close();

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -2025,6 +2025,11 @@ void Platform_MainWindow::mipsShowFullScreen()
     // 保留 WindowMinimized 旧状态标识
     setWindowState(windowState() | Qt::WindowFullScreen);
     setVisible(true);
+
+    // 全屏时设置绕过合成器
+    if (windowHandle()) {
+        Utility::setBypassCompositor(windowHandle()->winId(), true);
+    }
 }
 
 void Platform_MainWindow::menuItemInvoked(QAction *pAction)
@@ -2560,6 +2565,11 @@ void Platform_MainWindow::requestAction(ActionFactory::ActionKind actionKind, bo
 
         if (isFullScreen()) {
             qDebug() << "isFullScreen()";
+            // 取消全屏前，先取消绕过合成器
+            if (windowHandle()) {
+                Utility::setBypassCompositor(windowHandle()->winId(), false);
+            }
+
             // 和 mainwindow.cpp 保持一致，在 mipsShowFullScreen() 时保留 Qt::WindowMaximized 的状态以正常切换。
             setWindowState(windowState() & ~Qt::WindowFullScreen);
 

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -51,6 +51,7 @@ public:
     static QByteArray windowProperty(quint32 WId, xcb_atom_t propAtom, xcb_atom_t typeAtom, quint32 len);
     static QList<xcb_atom_t> windowNetWMState(quint32 WId);
     static void setWindowProperty(quint32 WId, xcb_atom_t propAtom, xcb_atom_t typeAtom, const void *data, quint32 len, uint8_t format = 8);
+    static void setBypassCompositor(quint32 WId, bool bypass);
 //    static void setStayOnTop(const QWidget *widget, bool on);
 
 private:

--- a/src/common/utility_x11.cpp
+++ b/src/common/utility_x11.cpp
@@ -1,9 +1,10 @@
-// Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
+// Copyright (C) 2020 ~ 2026, Deepin Technology Co., Ltd. <support@deepin.org>
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "utility.h"
+#include "utils.h"
 
 #include <QtWidgets>
 
@@ -41,6 +42,7 @@ const char kAtomNameWmStateAbove[] = "_NET_WM_STATE_ABOVE";
 const char kAtomNameWmStateStaysOnTop[] = "_NET_WM_STATE_STAYS_ON_TOP";
 const char kAtomNameWmSkipTaskbar[] = "_NET_WM_STATE_SKIP_TASKBAR";
 const char kAtomNameWmSkipPager[] = "_NET_WM_STATE_SKIP_PAGER";
+const char kAtomNameBypassCompositor[] = "_NET_WM_BYPASS_COMPOSITOR";
 
 xcb_atom_t Utility::internAtom(const char *name)
 {
@@ -380,4 +382,36 @@ bool Utility::setWindowCursor(quint32 WId, Utility::CornerEdge ce)
                &xev);
     XFlush(display);
 }*/
+
+void Utility::setBypassCompositor(quint32 WId, bool bypass)
+{
+    if (dmr::utils::check_wayland_env()) {
+        return;
+    }
+
+    Display *display = QX11Info::display();
+    if (!display) {
+        return;
+    }
+
+    Window windowId = static_cast<Window>(WId);
+    if (windowId == 0) {
+        return;
+    }
+
+    Atom bypassAtom = XInternAtom(display, kAtomNameBypassCompositor, false);
+    if (bypassAtom == None) {
+        return;
+    }
+
+    Atom cardinalAtom = XInternAtom(display, "CARDINAL", false);
+    if (cardinalAtom == None) {
+        return;
+    }
+
+    unsigned long value = bypass ? 1 : 0;
+    XChangeProperty(display, windowId, bypassAtom, cardinalAtom, 32,
+                   PropModeReplace, reinterpret_cast<unsigned char*>(&value), 1);
+    XFlush(display);
+}
 


### PR DESCRIPTION
Log: as title
    
task: https://pms.uniontech.com/task-view-384659.html

## Summary by Sourcery

Allow X11 fullscreen windows to request compositor bypass for performance and restore normal compositing when exiting fullscreen.

New Features:
- Add a Utility helper to toggle the _NET_WM_BYPASS_COMPOSITOR property on X11 windows.
- Enable main window implementations to set compositor bypass when entering fullscreen and clear it when leaving fullscreen.