### PR TITLE
fix(security): harden QProcess usage against command injection

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -586,13 +586,14 @@ mpv_handle *MpvProxy::mpv_init()
         if (CompositingManager::get().isZXIntgraphics() && !jmflag) {
             qDebug() << "DEBUG: ZXIntgraphics detected and no Jingjiawei driver. Checking apt policy.";
             QProcess process;
-            QStringList options;
-            options << "-c" << QString("apt policy cx4-linux-graphics-driver-dri | sed -n \'2p\'");
-            process.start("/bin/bash", options);
+            process.start("apt", QStringList{"policy", "cx4-linux-graphics-driver-dri"});
             process.waitForFinished();
             process.waitForReadyRead();
 
             QString comStr = process.readAllStandardOutput();
+            // Extract the version number from the second line of apt policy output
+            QStringList outputLines = comStr.split('\n');
+            comStr = (outputLines.size() >= 2) ? outputLines.at(1) : QString();
             comStr = comStr.right(3).left(2);
             int version = comStr.toInt();
             qDebug() << "DEBUG: apt policy output version:" << version;

--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -4925,7 +4925,19 @@ void MainWindow::contextMenuEvent(QContextMenuEvent *pEvent)
     } else {
         qDebug() << "!utils::check_wayland_env()";
         //通过窗口id查询窗口状态是否置顶，同步右键菜单中的选项状态
-        QStringList sResult = dmr::utils::runPipeProcess(QString("xprop -id %1").arg(winId()), "_NET_WM_STATE(ATOM)");
+        QProcess xpropProc;
+        xpropProc.start("xprop", QStringList{"-id", QString::number(winId())});
+        xpropProc.waitForFinished();
+        QString xpropOutput = xpropProc.readAllStandardOutput();
+        QStringList sResult = xpropOutput.split('\n');
+        // Filter lines containing _NET_WM_STATE(ATOM)
+        QStringList filtered;
+        for (const QString &line : sResult) {
+            if (line.contains("_NET_WM_STATE(ATOM)")) {
+                filtered.append(line);
+            }
+        }
+        sResult = filtered;
         foreach (QString drv, sResult) {
             if (drv.contains("_NET_WM_STATE_ABOVE") != m_bWindowAbove) {
                 m_bWindowAbove = drv.contains("_NET_WM_STATE_ABOVE");

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -4982,7 +4982,19 @@ void Platform_MainWindow::contextMenuEvent(QContextMenuEvent *pEvent)
     }
 
     //通过窗口id查询窗口状态是否置顶，同步右键菜单中的选项状态
-    QStringList sList = dmr::utils::runPipeProcess(QString("xprop -id %1").arg(winId()), "_NET_WM_STATE(ATOM)");
+    QProcess xpropProc;
+    xpropProc.start("xprop", QStringList{"-id", QString::number(winId())});
+    xpropProc.waitForFinished();
+    QString xpropOutput = xpropProc.readAllStandardOutput();
+    QStringList sList = xpropOutput.split('\n');
+    // Filter lines containing _NET_WM_STATE(ATOM)
+    QStringList filtered;
+    for (const QString &line : sList) {
+        if (line.contains("_NET_WM_STATE(ATOM)")) {
+            filtered.append(line);
+        }
+    }
+    sList = filtered;
     foreach(QString drv, sList) {
         if (drv.contains("_NET_WM_STATE_ABOVE") != m_bWindowAbove) {
             m_bWindowAbove = drv.contains("_NET_WM_STATE_ABOVE");

--- a/src/libdmr/compositing_manager.cpp
+++ b/src/libdmr/compositing_manager.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2020 ~ 2026, Deepin Technology Co., Ltd. <support@deepin.org>
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -771,7 +771,7 @@ void CompositingManager::detectPciID()
     qDebug() << "Entering CompositingManager::detectPciID()";
     QProcess pcicheck;
     qDebug() << "Starting lspci -vn process.";
-    pcicheck.start("lspci -vn");
+    pcicheck.start("lspci", QStringList{"-vn"});
     if (pcicheck.waitForStarted() && pcicheck.waitForFinished()) {
         qDebug() << "lspci -vn process started and finished successfully.";
 

--- a/src/libdmr/utils.cpp
+++ b/src/libdmr/utils.cpp
@@ -37,6 +37,14 @@ QStringList runPipeProcess(const QString &command, const QString &filter)
         return QStringList();
 
     QString cmd = parms.takeFirst();
+
+    // Reject commands containing shell metacharacters to prevent injection.
+    // Use QProcess::start(program, args) directly for proper argument separation.
+    if (command.contains(QRegularExpression("[|;&$`\\\\]"))) {
+        qWarning() << "runPipeProcess: rejected potentially unsafe command:" << command;
+        return QStringList();
+    }
+
     process.start(cmd, parms);
     process.waitForFinished();
 

--- a/src/widgets/toolbox_proxy.cpp
+++ b/src/widgets/toolbox_proxy.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -983,7 +983,16 @@ void viewProgBarLoad::loadViewProgBar(QSize size)
     bool command = false;
     if(m_pEngine->duration() < 300) {
         qDebug() << "m_pEngine->duration() < 300";
-        QStringList sList = dmr::utils::runPipeProcess(QString("ffprobe -v quiet -show_frames %1").arg(url.toLocalFile()), "pict_type=I");
+        QProcess ffprobeProc;
+        ffprobeProc.start("ffprobe", QStringList{"-v", "quiet", "-show_frames", url.toLocalFile()});
+        ffprobeProc.waitForFinished();
+        QString ffprobeOutput = ffprobeProc.readAllStandardOutput();
+        QStringList sList;
+        for (const QString &line : ffprobeOutput.split('\n')) {
+            if (line.contains("pict_type=I")) {
+                sList.append(line);
+            }
+        }
         int pictI = sList.count();
         if (pictI < 5)
             command = true;


### PR DESCRIPTION
Replace unsafe QProcess patterns with safe argument-separated calls:
- Use start(program, args) instead of start("cmd args") to avoid implicit shell-like splitting
- Replace /bin/bash -c invocations with direct program calls
- Add shell metacharacter guard to runPipeProcess() to block potential future injection via |;&$`\\ metacharacters
- Eliminate QString::arg() command concatenation in xprop/ffprobe calls, use proper QStringList argument separation instead

消除 QProcess 不安全调用方式，防范命令注入风险：
- 使用 start(program, args) 代替 start("cmd args") 避免隐式拆分
- 用直接调用替代 /bin/bash -c 执行 shell 命令
- 为 runPipeProcess() 添加 shell 元字符检测，阻止潜在注入
- 消除 xprop/ffprobe 调用中的 QString::arg() 字符串拼接

Log: 修复 QProcess 命令注入安全风险
Influence: 提升播放器安全性，消除外部输入通过 shell 执行的风险