### PR TITLE
fix(platform): remove 50ms delay on first volume hint display at plat…

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -3518,22 +3518,15 @@ void Platform_MainWindow::slotVolumeChanged(int nVolume)
         m_pPresenter->slotvolumeChanged();
     }
 
-    static bool firstInit = false;
+    static bool firstInit = true;
     if (!firstInit) {
-        QTimer::singleShot(50, [=](){
-            if (nVolume == 0) {
-                m_pCommHintWid->updateWithMessage(tr("Mute"));
-            } else {
-                m_pCommHintWid->updateWithMessage(tr("Volume: %1%").arg(nVolume));
-            }
-        });
-        firstInit = true;
-    } else {
         if (nVolume == 0) {
             m_pCommHintWid->updateWithMessage(tr("Mute"));
         } else {
             m_pCommHintWid->updateWithMessage(tr("Volume: %1%").arg(nVolume));
         }
+    } else {
+        firstInit = false;
     }
 }
 


### PR DESCRIPTION
…form layer

In Platform_MainWindow::slotVolumeChanged, the first invocation
  (previously delayed by 50ms) still displayed the volume hint.
  Invert the firstInit flag and swap branches so the first call
  silently initializes the flag, effectively suppressing the hint
  on initial startup

log: fix bug

Bug: https://pms.uniontech.com/bug-view-364653.html