### PR TITLE
chore: update chatops check workflow to inherit secrets

### DIFF
--- a/.github/workflows/call-chatOps.yml
+++ b/.github/workflows/call-chatOps.yml
@@ -6,5 +6,4 @@ on:
 jobs:
   chatopt:
     uses: linuxdeepin/.github/.github/workflows/chatOps.yml@master
-    secrets:
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+    secrets: inherit


### PR DESCRIPTION
Log: build

## Summary by Sourcery

Build:
- Configure the call-chatOps GitHub Actions workflow to use `secrets: inherit` when invoking the shared chatOps workflow.