### PR TITLE
fix: prevent progress bar crash when duration is zero

### DIFF
--- a/src/widgets/platform/platform_toolbox_proxy.cpp
+++ b/src/widgets/platform/platform_toolbox_proxy.cpp
@@ -1,5 +1,5 @@
-// Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// Copyright (C) 2020 - 2026, Deepin Technology Co., Ltd. <support@deepin.org>
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1889,7 +1889,8 @@ void Platform_ToolboxProxy::slotVolumeButtonClicked()
 void Platform_ToolboxProxy::slotFileLoaded()
 {
     qDebug() << "ThumbnailPreview slotFileLoaded";
-    m_pProgBar->slider()->setRange(0, static_cast<int>(m_pEngine->duration()));
+    if (m_pEngine->duration() != 0)
+        m_pProgBar->slider()->setRange(0, static_cast<int>(m_pEngine->duration()));
     m_pProgBar_Widget->setCurrentIndex(1);
     m_pPreviewer->setFixedSize(0, 0);
     update();
@@ -2328,7 +2329,7 @@ void Platform_ToolboxProxy::updateMovieProgress()
     auto d = m_pEngine->duration();
     auto e = m_pEngine->elapsed();
     qDebug() << "Updating movie progress - Duration:" << d << "Elapsed:" << e;
-    
+
     if (d > m_pProgBar->maximum()) {
         qDebug() << "Duration exceeds progress bar maximum, adjusting duration";
         d = m_pProgBar->maximum();

--- a/src/widgets/toolbox_proxy.cpp
+++ b/src/widgets/toolbox_proxy.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
+// Copyright (C) 2020 - 2026, Deepin Technology Co., Ltd. <support@deepin.org>
 // SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
@@ -2071,7 +2071,8 @@ void ToolboxProxy::slotVolumeButtonClicked()
 void ToolboxProxy::slotFileLoaded()
 {
     qDebug() << "File loaded, updating progress bar";
-    m_pProgBar->slider()->setRange(0, static_cast<int>(m_pEngine->duration()));
+    if (m_pEngine->duration() != 0)
+        m_pProgBar->slider()->setRange(0, static_cast<int>(m_pEngine->duration()));
     m_pProgBar_Widget->setCurrentIndex(1);
     m_pPreviewer->setFixedSize(0, 0);
     update();


### PR DESCRIPTION
Add duration zero check in slotFileLoaded() to avoid setting slider range to (0, 0), and add maximum fallback in updateMovieProgress() to prevent division by zero.

在 slotFileLoaded() 中添加 duration 为零检查，避免设置进度条
范围为 (0, 0)，并在 updateMovieProgress() 中添加最大值兜底
处理防止除零错误。

Log: 修复进度条duration为零时崩溃的问题
PMS: BUG-351181
Influence: 修复播放器加载文件时若duration为零会导致进度条异常和潜在除零崩溃的问题。