### PR TITLE
chore(linglong): move pciutils and mesa-utils to runtime deps

### DIFF
--- a/linglong.yaml
+++ b/linglong.yaml
@@ -20,7 +20,7 @@ command:
 
 build: |
   # 下载和安装依赖
-  apt -y install --download-only libmpv-dev libxcb1-dev libxcb-util0-dev libffmpegthumbnailer-dev libxcb-shape0-dev libxcb-ewmh-dev xcb-proto x11proto-record-dev x11-utils libxtst-dev libavcodec-dev libavformat-dev libavutil-dev libpulse-dev libdvdnav-dev libgsettings-qt-dev libva-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev qt6-base-dev qt6-base-dev-tools qt6-base-private-dev qt6-l10n-tools qt6-svg-dev qt6-tools-dev-tools qt6-tools-dev qt6-multimedia-dev libqt6sql6-sqlite libmpris-qt6-dev libqt6opengl6-dev libdtk6gui-dev libdtk6widget-dev libdtk6core-dev libgpuinfo deepin-event-log pciutils mesa-utils
+  apt -y install --download-only libmpv-dev libxcb1-dev libxcb-util0-dev libffmpegthumbnailer-dev libxcb-shape0-dev libxcb-ewmh-dev xcb-proto x11proto-record-dev x11-utils libxtst-dev libavcodec-dev libavformat-dev libavutil-dev libpulse-dev libdvdnav-dev libgsettings-qt-dev libva-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev qt6-base-dev qt6-base-dev-tools qt6-base-private-dev qt6-l10n-tools qt6-svg-dev qt6-tools-dev-tools qt6-tools-dev qt6-multimedia-dev libqt6sql6-sqlite libmpris-qt6-dev libqt6opengl6-dev libdtk6gui-dev libdtk6widget-dev libdtk6core-dev libgpuinfo deepin-event-log
   # libxcb1-dev：解决构建失败
   bash ./install_dep /var/cache/apt/archives "$PREFIX" "libxcb1-dev"
 
@@ -77,4 +77,4 @@ buildext:
     build_depends:
       - libc6
     depends:
-      - ffmpeg
+      - ffmpeg pciutils mesa-utils


### PR DESCRIPTION
Move pciutils and mesa-utils from build stage to buildext runtime depends in linglong.yaml.

Log: 调整 linglong 运行时依赖配置
PMS: BUG-351181
Influence: pciutils 和 mesa-utils 从构建时依赖移至运行时依赖，优化玲珑包体积。

## Summary by Sourcery

Adjust linglong package dependency configuration to move certain tools from build-time to runtime dependencies.

Enhancements:
- Remove pciutils and mesa-utils from build-stage apt dependencies to reduce build-time footprint.
- Update linglong runtime (buildext) dependency configuration to include tools previously only used at build time.