### PR TITLE
fix(gl): use GL texture overlay for fullscreen time display

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -270,15 +270,13 @@ void MpvProxy::firstInit()
             qInfo() << "Creating MPV GL widget";
             m_pMpvGLwidget = new MpvGLWidget(this, m_handle);
             connect(this, &MpvProxy::stateChanged, this, &MpvProxy::slotStateChanged);
-#ifdef __x86_64__
             connect(this, &MpvProxy::elapsedChanged, [ this ]() {
-                qDebug() << "DEBUG: Elapsed time changed, updating movie progress."; // Add log for lambda
                 m_pMpvGLwidget->updateMovieProgress(duration(), elapsed());
-                m_pMpvGLwidget->update();
+                QWidget *top = m_pMpvGLwidget->topLevelWidget();
+                QVariant v = top ? top->property("showTimeFullScreen") : QVariant();
+                if (top && top->isFullScreen() && v.isValid() && v.toBool())
+                    m_pMpvGLwidget->update();
             });
-#else
-            qDebug() << "DEBUG: Skipping elapsedChanged connection for non-x86_64."; // Log for skipped connection
-#endif
 #if defined(USE_DXCB)
             qDebug() << "DEBUG: USE_DXCB defined. Toggling rounded clip to false."; // Log for DXCB
             m_pMpvGLwidget->toggleRoundedClip(false);


### PR DESCRIPTION
Remove x86_64 guard from elapsedChanged connect so ARM platforms also update movie progress. Only trigger GL redraw when fullscreen and showTimeFullScreen property is enabled.

去掉elapsedChanged的x86_64限制，ARM也能更新进度；
仅在全屏且showTimeFullScreen开启时触发GL重绘。

Log: 去掉mpv_proxy中elapsedChanged的x86限制
PMS: BUG-362115
Influence: ARM平台全屏时也能显示视频进度时间，非全屏时不再无意义重绘。