### PR TITLE
fix: use software decoding for YUV422P format on Wayland

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,11 @@ debian/deepin-movie-reborn/
 debian/files
 
 CMakeLists.txt.user
+
+# ai
+CLAUDE.md
+AGENTS.md
+.cursor
+.trellis
+.claude
+.agents

--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
+// Copyright (C) 2020 ~ 2026, Deepin Technology Co., Ltd. <support@deepin.org>
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -1381,9 +1381,8 @@ void MpvProxy::refreshDecode()
             }
 #endif
             if(utils::check_wayland_env()){
-                PlaylistModel *playMode = dynamic_cast<PlayerEngine *>(m_pParentWidget)->getplaylist();
-                QVariant varPixfmt = playMode->property(currentInfo.mi.filePath.toUtf8());
-                if(varPixfmt.isValid() && varPixfmt.toInt() == AV_PIX_FMT_YUV444P) {
+                if (currentInfo.mi.pix_fmt == AV_PIX_FMT_YUV444P
+                        || currentInfo.mi.pix_fmt == AV_PIX_FMT_YUV422P) {
                     isSoftCodec = true;
                     qWarning() << "Using SoftCodec because of format";
                 }
@@ -1393,7 +1392,6 @@ void MpvProxy::refreshDecode()
                         codec.toLower().contains("hevc")  ||
                         codec.toLower().contains("vp")) {
                     my_set_property(m_handle, "hwdec-codecs", codec.toLower());
-                    isSoftCodec = false;
                 }
             }
         }
@@ -1525,8 +1523,8 @@ void MpvProxy::refreshDecode()
         PlaylistModel *playMode = dynamic_cast<PlayerEngine *>(m_pParentWidget)->getplaylist();
         PlayItemInfo currentInfo = playMode->currentInfo();
         if(utils::check_wayland_env()){
-            QVariant varPixfmt = playMode->property(currentInfo.mi.filePath.toUtf8());
-            if(varPixfmt.isValid() && varPixfmt.toInt() == AV_PIX_FMT_YUV444P) {
+            if (currentInfo.mi.pix_fmt == AV_PIX_FMT_YUV444P
+                    || currentInfo.mi.pix_fmt == AV_PIX_FMT_YUV422P) {
                 qWarning() << "Using SoftCodec because of format";
                 my_set_property(m_handle, "hwdec","no");
             }

--- a/src/libdmr/playlist_model.cpp
+++ b/src/libdmr/playlist_model.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
+// Copyright (C) 2020 ~ 2026, Deepin Technology Co., Ltd. <support@deepin.org>
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -100,6 +100,7 @@ QDataStream &operator<< (QDataStream &st, const MovieInfo &mi)
     st << mi.aDigit;
     st << mi.channels;
     st << mi.sampling;
+    st << mi.pix_fmt;
 #ifdef _MOVIE_USE_
     st << mi.strFmtName;
 #endif
@@ -128,6 +129,7 @@ QDataStream &operator>> (QDataStream &st, MovieInfo &mi)
     st >> mi.aDigit;
     st >> mi.channels;
     st >> mi.sampling;
+    st >> mi.pix_fmt;
 #ifdef _MOVIE_USE_
     st >> mi.strFmtName;
 #endif
@@ -137,7 +139,7 @@ QDataStream &operator>> (QDataStream &st, MovieInfo &mi)
 static class PersistentManager *_persistentManager = nullptr;
 
 static const qint32 CACHE_MAGIC = 0x444D5243;  // "DMRC" (Deepin Movie Replay Cache)
-static const qint32 CACHE_VERSION = 2;  // v2: lastModified
+static const qint32 CACHE_VERSION = 3;  // v3: pix_fmt
 
 static QString hashUrl(const QUrl &url)
 {
@@ -437,14 +439,7 @@ struct MovieInfo PlaylistModel::parseFromFile(const QFileInfo &fi, bool *ok)
         } else {
             mi.proportion = 0;
         }
-        AVCodecContext *codec_context = g_mvideo_avcodec_alloc_context3(NULL);
-        g_mvideo_avcodec_parameters_to_context(codec_context, video_dec_ctx);
-        AVCodec *videoCodec = g_mvideo_avcodec_find_decoder(video_dec_ctx->codec_id);
-        if (g_mvideo_avcodec_open2(codec_context, videoCodec, 0) > 0) {
-            //用唯一的文件名绑定对应视频的对应pix_fmt值
-            setProperty(fi.filePath().toUtf8(), codec_context->pix_fmt);
-        }
-        g_mvideo_avcodec_free_context(&codec_context);
+        mi.pix_fmt = video_dec_ctx->format;
     }
     if (audioRet >= 0) {
         int audio_stream_index = -1;

--- a/src/libdmr/playlist_model.h
+++ b/src/libdmr/playlist_model.h
@@ -1,3 +1,4 @@
+// Copyright (C) 2020 ~ 2026, Deepin Technology Co., Ltd. <support@deepin.org>
 // SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -47,6 +48,7 @@ struct MovieInfo {
     int aDigit;
     int channels;
     int sampling;
+    int pix_fmt;
 #ifdef _MOVIE_USE_
     QString strFmtName; // 文件封装名
 #endif
@@ -66,6 +68,7 @@ struct MovieInfo {
         aDigit = -1;
         channels = -1;
         sampling = -1;
+        pix_fmt = -1;
     }
 
     static struct MovieInfo parseFromFile(const QFileInfo &fi, bool *ok = nullptr);


### PR DESCRIPTION
Hardware decoders may not support 4:2:2 chroma subsampling,
causing playback to hang with continuous decode errors.

log: fix bug

Bug: https://pms.uniontech.com/bug-view-363493.html

## Summary by Sourcery

Bug Fixes:
- Force software decoding for YUV422P pixel format on Wayland to prevent decode errors and hanging playback alongside the existing YUV444P handling.