### PR TITLE
fix(ui): center idle icon correctly on HiDPI displays

### DIFF
--- a/src/backends/mpv/mpv_glwidget.cpp
+++ b/src/backends/mpv/mpv_glwidget.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026, Deepin Technology Co., Ltd. <support@deepin.org>
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -549,39 +549,45 @@ namespace dmr {
     void MpvGLWidget::prepareSplashImages()
     {
         qDebug() << "DEBUG: Entering prepareSplashImages.";
+        qreal dpr = qApp->devicePixelRatio();
+
         QPixmap pixmap;
         QImage img=utils::LoadHiDPIImage(":/resources/icons/dark/init-splash-bac.svg");
         pixmap=pixmap.fromImage(img);
-        qDebug() << "DEBUG: Loaded dark splash background image.";
+        qDebug() << "DEBUG: Loaded dark splash background image. Size:" << pixmap.size();
 
+        int iconSize = static_cast<int>(130 * dpr);
         QPixmap pixmap2;
-        QImage img1=QIcon::fromTheme("deepin-movie").pixmap(130, 130).toImage();
+        QImage img1=QIcon::fromTheme("deepin-movie").pixmap(iconSize, iconSize).toImage();
         pixmap2=pixmap2.fromImage(img1);
-        qDebug() << "DEBUG: Loaded deepin-movie icon for splash.";
+        qDebug() << "DEBUG: Loaded deepin-movie icon for splash. Size:" << pixmap2.size();
+
+        int iconX = static_cast<int>(102 * dpr);
+        int iconY = static_cast<int>(126 * dpr);
 
         QPainter painter(&pixmap);
-        painter.drawPixmap(102,126,pixmap2); // 参数102 126，在界面上保持居中
+        painter.drawPixmap(iconX, iconY, pixmap2);
         m_imgBgDark=pixmap.toImage();
-        m_imgBgDark.setDevicePixelRatio(qApp->devicePixelRatio());
-        qDebug() << "DEBUG: Dark splash image prepared.";
+        m_imgBgDark.setDevicePixelRatio(dpr);
+        qDebug() << "DEBUG: Dark splash image prepared. Icon position:" << iconX << iconY;
 
         QPixmap pixmap3;
         QImage image(pixmap.size(),QImage::Format_Alpha8);
         image.fill(QColor(0, 0, 0, 0));
-        image.setDevicePixelRatio(qApp->devicePixelRatio());
+        image.setDevicePixelRatio(dpr);
         pixmap3=pixmap3.fromImage(image);
         qDebug() << "DEBUG: Created alpha channel image for light splash.";
 
         QPixmap pixmap4;
-        QImage img2=QIcon::fromTheme("deepin-movie").pixmap(130, 130).toImage();
+        QImage img2=QIcon::fromTheme("deepin-movie").pixmap(iconSize, iconSize).toImage();
         pixmap4=pixmap4.fromImage(img2);
-        qDebug() << "DEBUG: Loaded deepin-movie icon for light splash.";
+        qDebug() << "DEBUG: Loaded deepin-movie icon for light splash. Size:" << pixmap4.size();
 
         QPainter painter1(&pixmap3);
-        painter1.drawPixmap(102,126,pixmap4); // 参数102 126，在界面上保持居中
+        painter1.drawPixmap(iconX, iconY, pixmap4);
         m_imgBgLight = pixmap3.toImage();
-        m_imgBgLight.setDevicePixelRatio(qApp->devicePixelRatio());
-        qDebug() << "DEBUG: Light splash image prepared.";
+        m_imgBgLight.setDevicePixelRatio(dpr);
+        qDebug() << "DEBUG: Light splash image prepared. Icon position:" << iconX << iconY;
     }
 
     //cppcheck误报

--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -5177,15 +5177,17 @@ void MainWindow::paintEvent(QPaintEvent *pEvent)
 
     if (m_pEngine->state() == PlayerEngine::Idle) {
         qDebug() << "m_pEngine->state() == PlayerEngine::Idle";
-        QImage bg = QIcon::fromTheme("deepin-movie").pixmap(130, 130).toImage();
+        qreal dpr = devicePixelRatioF();
+        int iconSize = static_cast<int>(130 * dpr);
+        QImage bg = QIcon::fromTheme("deepin-movie").pixmap(iconSize, iconSize).toImage();
+        bg.setDevicePixelRatio(dpr);
         //和产品、ui商议深色主题下去除深色背景效果
 //        if (DGuiApplicationHelper::DarkType == DGuiApplicationHelper::instance()->themeType()) {
 //            QImage img = utils::LoadHiDPIImage(":/resources/icons/dark/init-splash-bac.svg");
 //            QPointF pos = bgRect.center() - QPoint(img.width() / 2, img.height() / 2) / devicePixelRatioF();
 //            painter.drawImage(pos, img);
 //        }
-        qDebug() << "QImage bg = QIcon::fromTheme(\"deepin-movie\").pixmap(130, 130).toImage()";
-        QPointF pos = bgRect.center() - QPoint(bg.width() / 2, bg.height() / 2) / devicePixelRatioF();
+        QPointF pos = bgRect.center() - QPointF(bg.width() / 2.0 / dpr, bg.height() / 2.0 / dpr);
         painter.drawImage(pos, bg);
     }
 

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -5245,14 +5245,17 @@ void Platform_MainWindow::paintEvent(QPaintEvent *pEvent)
     }
 
     if (m_pEngine->state() == PlayerEngine::Idle) {
-        QImage bg = QIcon::fromTheme("deepin-movie").pixmap(130, 130).toImage();
+        qreal dpr = devicePixelRatioF();
+        int iconSize = static_cast<int>(130 * dpr);
+        QImage bg = QIcon::fromTheme("deepin-movie").pixmap(iconSize, iconSize).toImage();
+        bg.setDevicePixelRatio(dpr);
         //和产品、ui商议深色主题下去除深色背景效果
 //        if (DGuiApplicationHelper::DarkType == DGuiApplicationHelper::instance()->themeType()) {
 //            QImage img = utils::LoadHiDPIImage(":/resources/icons/dark/init-splash-bac.svg");
 //            QPointF pos = bgRect.center() - QPoint(img.width() / 2, img.height() / 2) / devicePixelRatioF();
 //            painter.drawImage(pos, img);
 //        }
-        QPointF pos = bgRect.center() - QPoint(bg.width() / 2, bg.height() / 2) / devicePixelRatioF();
+        QPointF pos = bgRect.center() - QPointF(bg.width() / 2.0 / dpr, bg.height() / 2.0 / dpr);
         painter.drawImage(pos, bg);
     }
 

