### PR TITLE
fix(notification): use mapToGlobal for popup position on multi-screen…

### DIFF
--- a/src/widgets/platform/platform_notification_widget.cpp
+++ b/src/widgets/platform/platform_notification_widget.cpp
@@ -97,7 +97,7 @@ void Platform_NotificationWidget::syncPosition()
         break;
 
     case ANCHOR_NORTH_WEST:
-        move(geom.topLeft() + m_anchorPoint);
+        move(m_pMainWindow->mapToGlobal(QPoint(0, 0)) + m_anchorPoint);
         break;
 
     case ANCHOR_NONE:


### PR DESCRIPTION
… setups

  Replace geometry().topLeft() with mapToGlobal(QPoint(0,0)) in
  syncPosition() to correctly handle multi-monitor configurations
  with different DPI scaling factors.

Log: 修复双屏不同缩放下分辨率弹窗位置异常的问题
Influence: 修复后弹窗在双屏不同缩放比例下能正确定位在主窗口左上角

Bug: https://pms.uniontech.com/bug-view-365171.html

## Summary by Sourcery

Bug Fixes:
- Fix incorrect notification popup position on multi-screen configurations with different DPI scaling by basing the anchor on the main window's global top-left point.