### PR TITLE
fix: enable cpp17 for mpris try_compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,11 +49,12 @@ try_compile(USE_FORK_MPRIS
               ${CMAKE_CURRENT_SOURCE_DIR}/tests/mpris_test.cc
             LINK_LIBRARIES
               PkgConfig::MPRIS
+            CXX_STANDARD 17
             OUTPUT_VARIABLE TRY_COMPILE_OUTPUT
 )
 
 # 输出是否使用deepin fork的mpris-qt5
-#message(STATUS "use deepin fork mpris-qt5: ${USE_FORK_MPRIS}")
+message(STATUS "use deepin fork mpris-qt5: ${USE_FORK_MPRIS}")
 
 # 如果使用deepin fork的mpris-qt5，添加编译定义
 if(USE_FORK_MPRIS)


### PR DESCRIPTION
Add CXX_STANDARD 17 to try_compile command for proper compilation. Enable message output for MPRIS fork detection.

添加 C++17 标准到 try_compile 命令以确保正确编译。
启用 MPRIS fork 检测的消息输出。

Log: 修复 MPRIS 编译标准问题
PMS: BUG-361321
Influence: 修复后 MPRIS 相关功能可以正常编译，解决编译失败问题。