--- a/src/libdmr/player_engine.cpp
+++ b/src/libdmr/player_engine.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2020 ~ 2026, Deepin Technology Co., Ltd. <support@deepin.org>
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -704,9 +704,12 @@ void PlayerEngine::paintEvent(QPaintEvent *e)
             p.fillRect(rect, QBrush(QColor(0, 0, 0)));
         } else {
             qDebug() << "Player is idle or not audio, drawing icon.";
-            QImage icon = QIcon::fromTheme("deepin-movie").pixmap(130, 130).toImage();;
+            qreal dpr = devicePixelRatioF();
+            int iconSize = static_cast<int>(130 * dpr);
+            QImage icon = QIcon::fromTheme("deepin-movie").pixmap(iconSize, iconSize).toImage();
+            icon.setDevicePixelRatio(dpr);
             QPixmap pix = QPixmap::fromImage(icon);
-            QPointF pos = rect.center() - QPoint(pix.width() / 2, pix.height() / 2) / devicePixelRatioF();
+            QPointF pos = rect.center() - QPointF(pix.width() / 2.0 / dpr, pix.height() / 2.0 / dpr);
 
             if (DGuiApplicationHelper::LightType == DGuiApplicationHelper::instance()->themeType()) {
                 qDebug() << "Theme type is Light, filling white rectangle and drawing pixmap.";


### PR DESCRIPTION
Scale icon size by devicePixelRatio for proper HiDPI rendering.

修复空闲状态图标在高DPI显示下未居中的问题。

Log: 修复空闲图标高DPI居中问题
PMS: BUG-361435
Influence: 影响影院空闲状态下居中图标的显示，修复后图标在任意缩放比例下均正确居中。

## Summary by Sourcery

Adjust idle and splash icon rendering to respect device pixel ratio for correct centering on HiDPI displays.

Bug Fixes:
- Fix misaligned idle state icon by scaling its size and position according to the device pixel ratio in player and main window paint routines.
- Correct centering of splash screen icons on HiDPI displays by using device pixel ratio for icon size, positioning, and background images.

Enhancements:
- Update copyright and SPDX metadata years in core playback and UI components.