### PR TITLE
chore: Update version to 6.5.47

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+deepin-movie-reborn (6.5.47) unstable; urgency=medium
+
+  * chore: Update version to 6.5.47
+  * fix(ui): center idle icon correctly on HiDPI displays
+  * fix(gpu): improve GPU info error handling
+  * fix(mpv): add fast profile for 4K playback
+  * fix(decode): check decode mode before applying Effect setting
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Wed, 20 May 2026 13:46:56 +0800
+
 deepin-movie-reborn (6.5.46) unstable; urgency=medium
 
   * feat: allow bypassing the compositor when fullscreen

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.46.1
+  version: 6.5.47.1
   kind: app
   description: |
     movie for deepin os.


### PR DESCRIPTION
- update version to 6.5.47

log: update version to 6.5.47

## Summary by Sourcery

Bump the deepin-movie package version metadata to 6.5.47.1 in the linglong configuration.