### PR TITLE
fix: prevent focus stealing on auto-advance in fullscreen mode

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -908,8 +908,10 @@ Platform_MainWindow::Platform_MainWindow(QWidget *parent)
                         m_pProgIndicator->setVisible(true);
                     }
                     QTimer::singleShot(200, [ = ]() {
-                        activateWindow();    // show other window make mainwindow deactivate
-                        setFocus();
+                        if (qApp->applicationState() == Qt::ApplicationActive) {
+                            activateWindow();    // show other window make mainwindow deactivate
+                            setFocus();
+                        }
                     });
                 }
             }


### PR DESCRIPTION
When auto-advancing to the next video in fullscreen while the user is working in another application, Platform_MainWindow calls ctivateWindow() unconditionally on every state transition to Playing, stealing focus from the foreground app. Guard the activateWindow() call with qApp->applicationState() == Qt::ApplicationActive, so focus is only restored when the player window is already the active window. This preserves the original intent of keeping focus during normal playback while avoiding disruption when the user has switched to another application.

log: fix bug

Bug: https://pms.uniontech.com/bug-view-364487.html