### PR TITLE
chore: Update version to 6.5.51

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-movie-reborn (6.5.51) unstable; urgency=medium
+
+  * chore: Update version to 6.5.51
+  * fix: dynamically sync progress bar range with duration
+  * fix: prevent progress bar crash when duration is zero
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Wed, 17 Jun 2026 20:54:22 +0800
+
 deepin-movie-reborn (6.5.50) unstable; urgency=medium
 
   * chore: Update version to 6.5.50

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.50.1
+  version: 6.5.51.1
   kind: app
   description: |
     movie for deepin os.


### PR DESCRIPTION
- update version to 6.5.51

log: update version to 6.5.51

## Summary by Sourcery

Chores:
- Update linglong package manifest to reference version 6.5.51.1.