### PR TITLE
fix(gl): use GL texture overlay for fullscreen time display

### DIFF
--- a/src/backends/mpv/mpv_glwidget.cpp
+++ b/src/backends/mpv/mpv_glwidget.cpp
@@ -18,6 +18,7 @@
 
 #include <QLibrary>
 #include <QPainterPath>
+#include <QSharedPointer>
 
 #include <dthememanager.h>
 #include <DApplication>
@@ -227,6 +228,64 @@ void main() {
 )";
 
 namespace dmr {
+
+#ifdef __x86_64__
+    // Fullscreen overlay state stored in a file-static map (no header change).
+    // QPainter on offscreen QImage → GL texture, avoids glyph-cache corruption.
+    namespace {
+        struct OverlayState {
+            QOpenGLTexture *tex = nullptr;
+            QOpenGLVertexArrayObject vao;
+            QOpenGLBuffer vbo;
+            QString lastPlayTime;
+            QString lastSysTime;
+            int lastPert = -1;
+            QSize logicalSize{0, 0};
+            QSize lastWidgetSize{0, 0};
+            QImage img;
+        };
+        static QHash<const MpvGLWidget *, QSharedPointer<OverlayState>> g_overlayStates;
+
+        QSharedPointer<OverlayState> getOverlay(const MpvGLWidget *w)
+        {
+            auto it = g_overlayStates.find(w);
+            if (it == g_overlayStates.end()) {
+                auto ptr = QSharedPointer<OverlayState>::create();
+                // Auto-cleanup: remove entry when widget is destroyed, even if
+                // the destructor path is skipped due to abnormal shutdown.
+                QObject::connect(w, &QObject::destroyed, [w]() { g_overlayStates.remove(w); });
+                it = g_overlayStates.insert(w, ptr);
+            }
+            return *it;
+        }
+
+        void destroyOverlay(const MpvGLWidget *w)
+        {
+            auto it = g_overlayStates.find(w);
+            if (it == g_overlayStates.end())
+                return;
+            OverlayState *s = it.value().data();
+            // Explicitly clean GL resources while context is current.
+            if (s->tex) {
+                s->tex->destroy();
+                delete s->tex;
+                s->tex = nullptr;
+            }
+            if (s->vbo.isCreated())
+                s->vbo.destroy();
+            if (s->vao.isCreated())
+                s->vao.destroy();
+            g_overlayStates.erase(it);
+        }
+
+        // Forward declarations; definitions at file end for protected-member access.
+        static void rebuildOverlayTexture(MpvGLWidget *self, qreal pert, const QString &strSysTime, const QString &strPlayTime, bool bRawFormat);
+        static void renderFullscreenOverlay(MpvGLWidget *self, QOpenGLFunctions *pGLFunction,
+                                            QOpenGLShaderProgram *prog,
+                                            qreal pert, const QString &strPlayTime, bool bRawFormat);
+    }
+#endif
+
     static void* GLAPIENTRY glMPGetNativeDisplay(const char* name) {
         qWarning() << __func__ << name;
         if (!strcmp(name, "x11") || !strcmp(name, "X11")) {
@@ -296,7 +355,7 @@ namespace dmr {
         qDebug() << "DEBUG: Exiting gl_update_callback.";
     }
 
-    //cppcheck 被QMetaObject::invokeMethod使用
+    //cppcheck false positive: used by QMetaObject::invokeMethod
     void MpvGLWidget::onNewFrame()
     {
         qDebug() << "DEBUG: Entering onNewFrame.";
@@ -342,10 +401,14 @@ namespace dmr {
         qDebug() << "DEBUG: Exiting MpvGLWidget constructor.";
     }
 
-    MpvGLWidget::~MpvGLWidget() 
+    MpvGLWidget::~MpvGLWidget()
     {
         qDebug() << "DEBUG: Entering MpvGLWidget destructor.";
         makeCurrent();
+#ifdef __x86_64__
+        // Clean overlay GL resources first, while context is guaranteed valid.
+        destroyOverlay(this);
+#endif
         if (m_pDarkTex) {
             qDebug() << "DEBUG: Destroying dark texture.";
             m_pDarkTex->destroy();
@@ -698,14 +761,14 @@ namespace dmr {
             m_pFbo->release();
             delete m_pFbo;
         }
-        // 创建 FBO 格式
+        // Create FBO format
         QOpenGLFramebufferObjectFormat format;
         format.setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);
-        format.setSamples(0);  // 禁用多重采样，避免与视频渲染冲突
+        format.setSamples(0);  // Disable MSAA to avoid conflict with video rendering
         format.setTextureTarget(GL_TEXTURE_2D);
-        format.setInternalTextureFormat(GL_RGBA8);  // 使用 8 位 RGBA 格式
+        format.setInternalTextureFormat(GL_RGBA8);  // 8-bit RGBA
         m_pFbo = new QOpenGLFramebufferObject(desiredSize, format);
-        // 检查 FBO 是否创建成功
+        // Verify FBO creation
         if (!m_pFbo || !m_pFbo->isValid()) {
             qCritical() << "Failed to create FBO with size:" << desiredSize;
             return;
@@ -961,6 +1024,9 @@ namespace dmr {
         m_renderContexRender = nullptr;
         m_renderContextUpdate = nullptr;
         m_bRawFormat = false;
+#ifdef __x86_64__
+        m_pert = 0.0;
+#endif
         qDebug() << "initMember end";
     }
 
@@ -979,7 +1045,7 @@ namespace dmr {
             return;
         }
     
-        // 检查纹理是否有效
+        // Check texture validity
         if (m_pLightTex && !m_pLightTex->isCreated()) {
             qWarning() << "Light texture not created in paintGL";
             return;
@@ -1072,48 +1138,12 @@ namespace dmr {
             }
 #ifdef __x86_64__
             QWidget *topWidget = topLevelWidget();
-            if(topWidget && (topWidget->isFullScreen())) {//全屏状态播放时更新显示进度
+            if (topWidget && topWidget->isFullScreen()) {
                 QVariant varShow = topWidget->property("showTimeFullScreen");
-                if(!varShow.isValid() || !varShow.toBool()) return;
-                QString time_text = QTime::currentTime().toString("hh:mm");
-                QRect rectTime = QRect(rect().width() - 90, 0, 90, 40);
-                QPainter painter;
-                painter.begin(this);
-                QPen pen;
-                pen.setColor(QColor(255, 255, 255, 255 * .4));
-                painter.setPen(pen);
-                QFontMetrics fm(font());
-                auto fr = fm.boundingRect(time_text);
-                fr.moveCenter(rectTime.center());
-                //显示系统时间
-                painter.drawText(fr,time_text);
-                QPoint pos((rectTime.topLeft().x() + 20), rectTime.topLeft().y() + rectTime.height() - 5);
-                int pert = qMin(m_pert * 10, 10.0);
-                for (int i = 0; i < 10; i++) {//显示影院视频播放进度
-                    if (i >= pert) {
-                        painter.fillRect(QRect(pos, QSize(3, 3)), QColor(255, 255, 255, 255 * .25));
-                    } else {
-                        painter.fillRect(QRect(pos, QSize(3, 3)), QColor(255, 255, 255, 255 * .5));
-                    }
-                    pos.rx() += 5;
+                if (varShow.isValid() && varShow.toBool()) {
+                    renderFullscreenOverlay(this, pGLFunction, m_pGlProgBlend,
+                                            m_pert, m_strPlayTime, m_bRawFormat);
                 }
-                QRect rectMovieTime = QRect(rect().width() - 175, 46, 175, 20);
-                if(m_strPlayTime.isNull() || m_strPlayTime.isEmpty()) return;
-                QPalette Palette;
-                pen.setColor(Palette.color(QPalette::Text));
-                if (m_bRawFormat) {
-                    if (DGuiApplicationHelper::LightType == DGuiApplicationHelper::instance()->themeType()) {
-                        pen.setColor(QColor(0, 0, 0, 40));
-                    } else {
-                        pen.setColor(QColor(255, 255, 255, 40));
-                    }
-                }
-                painter.setPen(pen);
-                fr = fm.boundingRect(m_strPlayTime);
-                fr.moveCenter(rectMovieTime.center());
-                //显示影院视频播放时间与总时间
-                painter.drawText(fr,m_strPlayTime);
-                painter.end();
             }
 #endif
         } else {
@@ -1200,10 +1230,183 @@ namespace dmr {
     {
         if (pos > duration)
             pos = duration;
-        m_pert = (qreal)pos / duration;//更新影院播放进度
+        m_pert = (duration > 0) ? (qreal)pos / duration : 0.0;
         QString sCurtime = QString("%1 %2").arg(utils::Time2str(pos)).arg("/ ");
         QString stime = QString("%1").arg(utils::Time2str(duration));
-        m_strPlayTime = sCurtime + stime;//更新影院当前播放时长
+        m_strPlayTime = sCurtime + stime;  // Update fullscreen play-time string
+    }
+
+    /**
+     * @brief Paint overlay onto offscreen QImage → upload as GL texture.
+     * Avoids QPainter on GL widget which corrupts mpv's GL state.
+     */
+    namespace {
+        void rebuildOverlayTexture(MpvGLWidget *self, qreal pert,
+                                   const QString &strSysTime, const QString &strPlayTime, bool bRawFormat)
+        {
+            auto s = getOverlay(self);
+
+            // Overlay logical size: 185×72 fits time + dots + duration
+            const int kOverlayWidth = 185;
+            const int kOverlayHeight = 72;
+            s->logicalSize = QSize(kOverlayWidth, kOverlayHeight);
+
+            qreal dpr = self->devicePixelRatioF();
+            QSize physSize = QSize(kOverlayWidth, kOverlayHeight) * dpr;
+            if (s->img.size() != physSize || s->img.format() != QImage::Format_ARGB32_Premultiplied) {
+                s->img = QImage(physSize, QImage::Format_ARGB32_Premultiplied);
+                s->img.setDevicePixelRatio(dpr);
+            }
+            s->img.fill(Qt::transparent);
+
+            QPainter p(&s->img);
+            p.setRenderHint(QPainter::Antialiasing);
+            p.setRenderHint(QPainter::TextAntialiasing);
+
+            QFont f = self->font();
+            f.setPixelSize(14);
+            QFontMetrics fm(f);
+            p.setFont(f);
+
+            // ① System time hh:mm, semi-transparent white
+            QRect rTime(kOverlayWidth - 90, 0, 90, 40);
+            QRect frTime = fm.boundingRect(strSysTime);
+            frTime.moveCenter(rTime.center());
+            p.setPen(QColor(255, 255, 255, static_cast<int>(255 * 0.4)));
+            p.drawText(frTime, strSysTime);
+
+            // ② Progress dots
+            int dotCount = qMin(qRound(pert * 10), 10);
+            QPoint dot(rTime.topLeft().x() + 20, rTime.topLeft().y() + rTime.height() - 5);
+            for (int i = 0; i < 10; ++i) {
+                QColor c = (i >= dotCount) ? QColor(255, 255, 255, static_cast<int>(255 * 0.25))
+                                           : QColor(255, 255, 255, static_cast<int>(255 * 0.5));
+                p.fillRect(QRect(dot, QSize(3, 3)), c);
+                dot.rx() += 5;
+            }
+
+            // ③ Video duration hh:mm:ss / hh:mm:ss
+            if (!strPlayTime.isNull() && !strPlayTime.isEmpty()) {
+                QRect rMovie(kOverlayWidth - 175, 46, 175, 20);
+                QColor textColor;
+                if (bRawFormat) {
+                    if (DGuiApplicationHelper::LightType == DGuiApplicationHelper::instance()->themeType())
+                        textColor = QColor(0, 0, 0, 40);
+                    else
+                        textColor = QColor(255, 255, 255, 40);
+                } else {
+                    textColor = QPalette().color(QPalette::Text);
+                }
+                QRect frMovie = fm.boundingRect(strPlayTime);
+                frMovie.moveCenter(rMovie.center());
+                p.setPen(textColor);
+                p.drawText(frMovie, strPlayTime);
+            }
+            p.end();
+
+            // Convert ARGB32_Premultiplied → RGBA8888 (Qt handles unpremultiply)
+            // and upload as GL texture.
+            QImage glImg = s->img.convertToFormat(QImage::Format_RGBA8888);
+            if (!s->tex) {
+                s->tex = new QOpenGLTexture(QOpenGLTexture::Target2D);
+                s->tex->setMinificationFilter(QOpenGLTexture::Linear);
+                s->tex->setMagnificationFilter(QOpenGLTexture::Linear);
+                s->tex->setWrapMode(QOpenGLTexture::ClampToEdge);
+            }
+            s->tex->setData(glImg);
+        }
+
+        void renderFullscreenOverlay(MpvGLWidget *self, QOpenGLFunctions *pGLFunction,
+                                     QOpenGLShaderProgram *prog,
+                                     qreal pert, const QString &strPlayTime, bool bRawFormat)
+        {
+            auto s = getOverlay(self);
+            QString sCurSysTime = QTime::currentTime().toString("hh:mm");
+            int curPert = qMin(qRound(pert * 10), 10);
+
+            // Rebuild texture only when content changes
+            bool needRebuild = (!s->tex)
+                    || sCurSysTime != s->lastSysTime
+                    || curPert != s->lastPert
+                    || strPlayTime != s->lastPlayTime;
+            if (needRebuild) {
+                rebuildOverlayTexture(self, pert, sCurSysTime, strPlayTime, bRawFormat);
+                s->lastSysTime = sCurSysTime;
+                s->lastPert = curPert;
+                s->lastPlayTime = strPlayTime;
+            }
+            if (!s->tex || !prog)
+                return;
+
+            // Ensure we draw into Qt's internal FBO.
+            GLint prevFbo = 0;
+            pGLFunction->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFbo);
+            pGLFunction->glBindFramebuffer(GL_FRAMEBUFFER, self->defaultFramebufferObject());
+
+            // Compute NDC coordinates for the top-right corner
+            const int W = self->width();
+            const int H = self->height();
+            const int ow = s->logicalSize.width();
+            const int oh = s->logicalSize.height();
+            float x0 = static_cast<float>(W - ow) / W * 2.0f - 1.0f;
+            float x1 = 1.0f;
+            float y0 = 1.0f;
+            float y1 = 1.0f - static_cast<float>(oh) / H * 2.0f;
+
+            // Vertices: (x, y, u, v). Top row (y=y0) maps to QImage row 0 → v=0.
+            const GLfloat verts[] = {
+                x0, y0,  0.0f, 0.0f,
+                x1, y0,  1.0f, 0.0f,
+                x0, y1,  0.0f, 1.0f,
+                x1, y0,  1.0f, 0.0f,
+                x1, y1,  1.0f, 1.0f,
+                x0, y1,  0.0f, 1.0f,
+            };
+
+            if (!s->vao.isCreated())
+                s->vao.create();
+            if (!s->vbo.isCreated()) {
+                s->vbo.create();
+                s->vbo.setUsagePattern(QOpenGLBuffer::StaticDraw);
+            }
+
+            QSize curWidgetSize(W, H);
+            bool vboDirty = (curWidgetSize != s->lastWidgetSize);
+
+            QOpenGLVertexArrayObject::Binder vaoBind(&s->vao);
+            s->vbo.bind();
+            if (vboDirty) {
+                s->vbo.allocate(verts, sizeof(verts));
+                s->lastWidgetSize = curWidgetSize;
+            }
+
+            prog->bind();
+            int nVertexLoc = prog->attributeLocation("position");
+            int nCoordLoc = prog->attributeLocation("vTexCoord");
+            if (nVertexLoc < 0 || nCoordLoc < 0) {
+                prog->release();
+                return;
+            }
+            prog->enableAttributeArray(nVertexLoc);
+            prog->setAttributeBuffer(nVertexLoc, GL_FLOAT, 0, 2, 4 * sizeof(GLfloat));
+            prog->enableAttributeArray(nCoordLoc);
+            prog->setAttributeBuffer(nCoordLoc, GL_FLOAT, 2 * sizeof(GLfloat), 2, 4 * sizeof(GLfloat));
+            prog->setUniformValue("movie", 0);
+
+            pGLFunction->glEnable(GL_BLEND);
+            pGLFunction->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            pGLFunction->glActiveTexture(GL_TEXTURE0);
+            s->tex->bind();
+            pGLFunction->glDrawArrays(GL_TRIANGLES, 0, 6);
+            s->tex->release();
+
+            prog->disableAttributeArray(nVertexLoc);
+            prog->disableAttributeArray(nCoordLoc);
+            prog->release();
+            s->vbo.release();
+            pGLFunction->glDisable(GL_BLEND);
+            pGLFunction->glBindFramebuffer(GL_FRAMEBUFFER, prevFbo);
+        }
     }
 #endif
   

--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -273,9 +273,7 @@ void MpvProxy::firstInit()
 #ifdef __x86_64__
             connect(this, &MpvProxy::elapsedChanged, [ this ]() {
                 qDebug() << "DEBUG: Elapsed time changed, updating movie progress."; // Add log for lambda
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
                 m_pMpvGLwidget->updateMovieProgress(duration(), elapsed());
-#endif
                 m_pMpvGLwidget->update();
             });
 #else

--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -915,16 +915,18 @@ MainWindow::MainWindow(QWidget *parent)
     qDebug() << "Connected PlayerEngine::finishedAddFiles signal.";
 
     //Initialization is performed at normal conditions
+    m_pProgIndicator = nullptr;
+    m_pFullScreenTimeLabel = nullptr;
     if (CompositingManager::get().platform() != Platform::Mips) {
         qDebug() << "Platform is not Mips. Initializing MovieProgressIndicator and QLabel for full screen time.";
-        m_pProgIndicator = new MovieProgressIndicator(this);
-        m_pFullScreenTimeLabel = new QLabel;
+        //m_pProgIndicator = new MovieProgressIndicator(this);
+        //m_pFullScreenTimeLabel = new QLabel;
         qDebug() << "MovieProgressIndicator and QLabel initialized.";
     } else {
         qDebug() << "Platform is Mips. Skipping MovieProgressIndicator and QLabel initialization.";
     }
 
-    if (m_pProgIndicator) {
+    if (m_pProgIndicator && m_pFullScreenTimeLabel) {
         qDebug() << "MovieProgressIndicator is valid. Setting visibility and connecting elapsedChanged.";
         m_pProgIndicator->setVisible(false);
         connect(m_pEngine, &PlayerEngine::elapsedChanged, [ = ]() {
@@ -998,7 +1000,7 @@ MainWindow::MainWindow(QWidget *parent)
         if (m_pEngine->state() == PlayerEngine::CoreState::Idle) {
             qInfo() << "Player entered idle state";
             //播放切换时，更新音量dbus 当前的sinkInputPath
-            if (m_pProgIndicator) {
+            if (m_pProgIndicator && m_pFullScreenTimeLabel) {
                 qDebug() << "Player idle: Hiding full screen time label and progress indicator.";
                 m_pFullScreenTimeLabel->close();
                 m_pProgIndicator->setVisible(false);
@@ -1210,7 +1212,7 @@ MainWindow::MainWindow(QWidget *parent)
             setProperty("showTimeFullScreen", value);
             //The X86 platform draws on GiWidget, and the MIPS platform does not need to draw
             if (CompositingManager::get().platform() == Platform::Arm64 || CompositingManager::get().platform() == Platform::Alpha) {
-                if(m_pEngine && (m_pEngine->state() != PlayerEngine::Idle) && isFullScreen()) {
+                if(m_pEngine && (m_pEngine->state() != PlayerEngine::Idle) && isFullScreen() && m_pProgIndicator && m_pFullScreenTimeLabel) {
                     m_pProgIndicator->setVisible(value.toBool());
                     m_pFullScreenTimeLabel->setVisible(value.toBool());
                 }
@@ -1399,7 +1401,8 @@ void MainWindow::onWindowStateChanged()
         if (m_bShowTime) {
             bool showIndicator = isFullScreen() && m_pEngine && m_pEngine->state() != PlayerEngine::Idle;
             qDebug() << "Setting progress indicator visibility:" << showIndicator;
-            m_pProgIndicator->setVisible(showIndicator);
+            if (m_pProgIndicator)
+                m_pProgIndicator->setVisible(showIndicator);
         }
     }
 
@@ -2566,10 +2569,12 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
 #endif
                         qDebug() << "pixelsWidth";
                         pixelsWidth = qMax(117, pixelsWidth);
-                        m_pFullScreenTimeLabel->setGeometry(deskRect.width() - pixelsWidth - 60, 40, pixelsWidth + 60, 36);
-                        qDebug() << "m_pFullScreenTimeLabel->setGeometry";
-                        if(m_bShowTime) {
-                            m_pFullScreenTimeLabel->show();
+                        if (m_pFullScreenTimeLabel) {
+                            m_pFullScreenTimeLabel->setGeometry(deskRect.width() - pixelsWidth - 60, 40, pixelsWidth + 60, 36);
+                            qDebug() << "m_pFullScreenTimeLabel->setGeometry";
+                            if(m_bShowTime) {
+                                m_pFullScreenTimeLabel->show();
+                            }
                         }
                     }
                 }
@@ -4032,7 +4037,7 @@ void MainWindow::slotFocusWindowChanged()
 {
 #ifndef __mips__
     PlayerEngine *engine = dynamic_cast<PlayerEngine *>(sender());
-    if (engine) {
+    if (engine && m_pProgIndicator) {
         m_pProgIndicator->updateMovieProgress(engine->duration(), engine->elapsed());
     }
 #endif
@@ -4098,7 +4103,8 @@ void MainWindow::slotFontChanged(const QFont &/*font*/)
     QRect deskRect = qApp->primaryScreen()->availableGeometry();
 #endif
     qDebug() << "deskRect";
-    m_pFullScreenTimeLabel->setGeometry(deskRect.width() - pixelsWidth - 32, 40, pixelsWidth + 32, 36);
+    if (m_pFullScreenTimeLabel)
+        m_pFullScreenTimeLabel->setGeometry(deskRect.width() - pixelsWidth - 32, 40, pixelsWidth + 32, 36);
 #endif
 }
 
@@ -5425,9 +5431,11 @@ void MainWindow::toggleUIMode()
                     QRect deskRect = qApp->primaryScreen()->availableGeometry();
 #endif
                     pixelsWidth = qMax(117, pixelsWidth);
-                    m_pFullScreenTimeLabel->setGeometry(deskRect.width() - pixelsWidth - 60, 40, pixelsWidth + 60, 36);
-                    if(m_bShowTime) {
-                        m_pFullScreenTimeLabel->show();
+                    if (m_pFullScreenTimeLabel) {
+                        m_pFullScreenTimeLabel->setGeometry(deskRect.width() - pixelsWidth - 60, 40, pixelsWidth + 60, 36);
+                        if(m_bShowTime) {
+                            m_pFullScreenTimeLabel->show();
+                        }
                     }
                 }
             }

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -938,11 +938,14 @@ Platform_MainWindow::Platform_MainWindow(QWidget *parent)
 
     //In the case of Platform, this is currently not initialized in the case of
     //MIPS, followed by the situation, and the code is subsequently removed by judging the macro.
+    m_pProgIndicator = nullptr;
+    m_pFullScreenTimeLabel = nullptr;
     if (CompositingManager::get().platform() != Platform::Mips) {
         qDebug() << "CompositingManager::get().platform() != Platform::Mips";
-        m_pProgIndicator = new Platform_MovieProgressIndicator(this);
-        m_pFullScreenTimeLabel = new QLabel;
-
+        //m_pProgIndicator = new Platform_MovieProgressIndicator(this);
+        //m_pFullScreenTimeLabel = new QLabel;
+    }
+    if (m_pProgIndicator && m_pFullScreenTimeLabel) {
         m_pProgIndicator->setVisible(false);
         connect(m_pEngine, &PlayerEngine::elapsedChanged, [ = ]() {
             m_pProgIndicator->updateMovieProgress(m_pEngine->duration(), m_pEngine->elapsed());
@@ -1012,7 +1015,7 @@ Platform_MainWindow::Platform_MainWindow(QWidget *parent)
             qDebug() << "m_pProgIndicator";
             if (m_pEngine->state() == PlayerEngine::CoreState::Idle) {
                 //播放切换时，更新音量dbus 当前的sinkInputPath
-                if (m_pProgIndicator) {
+                if (m_pProgIndicator && m_pFullScreenTimeLabel) {
                     qDebug() << "m_pProgIndicator";
                     m_pFullScreenTimeLabel->close();
                     m_pProgIndicator->setVisible(false);
@@ -1031,11 +1034,13 @@ Platform_MainWindow::Platform_MainWindow(QWidget *parent)
                     QRect screenGeo = windowHandle()->screen()->geometry();
                     int pixelsWidth = m_pToolbox->getfullscreentimeLabel()->width() + m_pToolbox->getfullscreentimeLabelend()->width();
                     pixelsWidth = qMax(117, pixelsWidth);
-                    m_pFullScreenTimeLabel->setGeometry(screenGeo.width() + screenGeo.x() - pixelsWidth - 60, 40 + screenGeo.y(), pixelsWidth + 60, 36);
-                    qDebug() << "m_pFullScreenTimeLabel->setGeometry";
-                    if(m_bShowTime) {
-                        m_pFullScreenTimeLabel->show();
-                        m_pProgIndicator->setVisible(true);
+                    if (m_pFullScreenTimeLabel) {
+                        m_pFullScreenTimeLabel->setGeometry(screenGeo.width() + screenGeo.x() - pixelsWidth - 60, 40 + screenGeo.y(), pixelsWidth + 60, 36);
+                        qDebug() << "m_pFullScreenTimeLabel->setGeometry";
+                        if(m_bShowTime) {
+                            m_pFullScreenTimeLabel->show();
+                            m_pProgIndicator->setVisible(true);
+                        }
                     }
                     QTimer::singleShot(200, [ = ]() {
                         activateWindow();    // show other window make mainwindow deactivate
@@ -1267,7 +1272,7 @@ Platform_MainWindow::Platform_MainWindow(QWidget *parent)
             m_bShowTime = value.toBool();
             //The X86 platform draws on GiWidget, and the MIPS platform does not need to draw
             if (CompositingManager::get().platform() != Platform::Mips) {
-                if(m_pEngine && (m_pEngine->state() != PlayerEngine::Idle) && isFullScreen()) {
+                if(m_pEngine && (m_pEngine->state() != PlayerEngine::Idle) && isFullScreen() && m_pProgIndicator && m_pFullScreenTimeLabel) {
                     m_pProgIndicator->setVisible(value.toBool());
                     m_pFullScreenTimeLabel->setVisible(value.toBool());
                 }
@@ -1474,7 +1479,7 @@ void Platform_MainWindow::onWindowStateChanged()
         m_pTitlebar->setVisible(false);
     }
     if (CompositingManager::get().platform() != Platform::Mips) {
-        if (m_bShowTime) {
+        if (m_bShowTime && m_pProgIndicator) {
             m_pProgIndicator->setVisible(isFullScreen() && m_pEngine && m_pEngine->state() != PlayerEngine::Idle);
         }
     }
@@ -2605,7 +2610,7 @@ void Platform_MainWindow::requestAction(ActionFactory::ActionKind actionKind, bo
                 QRect screenGeo = windowHandle()->screen()->geometry();
                 m_pProgIndicator->move(screenGeo.width() + screenGeo.x() - m_pProgIndicator->width() - 18, 8 + screenGeo.y());
                 if (CompositingManager::get().platform() != Platform::Mips) {
-                    if (m_pEngine->state() != PlayerEngine::CoreState::Idle) {
+                    if (m_pEngine->state() != PlayerEngine::CoreState::Idle && m_pFullScreenTimeLabel) {
                         int pixelsWidth = m_pToolbox->getfullscreentimeLabel()->width() + m_pToolbox->getfullscreentimeLabelend()->width();
                         pixelsWidth = qMax(117, pixelsWidth);
                         m_pFullScreenTimeLabel->setGeometry(screenGeo.width() + screenGeo.x() - pixelsWidth - 60, 40 + screenGeo.y(), pixelsWidth + 60, 36);
@@ -4072,7 +4077,7 @@ void Platform_MainWindow::slotFocusWindowChanged()
 {
 #ifndef __mips__
     PlayerEngine *engine = dynamic_cast<PlayerEngine *>(sender());
-    if (engine) {
+    if (engine && m_pProgIndicator) {
         m_pProgIndicator->updateMovieProgress(engine->duration(), engine->elapsed());
     }
 #endif
@@ -4123,7 +4128,8 @@ void Platform_MainWindow::slotFontChanged(const QFont &/*font*/)
 #else
         QRect deskRect = QGuiApplication::primaryScreen()->availableGeometry();
 #endif
-        m_pFullScreenTimeLabel->setGeometry(deskRect.width() - pixelsWidth - 32, 40, pixelsWidth + 32, 36);
+        if (m_pFullScreenTimeLabel)
+            m_pFullScreenTimeLabel->setGeometry(deskRect.width() - pixelsWidth - 32, 40, pixelsWidth + 32, 36);
     }
     qDebug() << "Exit slotFontChanged function";
 }


### PR DESCRIPTION
Replace QPainter-on-GL-widget approach with offscreen QImage → GL texture overlay to avoid glyph-cache corruption causing black frames. Disable Qt widget controls (MovieProgressIndicator, QLabel) since the GL overlay now handles all fullscreen time rendering. Enable updateMovieProgress() for Qt6 by removing the version guard.

用离屏QImage绘制全屏右上角叠加内容再上传为GL纹理，避免
QPainter直接绘制到GL widget导致glyph cache破坏渲染状态。
禁用Qt控件（MovieProgressIndicator、QLabel），改用GL overlay 渲染全屏时间。移除Qt6版本守卫，启用updateMovieProgress。

Log: 全屏时间显示改为GL纹理叠加，避免黑屏
PMS: BUG-362115
Influence: 全屏时右上角时间/进度/视频时长改为GL纹理渲染，不再依赖Qt控件窗口，
避免QPainter破坏mpv GL状态导致画面变黑。