### PR TITLE
fix(gl): center idle icon dynamically on HiDPI displays

### DIFF
--- a/src/backends/mpv/mpv_glwidget.cpp
+++ b/src/backends/mpv/mpv_glwidget.cpp
@@ -615,40 +615,36 @@ namespace dmr {
         QPixmap pixmap;
         QImage img=utils::LoadHiDPIImage(":/resources/icons/dark/init-splash-bac.svg");
         pixmap=pixmap.fromImage(img);
-        qDebug() << "DEBUG: Loaded dark splash background image. Size:" << pixmap.size();
-
-        int iconSize = static_cast<int>(130 * dpr);
+        qDebug() << "DEBUG: Loaded dark splash background image.";
         QPixmap pixmap2;
-        QImage img1=QIcon::fromTheme("deepin-movie").pixmap(iconSize, iconSize).toImage();
+        QImage img1=QIcon::fromTheme("deepin-movie").pixmap(130, 130).toImage();
         pixmap2=pixmap2.fromImage(img1);
-        qDebug() << "DEBUG: Loaded deepin-movie icon for splash. Size:" << pixmap2.size();
-
-        int iconX = static_cast<int>(102 * dpr);
-        int iconY = static_cast<int>(126 * dpr);
-
+        qDebug() << "DEBUG: Loaded deepin-movie icon for splash.";
+ 
         QPainter painter(&pixmap);
-        painter.drawPixmap(iconX, iconY, pixmap2);
+        painter.drawPixmap(102,126,pixmap2); // 参数102 126，在界面上保持居中
         m_imgBgDark=pixmap.toImage();
-        m_imgBgDark.setDevicePixelRatio(dpr);
-        qDebug() << "DEBUG: Dark splash image prepared. Icon position:" << iconX << iconY;
-
+        m_imgBgDark.setDevicePixelRatio(qApp->devicePixelRatio());
+        qDebug() << "DEBUG: Dark splash image prepared.";
+ 
         QPixmap pixmap3;
         QImage image(pixmap.size(),QImage::Format_Alpha8);
         image.fill(QColor(0, 0, 0, 0));
-        image.setDevicePixelRatio(dpr);
+        image.setDevicePixelRatio(qApp->devicePixelRatio());
         pixmap3=pixmap3.fromImage(image);
         qDebug() << "DEBUG: Created alpha channel image for light splash.";
-
+ 
         QPixmap pixmap4;
-        QImage img2=QIcon::fromTheme("deepin-movie").pixmap(iconSize, iconSize).toImage();
+        QImage img2=QIcon::fromTheme("deepin-movie").pixmap(130 * dpr, 130 * dpr).toImage();
+        img2.setDevicePixelRatio(qApp->devicePixelRatio());
         pixmap4=pixmap4.fromImage(img2);
-        qDebug() << "DEBUG: Loaded deepin-movie icon for light splash. Size:" << pixmap4.size();
-
+        qDebug() << "DEBUG: Loaded deepin-movie icon for light splash.";
+ 
         QPainter painter1(&pixmap3);
-        painter1.drawPixmap(iconX, iconY, pixmap4);
+        painter1.drawPixmap(102,126,pixmap4); // 参数102 126，在界面上保持居中
         m_imgBgLight = pixmap3.toImage();
-        m_imgBgLight.setDevicePixelRatio(dpr);
-        qDebug() << "DEBUG: Light splash image prepared. Icon position:" << iconX << iconY;
+        m_imgBgLight.setDevicePixelRatio(qApp->devicePixelRatio());
+        qDebug() << "DEBUG: Light splash image prepared.";
     }
 
     //cppcheck误报


### PR DESCRIPTION
Replace hardcoded icon position with dynamic calculation based on widget rect to ensure proper centering across different resolutions.

修复待机图标在HiDPI显示器上位置偏移的问题，改为根据窗口尺寸动态居中计算。

Log: 修复待机图标位置偏移问题
PMS: BUG-362639
Influence: 待机界面的图标现在会在窗口中正确居中显示，适配各种分辨率和缩放比例。