### PR TITLE
chore: Update version to 6.5.48

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+deepin-movie-reborn (6.5.48) unstable; urgency=medium
+
+  * chore: Update version to 6.5.48
+  * fix(gl): center idle icon dynamically on HiDPI displays
+  * fix(gl): use GL texture overlay for fullscreen time display
+  * fix(gl): remove x86_64 guard from fullscreen overlay
+  * fix(gl): use GL texture overlay for fullscreen time display
+  * fix: enable cpp17 for mpris try_compile
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 28 May 2026 19:48:43 +0800
+
 deepin-movie-reborn (6.5.47) unstable; urgency=medium
 
   * chore: Update version to 6.5.47

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.47.1
+  version: 6.5.48.1
   kind: app
   description: |
     movie for deepin os.


### PR DESCRIPTION
- update version to 6.5.48

log: update version to 6.5.48

## Summary by Sourcery

Bump the application version metadata to 6.5.48.1 across packaging files.

Build:
- Update linglong package manifest to version 6.5.48.1.

Chores:
- Update Debian changelog to reflect the 6.5.48 release.