### PR TITLE
chore: Update version to 6.5.52

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-movie-reborn (6.5.52) unstable; urgency=medium
+
+  * chore: Update version to 6.5.52
+  * fix: add clear playlist logic for X11 on quit
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 25 Jun 2026 20:22:54 +0800
+
 deepin-movie-reborn (6.5.51) unstable; urgency=medium
 
   * chore: Update version to 6.5.51

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.51.1
+  version: 6.5.52.1
   kind: app
   description: |
     movie for deepin os.


### PR DESCRIPTION
- update version to 6.5.52

log: update version to 6.5.52

## Summary by Sourcery

Build:
- Update packaging configuration to reference deepin-movie version 6.5.52.1.