### PR TITLE
fix: dynamically sync progress bar range with duration

### DIFF
--- a/src/widgets/platform/platform_toolbox_proxy.cpp
+++ b/src/widgets/platform/platform_toolbox_proxy.cpp
@@ -1889,8 +1889,7 @@ void Platform_ToolboxProxy::slotVolumeButtonClicked()
 void Platform_ToolboxProxy::slotFileLoaded()
 {
     qDebug() << "ThumbnailPreview slotFileLoaded";
-    if (m_pEngine->duration() != 0)
-        m_pProgBar->slider()->setRange(0, static_cast<int>(m_pEngine->duration()));
+    m_pProgBar->slider()->setRange(0, static_cast<int>(m_pEngine->duration()));
     m_pProgBar_Widget->setCurrentIndex(1);
     m_pPreviewer->setFixedSize(0, 0);
     update();
@@ -2330,9 +2329,8 @@ void Platform_ToolboxProxy::updateMovieProgress()
     auto e = m_pEngine->elapsed();
     qDebug() << "Updating movie progress - Duration:" << d << "Elapsed:" << e;
 
-    if (d > m_pProgBar->maximum()) {
-        qDebug() << "Duration exceeds progress bar maximum, adjusting duration";
-        d = m_pProgBar->maximum();
+    if (d != m_pProgBar->maximum()) {
+        m_pProgBar->slider()->setRange(0, static_cast<int>(d));
     }
     int v = 0;
     int v2 = 0;

--- a/src/widgets/toolbox_proxy.cpp
+++ b/src/widgets/toolbox_proxy.cpp
@@ -2071,8 +2071,7 @@ void ToolboxProxy::slotVolumeButtonClicked()
 void ToolboxProxy::slotFileLoaded()
 {
     qDebug() << "File loaded, updating progress bar";
-    if (m_pEngine->duration() != 0)
-        m_pProgBar->slider()->setRange(0, static_cast<int>(m_pEngine->duration()));
+    m_pProgBar->slider()->setRange(0, static_cast<int>(m_pEngine->duration()));
     m_pProgBar_Widget->setCurrentIndex(1);
     m_pPreviewer->setFixedSize(0, 0);
     update();
@@ -2610,9 +2609,8 @@ void ToolboxProxy::updateMovieProgress()
     }
     auto d = m_pEngine->duration();
     auto e = m_pEngine->elapsed();
-    if (d > m_pProgBar->maximum()) {
-        qDebug() << "d > m_pProgBar->maximum()";
-        d = m_pProgBar->maximum();
+    if (d != m_pProgBar->maximum()) {
+        m_pProgBar->slider()->setRange(0, static_cast<int>(d));
     }
     int v = 0;
     int v2 = 0;


### PR DESCRIPTION
Remove the zero-duration guard in slotFileLoaded() and instead dynamically update the slider range in updateMovieProgress() whenever the duration differs from the current maximum. This ensures the progress bar stays in sync if duration changes during playback (e.g. streaming media).

移除 slotFileLoaded() 中的零值守卫，改为在 updateMovieProgress() 中当 duration 与当前最大值不同时动态更新滑块范围，确保播放
过程中 duration 变化时进度条保持同步。

Log: 改进进度条range动态同步机制
PMS: BUG-351181
Influence: 修复播放器加载文件时若duration为零或播放中duration变化导致进度条异常和除零崩溃的问题。

## Summary by Sourcery

Bug Fixes:
- Update the progress bar range whenever the media duration changes, including zero or dynamically updated durations, to avoid out-of-sync progress and divide-by-zero issues.