### PR TITLE
fix(notification): include anchor offset in mapToGlobal for NORTH_WES…

### DIFF
--- a/src/widgets/platform/platform_notification_widget.cpp
+++ b/src/widgets/platform/platform_notification_widget.cpp
@@ -97,7 +97,7 @@ void Platform_NotificationWidget::syncPosition()
         break;
 
     case ANCHOR_NORTH_WEST:
-        move(m_pMainWindow->mapToGlobal(QPoint(0, 0)) + m_anchorPoint);
+        move(m_pMainWindow->mapToGlobal(QPoint(0, 0) + m_anchorPoint));
         break;
 
     case ANCHOR_NONE:


### PR DESCRIPTION
…T anchor

m_anchorPoint is a widget-local offset and must be transformed through
  mapToGlobal together with the origin point, not added as a raw
  screen-space offset afterward. On multi-screen or HiDPI setups the old
  code could misposition the popup because the offset bypassed the
  coordinate transformation.

log: fix bug

Bug: https://pms.uniontech.com/bug-view-365171.html

## Summary by Sourcery

Bug Fixes:
- Fix misaligned notification popups for north-west anchors on multi-screen or HiDPI setups by properly transforming the anchor offset to global coordinates.