### PR TITLE
fix(gpu): improve GPU info error handling

### DIFF
--- a/linglong.yaml
+++ b/linglong.yaml
@@ -20,7 +20,7 @@ command:
 
 build: |
   # 下载和安装依赖
-  apt -y install --download-only libmpv-dev libxcb1-dev libxcb-util0-dev libffmpegthumbnailer-dev libxcb-shape0-dev libxcb-ewmh-dev xcb-proto x11proto-record-dev x11-utils libxtst-dev libavcodec-dev libavformat-dev libavutil-dev libpulse-dev libdvdnav-dev libgsettings-qt-dev libva-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev qt6-base-dev qt6-base-dev-tools qt6-base-private-dev qt6-l10n-tools qt6-svg-dev qt6-tools-dev-tools qt6-tools-dev qt6-multimedia-dev libqt6sql6-sqlite libmpris-qt6-dev libqt6opengl6-dev libdtk6gui-dev libdtk6widget-dev libdtk6core-dev libgpuinfo deepin-event-log
+  apt -y install --download-only libmpv-dev libxcb1-dev libxcb-util0-dev libffmpegthumbnailer-dev libxcb-shape0-dev libxcb-ewmh-dev xcb-proto x11proto-record-dev x11-utils libxtst-dev libavcodec-dev libavformat-dev libavutil-dev libpulse-dev libdvdnav-dev libgsettings-qt-dev libva-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev qt6-base-dev qt6-base-dev-tools qt6-base-private-dev qt6-l10n-tools qt6-svg-dev qt6-tools-dev-tools qt6-tools-dev qt6-multimedia-dev libqt6sql6-sqlite libmpris-qt6-dev libqt6opengl6-dev libdtk6gui-dev libdtk6widget-dev libdtk6core-dev libgpuinfo deepin-event-log pciutils mesa-utils
   # libxcb1-dev：解决构建失败
   bash ./install_dep /var/cache/apt/archives "$PREFIX" "libxcb1-dev"
 
@@ -52,6 +52,8 @@ build: |
   # 项目生成应用名和动态隐式加载的依赖库，ldd无法找到的其他库
   LDD_FILES=(
     deepin-movie
+    lspci
+    glxinfo
     libmpv.so
     libgpuinfo.so
     libavcodec.so

--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -216,7 +216,11 @@ void MpvProxy::initGpuInfoFuns()
     QLibrary mpvLibrary(SysUtils::libPath("libgpuinfo.so"));
     m_gpuInfo = reinterpret_cast<void *>(mpvLibrary.resolve("vdp_Iter_decoderInfo"));
     m_gpuInfoVo = reinterpret_cast<const char* (*)(void)>(mpvLibrary.resolve("gpuinfo_get_vo"));
-    qInfo() << "GPU info functions initialized successfully";
+    if (m_gpuInfo && m_gpuInfoVo) {
+        qInfo() << "GPU info functions initialized successfully";
+    } else {
+        qWarning() << "GPU info functions initialized error";
+    }
 }
 
 void MpvProxy::firstInit()
@@ -2701,4 +2705,3 @@ void MpvProxy::setProperty(const QString &sName, const QVariant &val)
 }
 
 } // end of namespace dmr
-


### PR DESCRIPTION
Add proper error checking for GPU info initialization to provide better diagnostics when GPU info functions fail.

为GPU信息初始化添加错误检查，提供更好的诊断信息。

Log: 改进GPU信息错误处理
PMS: BUG-351181
Issue: Fixes #351181
Influence: GPU信息初始化失败时会输出错误日志，方便定位问题。