### PR TITLE
fix: add clear playlist logic for X11 on quit

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -4360,6 +4360,16 @@ void MainWindow::closeEvent(QCloseEvent *pEvent)
         _Exit(0);
     } else {
         // X11 environment - need to exit process as well
+#ifndef _LIBDMR_
+        if (Settings::get().isSet(Settings::ClearWhenQuit)) {
+            qDebug() << "Settings::get().isSet(Settings::ClearWhenQuit) - X11";
+            m_pEngine->playlist().clearPlaylist();
+        } else {
+            qDebug() << "!Settings::get().isSet(Settings::ClearWhenQuit) - X11";
+            //persistently save current playlist
+            m_pEngine->playlist().savePlaylist();
+        }
+#endif
         DMainWindow::closeEvent(pEvent);
         m_pEngine->stop();
         QApplication::quit();


### PR DESCRIPTION
The closeEvent handler missed ClearWhenQuit check in the X11 branch, causing playlist to never be cleared when the setting was enabled on X11 desktop environments.

X11环境的closeEvent分支缺少ClearWhenQuit检查，导致启用
"退出时清空播放列表"设置后在X11环境下不生效。

Log: 修复X11环境下退出影院时清空播放列表设置不生效的问题
PMS: BUG-367505
Influence: X11环境下启用"退出时清空播放列表"设置后，退出影院时播放列表将被正确清空。

## Summary by Sourcery

Bug Fixes:
- Honor the ClearWhenQuit setting in the X11 closeEvent path so playlists are correctly cleared on quit.