### PR TITLE
fix(decode): check decode mode before applying Effect setting

### DIFF
--- a/src/libdmr/compositing_manager.cpp
+++ b/src/libdmr/compositing_manager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
+// Copyright (C) 2020 ~ 2026, Deepin Technology Co., Ltd. <support@deepin.org>
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -213,34 +213,50 @@ CompositingManager::CompositingManager()
         qDebug() << "Config file opened successfully. Reading contents.";
         QTextStream in(&file);
         QString line;
+        int decodeSelect = -1;
+        int effectValue = -1;
         while (!in.atEnd()) {
+            if (decodeSelect != -1 && effectValue != -1)
+                break;
             line = in.readLine();
-            if (line.contains("[base.decode.Effect]")) {
-                qDebug() << "Line contains [base.decode.Effect]. Reading next line for value.";
+            if (line.contains("[base.decode.select]")) {
+                if (in.atEnd()) break;
                 line = in.readLine();
-                int index = line.indexOf("value=");
-                if (index != -1) {
-                    qDebug() << "'value=' found in line.";
-                    QString value = line.mid(index + 6); // 6 is the length of "value="
-                    value = value.trimmed(); // Remove leading and trailing whitespace
-                    file.close();
-                    qDebug() << "Config file closed after reading value. Parsed value:" << value;
-                    if (value.toInt() != 0) {
-                        _composited = value.toInt() == 1 ? true : false;
-                        qDebug() << "Composited mode set from config file value:" << _composited;
-                        m_pMpvConfig = new QMap<QString, QString>;
-                        qDebug() << "New QMap for MPV config created (from config file path).";
-                        utils::getPlayProperty("/etc/mpv/play.conf", m_pMpvConfig);
-                        return;
-                    }
-                } else {
-                    qDebug() << "'value=' not found in line after [base.decode.Effect].";
+                int idx = line.indexOf("value=");
+                if (idx != -1) {
+                    bool ok = false;
+                    int val = line.mid(idx + 6).trimmed().toInt(&ok);
+                    if (ok)
+                        decodeSelect = val;
+                    else
+                        qWarning() << "Invalid base.decode.select value in config";
+                }
+            } else if (line.contains("[base.decode.Effect]")) {
+                if (in.atEnd()) break;
+                line = in.readLine();
+                int idx = line.indexOf("value=");
+                if (idx != -1) {
+                    bool ok = false;
+                    int val = line.mid(idx + 6).trimmed().toInt(&ok);
+                    if (ok)
+                        effectValue = val;
+                    else
+                        qWarning() << "Invalid base.decode.Effect value in config";
                 }
             }
+                }
+        file.close();
+        qDebug() << "Parsed config: decodeSelect =" << decodeSelect << ", effectValue =" << effectValue;
+        // Effect only applies when in Customize mode (select == 3)
+        if (decodeSelect == 3 && effectValue > 0) {
+            _composited = (effectValue == 1);
+            qDebug() << "Composited mode set from config file value:" << _composited;
+            m_pMpvConfig = new QMap<QString, QString>;
+            qDebug() << "New QMap for MPV config created (from config file path).";
+            utils::getPlayProperty("/etc/mpv/play.conf", m_pMpvConfig);
+            return;
         }
     }
-    file.close();
-    qDebug() << "Config file explicitly closed (if not already).";
 
     //TODO: 临时处理方案
     _composited = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
+// Copyright (C) 2020 ~ 2026, Deepin Technology Co., Ltd. <support@deepin.org>
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -470,6 +470,7 @@ int main(int argc, char *argv[])
         dmr::Settings::get().settings()->setOption("base.decode.select", 0);
         dmr::Settings::get().settings()->setOption("base.decode.Decodemode", 0);
         dmr::Settings::get().settings()->setOption("base.decode.Videoout", 0);
+        dmr::Settings::get().settings()->setOption("base.decode.Effect", 0);
         dmr::Settings::get().crashCheck();
     }
 


### PR DESCRIPTION
CompositingManager now reads base.decode.select alongside Effect, only applying OpenGL rendering path when select == 3 (Customize).

CompositingManager 读取 base.decode.select，仅在自定义模式下
应用 Effect 设置，避免切回自动模式后仍走 OpenGL 路径。
同时修复崩溃恢复路径未重置 Effect 的问题。

Log: 修复自定义模式 Effect 残留导致重启后仍走 OpenGL
PMS: BUG-361169
Influence: 用户从自定义模式切回自动模式重启后，不再被残留的
Effect=OpenGL 设置影响渲染路径。

## Summary by Sourcery

Gate use of the OpenGL compositing path on both the decode mode selection and Effect setting, and ensure crash recovery resets the Effect configuration.

Bug Fixes:
- Ignore Effect-based compositing when decode mode is not in Customize (select == 3) to prevent stale settings from forcing the OpenGL path after switching back to automatic mode.
- Reset the base.decode.Effect option on crash recovery so that stale values do not affect rendering after restart.