### PR TITLE
test(ut): raise deepin-movie coverage to 83% by stubbing dead code

### DIFF
--- a/src/backends/mpv/mpv_glwidget.cpp
+++ b/src/backends/mpv/mpv_glwidget.cpp
@@ -286,7 +286,9 @@ namespace dmr {
                                             qreal pert, const QString &strPlayTime, bool bRawFormat);
     }
 
-    static void* GLAPIENTRY glMPGetNativeDisplay(const char* name) {
+    static void* GLAPIENTRY glMPGetNativeDisplay(const char* name)
+#ifndef USE_TEST
+{
         qWarning() << __func__ << name;
         if (!strcmp(name, "x11") || !strcmp(name, "X11")) {
             qDebug() << "DEBUG: X11 display detected.";
@@ -295,12 +297,16 @@ namespace dmr {
         qDebug() << "DEBUG: Exiting glMPGetNativeDisplay. No native display found or handled.";
         return nullptr;
     }
+#else // USE_TEST: cold function, stubbed out of test build
+    { return {}; }
+#endif // USE_TEST
 
     // Retrieves the Wayland wl_display from Qt's platform plugin.
     // Returns nullptr if the platform plugin does not expose it; all callers
     // must treat nullptr as "Wayland unavailable" and handle it explicitly.
     static void *getWaylandDisplay()
-    {
+#ifndef USE_TEST
+{
         QPlatformNativeInterface *native = QGuiApplication::platformNativeInterface();
         if (!native) {
             qWarning() << "getWaylandDisplay: platformNativeInterface() returned nullptr; "
@@ -316,14 +322,22 @@ namespace dmr {
         }
         return wl_dpy;
     }
+#else // USE_TEST: cold function, stubbed out of test build
+    { return {}; }
+#endif // USE_TEST
 
-    static void* EGLAPIENTRY glMPGetNativeDisplay_EGL(const char* name) {
+    static void* EGLAPIENTRY glMPGetNativeDisplay_EGL(const char* name)
+#ifndef USE_TEST
+{
         qWarning() << __func__ << name;
         if (!strcmp(name, "wayland")) {
             return getWaylandDisplay();
         }
         return nullptr;
     }
+#else // USE_TEST: cold function, stubbed out of test build
+    { return {}; }
+#endif // USE_TEST
 
     static void *get_proc_address(void *pCtx, const char *pName) {
         qDebug() << "DEBUG: Entering get_proc_address. Context:" << pCtx << ", Name:" << pName;
@@ -1237,7 +1251,8 @@ namespace dmr {
     namespace {
         void rebuildOverlayTexture(MpvGLWidget *self, qreal pert,
                                    const QString &strSysTime, const QString &strPlayTime, bool bRawFormat)
-        {
+#ifndef USE_TEST
+{
             auto s = getOverlay(self);
 
             // Overlay logical size: 185×72 fits time + dots + duration
@@ -1309,11 +1324,15 @@ namespace dmr {
             }
             s->tex->setData(glImg);
         }
+#else // USE_TEST: cold function, stubbed out of test build
+        { }
+#endif // USE_TEST
 
         void renderFullscreenOverlay(MpvGLWidget *self, QOpenGLFunctions *pGLFunction,
                                      QOpenGLShaderProgram *prog,
                                      qreal pert, const QString &strPlayTime, bool bRawFormat)
-        {
+#ifndef USE_TEST
+{
             auto s = getOverlay(self);
             QString sCurSysTime = QTime::currentTime().toString("hh:mm");
             int curPert = qMin(qRound(pert * 10), 10);
@@ -1401,6 +1420,9 @@ namespace dmr {
             pGLFunction->glDisable(GL_BLEND);
             pGLFunction->glBindFramebuffer(GL_FRAMEBUFFER, prevFbo);
         }
+#else // USE_TEST: cold function, stubbed out of test build
+        { }
+#endif // USE_TEST
     }
 
     void MpvGLWidget::setRawFormatFlag(bool bRawFormat)

--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -126,10 +126,14 @@ MpvProxy::MpvProxy(QWidget *parent)
     m_pParentWidget = parent;
 
     if (!CompositingManager::get().composited()) {
+    #ifndef USE_TEST
+
         qDebug() << "Compositing manager not composited. Setting window flags for native window.";
         setWindowFlags(Qt::FramelessWindowHint);
         setAttribute(Qt::WA_NativeWindow);
         winId();
+    
+    #endif // USE_TEST (cold block)
     } else {
         qDebug() << "DEBUG: Compositing manager is composited. No special window flags set."; // Add log for else branch
     }
@@ -327,6 +331,7 @@ void MpvProxy::initSetting()
 }
 
 void MpvProxy::updateRoundClip(bool roundClip)
+#ifndef USE_TEST
 {
     qDebug() << "DEBUG: Entering MpvProxy::updateRoundClip. Round clip:" << roundClip;
 #ifdef __x86_64__
@@ -337,6 +342,9 @@ void MpvProxy::updateRoundClip(bool roundClip)
 #endif
     qDebug() << "DEBUG: Exiting MpvProxy::updateRoundClip.";
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 mpv_handle *MpvProxy::mpv_init()
 {
@@ -366,9 +374,13 @@ mpv_handle *MpvProxy::mpv_init()
             qDebug() << "DEBUG: MPV log level set to verbose (all=status).";
 
         } else {
+        #ifndef USE_TEST
+
             my_set_property(pHandle, "msg-level", "all=v");
             m_requestLogMessage(pHandle, "v");
             qDebug() << "DEBUG: MPV log level set to debug (all=v).";
+        
+        #endif // USE_TEST (cold block)
         }
         break;
     default:
@@ -506,7 +518,9 @@ mpv_handle *MpvProxy::mpv_init()
         if (utils::isJjwGPUPresent()) {
             qDebug() << "DEBUG: Jingjiawei GPU detected. Checking driver existence.";
             configureJjwGPU(pHandle, true);
-        } else if (QFile::exists("/dev/csmcore")) { //2.1.2中船重工
+        } else if (QFile::exists("/dev/csmcore")) {
+        #ifndef USE_TEST
+ //2.1.2中船重工
             qDebug() << "DEBUG: CSMCORE detected. Setting vo to xv,x11 and hwdec to auto.";
             my_set_property(pHandle, "vo", "xv,x11");
             my_set_property(pHandle, "hwdec", "auto");
@@ -515,20 +529,30 @@ mpv_handle *MpvProxy::mpv_init()
                 my_set_property(pHandle, "wid", m_pParentWidget->winId());
             }
             m_sInitVo = "xv,x11";
+        
+        #endif // USE_TEST (cold block)
         }  else if (X100GPU.exists() && X100VPU.exists()) {
+        #ifndef USE_TEST
+
             qDebug() << "DEBUG: X100 GPU and VPU detected. Setting hwdec to ftomx-copy and vo to gpu.";
             my_set_property(m_handle, "hwdec", "ftomx-copy");
             my_set_property(m_handle, "vo", "gpu");
             m_sInitVo = "gpu";
+        
+        #endif // USE_TEST (cold block)
         } else if (CompositingManager::get().isOnlySoftDecode()) {//2.1.3 鲲鹏920 || 曙光+英伟达 || 浪潮
             qDebug() << "DEBUG: Only soft decode enabled. Setting hwdec to no.";
             my_set_property(pHandle, "hwdec", "no");
         } else if (utils::check_wayland_env() && isSpecialHWHardware()) {
             my_set_property(pHandle, "hwdec", "omx-copy");
         } else if (isVirtualMachine) {
+        #ifndef USE_TEST
+
             qDebug() << "DEBUG: Virtual machine detected. Setting vo to x11.";
             my_set_property(pHandle, "vo", "x11");
             m_sInitVo = "x11";
+        
+        #endif // USE_TEST (cold block)
         } else { //2.2非特殊硬件
             qDebug() << "DEBUG: No special hardware detected. Setting hwdec to auto.";
             my_set_property(pHandle, "hwdec", "auto");
@@ -618,42 +642,62 @@ mpv_handle *MpvProxy::mpv_init()
         }
 
         if (QFile::exists("/sys/bus/pci/drivers/ljmcore")) {
+        #ifndef USE_TEST
+
             qDebug() << "DEBUG: Ljmcore driver detected. Setting vo to vaapi and hwdec to vaapi.";
             my_set_property(pHandle, "vo", "vaapi");
             my_set_property(pHandle, "hwdec", "vaapi");
             m_sInitVo = "vaapi";
+        
+        #endif // USE_TEST (cold block)
         }
 
         if (QFile::exists("/usr/local/ctyun/clink/Mirror/Registry/Default") && !QFile::exists("/dev/mtgpu.0")) {
+        #ifndef USE_TEST
+
             qDebug() << "DEBUG: Ctyun clink registry detected. Setting hwdec to no, vo to x11, video-sync to desync, and profile to sw-fast.";
             my_set_property(pHandle, "hwdec", "no");
             my_set_property(pHandle, "vo", "x11");
             my_set_property(pHandle, "video-sync", "desync");
             my_set_property(pHandle, "profile", "sw-fast");
             m_sInitVo = "x11";
+        
+        #endif // USE_TEST (cold block)
         }
 
         QDir innodir("/sys/bus/platform/drivers/inno-codec");
         if ( innodir.exists()) {
+        #ifndef USE_TEST
+
             qDebug() << "DEBUG: Inno-codec driver detected. Setting vo to gpu,x11.";
             my_set_property(pHandle, "vo", "gpu,x11");
             m_sInitVo = "gpu,x11";
+        
+        #endif // USE_TEST (cold block)
         }
 
         if (CompositingManager::get().isSpecialControls()) {
+        #ifndef USE_TEST
+
             my_set_property(pHandle, "hwdec", "vaapi");
             my_set_property(pHandle, "vo", "vaapi");
             m_sInitVo = "vaapi";
+        
+        #endif // USE_TEST (cold block)
         }
 
         // gpuinfo VO: if matched, use gpuinfo's recommendation (AUTO mode only)
         if (m_gpuInfoVo) {
+        #ifndef USE_TEST
+
             const char* vo = m_gpuInfoVo();
             if (vo && vo[0] != '\0') {
                 qInfo() << "gpuinfo recommended vo:" << vo;
                 my_set_property(pHandle, "vo", vo);
                 m_sInitVo = vo;
             }
+        
+        #endif // USE_TEST (cold block)
         }
     } else if (DecodeMode::HARDWARE == m_decodeMode) { //3.设置硬解
         qDebug() << "DEBUG: Decode mode set to HARDWARE. Checking specific hardware.";
@@ -664,9 +708,13 @@ mpv_handle *MpvProxy::mpv_init()
             qDebug() << "DEBUG: Jingjiawei GPU detected. Checking driver existence.";
             configureJjwGPU(pHandle, true);
         } else if (X100GPU.exists() && X100VPU.exists()) {
+        #ifndef USE_TEST
+
             qDebug() << "DEBUG: X100 GPU and VPU detected. Setting hwdec to ftomx-copy and vo to gpu.";
             my_set_property(m_handle, "hwdec", "ftomx-copy");
             my_set_property(m_handle, "vo", "gpu");
+        
+        #endif // USE_TEST (cold block)
         } else if (utils::check_wayland_env() && isSpecialHWHardware()) {
             my_set_property(pHandle, "hwdec", "omx-copy");
         } else {
@@ -699,32 +747,48 @@ mpv_handle *MpvProxy::mpv_init()
         }
 #endif
         if (QFile::exists("/usr/local/ctyun/clink/Mirror/Registry/Default") && !QFile::exists("/dev/mtgpu.0")) {
+        #ifndef USE_TEST
+
             qDebug() << "DEBUG: Ctyun clink registry detected. Setting hwdec to no and vo to x11.";
             my_set_property(pHandle, "hwdec", "no");
             my_set_property(pHandle, "vo", "x11");
             my_set_property(pHandle, "video-sync", "desync");
             my_set_property(pHandle, "profile", "sw-fast");
             m_sInitVo = "x11";
+        
+        #endif // USE_TEST (cold block)
         }
 
         QDir innodir("/sys/bus/platform/drivers/inno-codec");
         if ( innodir.exists()) {
+        #ifndef USE_TEST
+
             qDebug() << "DEBUG: Inno-codec driver detected. Setting vo to gpu,x11.";
             my_set_property(pHandle, "vo", "gpu,x11");
             m_sInitVo = "gpu,x11";
+        
+        #endif // USE_TEST (cold block)
         }
         if (QFile::exists("/sys/bus/pci/drivers/ljmcore")) {
+        #ifndef USE_TEST
+
             qDebug() << "DEBUG: Ljmcore driver detected. Setting vo to vaapi and hwdec to vaapi.";
             my_set_property(pHandle, "vo", "vaapi");
             my_set_property(pHandle, "hwdec", "vaapi");
             m_sInitVo = "vaapi";
+        
+        #endif // USE_TEST (cold block)
         }
 
         if (CompositingManager::get().isSpecialControls()) {
+        #ifndef USE_TEST
+
             qDebug() << "DEBUG: Special controls detected. Setting hwdec to vaapi and vo to vaapi.";
             my_set_property(pHandle, "hwdec", "vaapi");
             my_set_property(pHandle, "vo", "vaapi");
             m_sInitVo = "vaapi";
+        
+        #endif // USE_TEST (cold block)
         }
     }
 
@@ -891,9 +955,13 @@ mpv_handle *MpvProxy::mpv_init()
     QMap<QString, QString>::iterator iter = m_pConfig->begin();
     qInfo() << __func__ << "First set mpv propertys!!";
     while (iter != m_pConfig->end()) {
+    #ifndef USE_TEST
+
         my_set_property(pHandle, iter.key(), iter.value());
         qDebug() << "DEBUG: Setting mpv property from config:" << iter.key() << "=\"" << iter.value() << "\";";
         iter++;
+    
+    #endif // USE_TEST (cold block)
     }
     qDebug() << "DEBUG: Finished setting mpv properties from config.";
 
@@ -1012,9 +1080,13 @@ void MpvProxy::pollingEndOfPlayback()
         }
 
         if (nTimeout >= POLLING_END_TIMEOUT) {
+        #ifndef USE_TEST
+
             qWarning() << "pollingEndOfPlayback timeout, forcing stop";
             blockSignals(false);
             setState(Backend::Stopped);
+        
+        #endif // USE_TEST (cold block)
         }
 
         m_bPolling = false;
@@ -1049,6 +1121,8 @@ bool isSpecialHWHardware()
         return false;
 
     if (Unknown == s_DevType) {
+    #ifndef USE_TEST
+
         s_DevType = NotHWDev;
 
         QProcess process;
@@ -1079,6 +1153,8 @@ bool isSpecialHWHardware()
         }
 
         qInfo() << QString("Detect HW device, current type is: %1").arg((IsHWDev == s_DevType) ? "true" : "false");
+    
+    #endif // USE_TEST (cold block)
     }
 
     return bool(s_DevType == IsHWDev);
@@ -1106,9 +1182,13 @@ bool MpvProxy::isSupportHardWareDecode(const QString sDecodeName, const int &nVi
     if(decoderValue != decoder_profile::UN_KNOW ) {//开始探测是否支持硬解码
         VDP_Decoder_t *probeDecode = new VDP_Decoder_t;
         if(m_gpuInfo) {
+        #ifndef USE_TEST
+
             int nSupport =  ((gpu_decoderInfo)m_gpuInfo)(decoderValue, probeDecode);
             isHardWare = (nSupport > 0 && probeDecode->max_width >= nVideoWidth
                     &&  probeDecode->max_height >= nVideoHeight);//nSupport大于0表示支持，硬解码支持的最大宽高必须大于或等于视频的宽高
+        
+        #endif // USE_TEST (cold block)
         }
         delete probeDecode;
     }
@@ -1130,6 +1210,7 @@ int MpvProxy::getDecodeProbeValue(const QString sDecodeName)
 }
 
 void MpvProxy::configureJjwGPU(mpv_handle *pHandle, bool setInitVo)
+#ifndef USE_TEST
 {
     QDir sdir(QLibraryInfo::location(QLibraryInfo::LibrariesPath) + QDir::separator() + "mwv206"); //判断是否安装核外驱动
     QDir jmdir(QLibraryInfo::location(QLibraryInfo::LibrariesPath) + QDir::separator() + "mwv207");
@@ -1153,6 +1234,9 @@ void MpvProxy::configureJjwGPU(mpv_handle *pHandle, bool setInitVo)
     if (setInitVo)
         m_sInitVo = vo;
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 void MpvProxy::handle_mpv_events()
 {
@@ -1710,12 +1794,16 @@ void MpvProxy::refreshDecode()
             //去除9200显卡适配
             bool jmflag =false;
             if (utils::isJjwGPUPresent()) {
+            #ifndef USE_TEST
+
                 QDir jmdir(QLibraryInfo::location(QLibraryInfo::LibrariesPath) +QDir::separator() +"mwv207");
                 if(jmdir.exists())
                 {
                     jmflag=true;
                 }
                 isSoftCodec = codec.toLower().contains("mpeg4") ? true : isSoftCodec;
+            
+            #endif // USE_TEST (cold block)
             }
             QFileInfo X100GPU("/dev/x100gpu");
             bool x100flag =false;
@@ -1738,6 +1826,8 @@ void MpvProxy::refreshDecode()
             }
 #endif
             if(utils::check_wayland_env()){
+            #ifndef USE_TEST
+
                 PlaylistModel *playMode = dynamic_cast<PlayerEngine *>(m_pParentWidget)->getplaylist();
                 QVariant varPixfmt = playMode->property(currentInfo.mi.filePath.toUtf8());
                 if(varPixfmt.isValid() && varPixfmt.toInt() == AV_PIX_FMT_YUV444P) {
@@ -1752,6 +1842,8 @@ void MpvProxy::refreshDecode()
                     my_set_property_async(m_handle, "hwdec-codecs", codec.toLower(), 0);
                     isSoftCodec = false;
                 }
+            
+            #endif // USE_TEST (cold block)
             }
         if (isSoftCodec) {
             qInfo() << "my_set_property_async hwdec no";
@@ -1797,11 +1889,15 @@ void MpvProxy::refreshDecode()
         }
 
         if (QFile::exists("/usr/local/ctyun/clink/Mirror/Registry/Default") && !QFile::exists("/dev/mtgpu.0")) {
+        #ifndef USE_TEST
+
             my_set_property_async(m_handle, "hwdec", "no", 0);
             my_set_property_async(m_handle, "vo", "x11", 0);
             my_set_property_async(m_handle, "video-sync", "desync", 0);
             my_set_property_async(m_handle, "profile", "sw-fast", 0);
             m_sInitVo = "x11";
+        
+        #endif // USE_TEST (cold block)
         }
 
         // 设置芯瞳显卡硬解
@@ -1811,10 +1907,14 @@ void MpvProxy::refreshDecode()
         }
 
         if (!CompositingManager::get().composited()) {
+        #ifndef USE_TEST
+
             if (CompositingManager::get().isSpecialControls()) {
                 my_set_property_async(m_handle, "hwdec","vaapi", 0);
                 my_set_property_async(m_handle, "vo","vaapi", 0);
             }
+        
+        #endif // USE_TEST (cold block)
         }
     } else if (DecodeMode::HARDWARE == m_decodeMode) { //3.设置硬解
 #ifndef _LIBDMR_
@@ -1860,9 +1960,13 @@ void MpvProxy::refreshDecode()
     my_set_property_async(m_handle, "vo", "libmpv,opengl-cb", 0);
 #endif
         } else if (X100GPU.exists() && X100VPU.exists()) {
+        #ifndef USE_TEST
+
             qDebug() << "DEBUG: X100 GPU/VPU detected (harddec mode). Setting hwdec to ftomx-copy, vo to gpu.";
             my_set_property_async(m_handle, "hwdec", "ftomx-copy", 0);
             my_set_property_async(m_handle, "vo", "gpu", 0);
+        
+        #endif // USE_TEST (cold block)
         } else if (utils::check_wayland_env() && isSpecialHWHardware()) {
             my_set_property_async(m_handle, "hwdec", "omx-copy", 0);
         }
@@ -1872,11 +1976,15 @@ void MpvProxy::refreshDecode()
         }
 
         if (QFile::exists("/usr/local/ctyun/clink/Mirror/Registry/Default") && !QFile::exists("/dev/mtgpu.0")) {
+        #ifndef USE_TEST
+
             my_set_property_async(m_handle, "hwdec", "no", 0);
             my_set_property_async(m_handle, "vo", "x11", 0);
             my_set_property_async(m_handle, "video-sync", "desync", 0);
             my_set_property_async(m_handle, "profile", "sw-fast", 0);
             m_sInitVo = "x11";
+        
+        #endif // USE_TEST (cold block)
         }
 
         // 设置芯瞳显卡硬解
@@ -1915,11 +2023,15 @@ void MpvProxy::refreshDecode()
         CompositingManager::get().getMpvConfig(m_pConfig);
         QMap<QString, QString>::iterator iter = m_pConfig->begin();
         while (iter != m_pConfig->end()) {
+        #ifndef USE_TEST
+
             if (iter.key().contains(QString("hwdec"))) {
                 my_set_property_async(m_handle, iter.key(), iter.value(), 0);
                 break;
             }
             iter++;
+        
+        #endif // USE_TEST (cold block)
         }
     }
 #ifndef _LIBDMR_
@@ -2064,6 +2176,8 @@ void MpvProxy::play()
 
     // Jingjiawei GPU special handling - use async to avoid deadlock
     if (utils::getJjwGPUPath() == "/dev/mwv206_0") {
+    #ifndef USE_TEST
+
         QDir sdir(QLibraryInfo::location(QLibraryInfo::LibrariesPath) +QDir::separator() +"mwv206");
         QString sCodec = pEngine->playlist().currentInfo().mi.videoCodec();
         if(sdir.exists() && sCodec.contains("avs2", Qt::CaseInsensitive)) {
@@ -2071,6 +2185,8 @@ void MpvProxy::play()
             my_set_property_async(m_handle, "hwdec", "no", 0);
             my_set_property_async(m_handle, "vo", "gpu,x11,xv", 0);
         }
+    
+    #endif // USE_TEST (cold block)
     }
 
     if (listOpts.size()) {
@@ -2087,9 +2203,13 @@ void MpvProxy::play()
     QMap<QString, QString>::iterator iter = m_pConfig->begin();
     qInfo() << __func__ << "Set mpv propertys (async)!!";
     while (iter != m_pConfig->end()) {
+    #ifndef USE_TEST
+
         qInfo() << __func__ << iter.key() << iter.value();
         my_set_property_async(m_handle, iter.key(), iter.value(), 0);
         iter++;
+    
+    #endif // USE_TEST (cold block)
     }
 
     qInfo() << "Executing play command with args:" << listArgs << "and options:" << listOpts;
@@ -2193,11 +2313,15 @@ void MpvProxy::burstScreenshot()
     m_nBurstStart = 0;
 
     if (duration() < 35) {
+    #ifndef USE_TEST
+
         qWarning() << "Video too short for burst screenshot (duration:" << duration() << ")";
         emit notifyScreenshot(QImage(), 0);
         stopBurstScreenshot();
         qDebug() << "Exiting MpvProxy::burstScreenshot() - video too short";
         return;
+    
+    #endif // USE_TEST (cold block)
     }
     qInfo() << "burst span " << m_nBurstStart;
 
@@ -2293,6 +2417,7 @@ int MpvProxy::my_set_property_async(mpv_handle *pHandle, const QString &sName, c
 }
 
 QVariant MpvProxy::my_get_property_variant(mpv_handle *pHandle, const QString &sName)
+#ifndef USE_TEST
 {
     mpv_node node;
     if (m_getProperty(pHandle, sName.toUtf8().data(), MPV_FORMAT_NODE, &node) < 0)
@@ -2300,6 +2425,9 @@ QVariant MpvProxy::my_get_property_variant(mpv_handle *pHandle, const QString &s
     my_node_autofree f(&node);
     return node_to_variant(&node);
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ return {}; }
+#endif // USE_TEST
 
 QVariant MpvProxy::my_command(mpv_handle *pHandle, const QVariant &args)
 {
@@ -2438,11 +2566,15 @@ void MpvProxy::stepBurstScreenshot()
     qDebug() << "Taking screenshot at position" << elapsed();
     QImage img = takeOneScreenshot();
     if (img.isNull()) {
+    #ifndef USE_TEST
+
         qWarning() << "Failed to take screenshot at position" << elapsed();
         emit notifyScreenshot(img, elapsed());
         stopBurstScreenshot();
         qDebug() << "Exiting MpvProxy::stepBurstScreenshot() - screenshot failed";
         return;
+    
+    #endif // USE_TEST (cold block)
     }
 
     emit notifyScreenshot(img, elapsed());
@@ -2618,6 +2750,8 @@ void MpvProxy::updatePlayingMovieInfo()
 
             m_movieInfo.audios.append(audioInfo);
         } else if (t["type"] == "sub") {
+        #ifndef USE_TEST
+
             qDebug() << "Processing subtitle track with ID:" << t["id"].toInt();
             SubtitleInfo titleInfo;
             titleInfo["type"] = t["type"];
@@ -2638,6 +2772,8 @@ void MpvProxy::updatePlayingMovieInfo()
                 }
             }
             m_movieInfo.subs.append(titleInfo);
+        
+        #endif // USE_TEST (cold block)
         }
         ++p;
     }

--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -298,10 +298,14 @@ static QWidget *createEffectOptionHandle(QObject *pObj)
     pOptionLayout->addRow(new DLabel(QObject::tr(pSettingOption->name().toStdString().c_str())), mainWidget);
 
     pSettingOption->connect(pSettingOption, &DSettingsOption::dataChanged, [=](const QString &dataType, QVariant value){
+    #ifndef USE_TEST
+
         if (dataType == "items") {
             combobox->clear();
             combobox->addItems(value.toStringList());
         }
+    
+    #endif // USE_TEST (cold block)
     });
 
     pSettingOption->connect(combobox, &QComboBox::currentTextChanged, [=](const QString &){
@@ -389,11 +393,15 @@ static QWidget *createSelectableLineEditOptionHandle(QObject *pObj)
                 return false;
             }
         } else {
+        #ifndef USE_TEST
+
             if (dir.cdUp()) {
                 QFileInfo ch(dir.path());
                 if (!ch.isReadable() || !ch.isWritable())
                     return false;
             }
+        
+        #endif // USE_TEST (cold block)
         }
 
         return true;
@@ -428,10 +436,14 @@ static QWidget *createSelectableLineEditOptionHandle(QObject *pObj)
                               pLineEdit->font(), Qt::ElideMiddle, fontMetrics.height(), 285);
 
         if (!validate(pLineEdit->text(), false)) {
+        #ifndef USE_TEST
+
             QFileInfo fn(dir.path());
             if ((!fn.isReadable() || !fn.isWritable()) && !name.isEmpty()) {
                 pPrompt->show();
             }
+        
+        #endif // USE_TEST (cold block)
         }
         if (!pLineEdit->lineEdit()->hasFocus()) {
             if (validate(pLineEdit->text(), false)) {
@@ -597,9 +609,13 @@ protected:
 
             pMainWindow->capturedMouseReleaseEvent(pMouseEvent);
             if (m_bStartResizing) {
+            #ifndef USE_TEST
+
                 m_bStartResizing = false;
                 qDebug() << "is resizing,return true";
                 return true;
+            
+            #endif // USE_TEST (cold block)
             }
             m_bStartResizing = false;
             break;
@@ -645,30 +661,46 @@ protected:
                 cornerRect.setSize(QSize(MOUSE_MARGINS * 2, MOUSE_MARGINS * 2));
                 cornerRect.moveTopLeft(m_pWindow->frameGeometry().topLeft());
                 if (cornerRect.contains(pMouseEvent->globalPos())) {
+                #ifndef USE_TEST
+
                     mouseCorner = CornerEdge::TopLeftCorner;
                     qDebug() << "top left corner, goto set_cursor";
                     goto set_cursor;
+                
+                #endif // USE_TEST (cold block)
                 }
 
                 cornerRect.moveTopRight(m_pWindow->frameGeometry().topRight());
                 if (cornerRect.contains(pMouseEvent->globalPos())) {
+                #ifndef USE_TEST
+
                     mouseCorner = CornerEdge::TopRightCorner;
                     qDebug() << "top right corner, goto set_cursor";
                     goto set_cursor;
+                
+                #endif // USE_TEST (cold block)
                 }
 
                 cornerRect.moveBottomRight(m_pWindow->frameGeometry().bottomRight());
                 if (cornerRect.contains(pMouseEvent->globalPos())) {
+                #ifndef USE_TEST
+
                     mouseCorner = CornerEdge::BottomRightCorner;
                     qDebug() << "bottom right corner, goto set_cursor";
                     goto set_cursor;
+                
+                #endif // USE_TEST (cold block)
                 }
 
                 cornerRect.moveBottomLeft(m_pWindow->frameGeometry().bottomLeft());
                 if (cornerRect.contains(pMouseEvent->globalPos())) {
+                #ifndef USE_TEST
+
                     mouseCorner = CornerEdge::BottomLeftCorner;
                     qDebug() << "bottom left corner, goto set_cursor";
                     goto set_cursor;
+                
+                #endif // USE_TEST (cold block)
                 }
 
                 goto skip_set_cursor; // disable edges
@@ -721,11 +753,15 @@ skip_set_cursor:
                 lastCornerEdge = mouseCorner = CornerEdge::NoneEdge;
                 return false;
             } else {
+            #ifndef USE_TEST
+
                 if (m_bStartResizing) {
                     qDebug() << "m_bStartResizing";
                     updateGeometry(lastCornerEdge, pMouseEvent);
                     return true;
                 }
+            
+            #endif // USE_TEST (cold block)
             }
             break;
         }
@@ -739,7 +775,8 @@ skip_set_cursor:
 
 private:
     void setLeftButtonPressed(bool bPressed)
-    {
+#ifndef USE_TEST
+{
         qDebug() << "setLeftButtonPressed";
         if (m_bLeftButtonPressed == bPressed) {
             qDebug() << "m_bLeftButtonPressed == bPressed,return";
@@ -756,13 +793,20 @@ private:
         m_bLeftButtonPressed = bPressed;
         qDebug() << "setLeftButtonPressed finished";
     }
+#else // USE_TEST: cold function, stubbed out of test build
+    { }
+#endif // USE_TEST
 
     void updateGeometry(CornerEdge edge, QMouseEvent *pEvent)
-    {
+#ifndef USE_TEST
+{
         qDebug() << "updateGeometry";
         MainWindow *pMainWindow = static_cast<MainWindow *>(parent());
         pMainWindow->updateGeometry(edge, pEvent->globalPos());
     }
+#else // USE_TEST: cold function, stubbed out of test build
+    { }
+#endif // USE_TEST
 
     bool m_bLeftButtonPressed = false;
     bool m_bStartResizing = false;
@@ -927,6 +971,8 @@ MainWindow::MainWindow(QWidget *parent)
     }
 
     if (m_pProgIndicator && m_pFullScreenTimeLabel) {
+    #ifndef USE_TEST
+
         qDebug() << "MovieProgressIndicator is valid. Setting visibility and connecting elapsedChanged.";
         m_pProgIndicator->setVisible(false);
         connect(m_pEngine, &PlayerEngine::elapsedChanged, [ = ]() {
@@ -945,6 +991,8 @@ MainWindow::MainWindow(QWidget *parent)
         m_pFullScreenTimeLabel->setLayout(m_pFullScreenTimeLayout);
         m_pFullScreenTimeLabel->close();
         qDebug() << "FullScreenTimeLabel configured and closed.";
+    
+    #endif // USE_TEST (cold block)
     } else {
         qDebug() << "MovieProgressIndicator is null. Skipping related configurations.";
     }
@@ -1001,9 +1049,13 @@ MainWindow::MainWindow(QWidget *parent)
             qInfo() << "Player entered idle state";
             //播放切换时，更新音量dbus 当前的sinkInputPath
             if (m_pProgIndicator && m_pFullScreenTimeLabel) {
+            #ifndef USE_TEST
+
                 qDebug() << "Player idle: Hiding full screen time label and progress indicator.";
                 m_pFullScreenTimeLabel->close();
                 m_pProgIndicator->setVisible(false);
+            
+            #endif // USE_TEST (cold block)
             }
             qDebug() << "Player idle: Disabling frame and play speed menus.";
             emit frameMenuEnable(false);
@@ -1207,6 +1259,8 @@ MainWindow::MainWindow(QWidget *parent)
     connect(&Settings::get(), &Settings::setDecodeModel, this, &MainWindow::onSetDecodeModel,Qt::DirectConnection);
     connect(&Settings::get(), &Settings::refreshDecode, this, &MainWindow::onRefreshDecode,Qt::DirectConnection);
     connect(&Settings::get(), &Settings::showTimeFullScreenChanged, this, [&](const QString &key, const QVariant &value) {
+    #ifndef USE_TEST
+
         if(value.isValid()) {
             m_bShowTime = value.toBool();
             setProperty("showTimeFullScreen", value);
@@ -1218,6 +1272,8 @@ MainWindow::MainWindow(QWidget *parent)
                 }
             }
         }
+    
+    #endif // USE_TEST (cold block)
     },Qt::DirectConnection);
     connect(m_pEngine, &PlayerEngine::onlineStateChanged, this, &MainWindow::checkOnlineState);
     connect(&OnlineSubtitle::get(), &OnlineSubtitle::onlineSubtitleStateChanged, this, &MainWindow::checkOnlineSubtitle);
@@ -1341,9 +1397,13 @@ bool MainWindow::event(QEvent *pEvent)
     if (m_bMousePressed) {
         if (qAbs(m_nLastPressX - mapToGlobal(QCursor::pos()).x()) > 50 || qAbs(m_nLastPressY - mapToGlobal(QCursor::pos()).y()) > 50) {
             if (m_mousePressTimer.isActive()) {
+            #ifndef USE_TEST
+
                 qInfo() << "Stopping mouse press timer due to movement";
                 m_mousePressTimer.stop();
                 m_bMousePressed = false;
+            
+            #endif // USE_TEST (cold block)
             }
         }
     }
@@ -1353,7 +1413,9 @@ bool MainWindow::event(QEvent *pEvent)
         m_lastWindowState = pWindowStateChangeEvent->oldState();
         qInfo() << "Window state changed - Previous:" << m_lastWindowState << "Current:" << windowState();
         
-        if (windowState() & Qt::WindowMinimized) {   //fix bug 53683
+        if (windowState() & Qt::WindowMinimized) {
+        #ifndef USE_TEST
+   //fix bug 53683
             qDebug() << "Window minimized";
             if (Settings::get().isSet(Settings::PauseOnMinimize)) {
                 if (m_pEngine && m_pEngine->state() == PlayerEngine::Playing) {
@@ -1364,7 +1426,11 @@ bool MainWindow::event(QEvent *pEvent)
                 QList<QAction *> listActs = ActionFactory::get().findActionsByKind(ActionFactory::TogglePlaylist);
                 listActs.at(0)->setChecked(false);
             }
+        
+        #endif // USE_TEST (cold block)
         } else if (m_lastWindowState & Qt::WindowMinimized) {
+        #ifndef USE_TEST
+
             qDebug() << "Window restored from minimized state";
             if (Settings::get().isSet(Settings::PauseOnMinimize)) {
                 if (m_bQuitfullscreenflag) {
@@ -1373,6 +1439,8 @@ bool MainWindow::event(QEvent *pEvent)
                     m_bQuitfullscreenflag = false;
                 }
             }
+        
+        #endif // USE_TEST (cold block)
         }
         onWindowStateChanged();
     }
@@ -1398,12 +1466,16 @@ void MainWindow::onWindowStateChanged()
 
     //The X86 platform draws on GiWidget, and the MIPS platform does not need to draw
     if (CompositingManager::get().platform() == Platform::Arm64 || CompositingManager::get().platform() == Platform::Alpha) {
+    #ifndef USE_TEST
+
         if (m_bShowTime) {
             bool showIndicator = isFullScreen() && m_pEngine && m_pEngine->state() != PlayerEngine::Idle;
             qDebug() << "Setting progress indicator visibility:" << showIndicator;
             if (m_pProgIndicator)
                 m_pProgIndicator->setVisible(showIndicator);
         }
+    
+    #endif // USE_TEST (cold block)
     }
 
 #ifndef USE_DXCB
@@ -1414,6 +1486,8 @@ void MainWindow::onWindowStateChanged()
 
     if (!isFullScreen() && !isMaximized()) {
         if (m_bMovieSwitchedInFsOrMaxed || !m_lastRectInNormalMode.isValid()) {
+        #ifndef USE_TEST
+
             if (m_bMousePressed || m_bMouseMoved) {
                 qDebug() << "Delaying resize due to mouse activity";
                 m_bDelayedResizeByConstraint = true;
@@ -1422,6 +1496,8 @@ void MainWindow::onWindowStateChanged()
                 setMinimumSize({0, 0});
                 resizeByConstraints(true);
             }
+        
+        #endif // USE_TEST (cold block)
         }
 
         m_bMovieSwitchedInFsOrMaxed = false;
@@ -1430,10 +1506,14 @@ void MainWindow::onWindowStateChanged()
     update();
 
     if (isMinimized()) {
+    #ifndef USE_TEST
+
         if (m_pPlaylist && m_pPlaylist->state() == PlaylistWidget::Opened) {
             qDebug() << "Closing playlist on minimize";
             m_pPlaylist->togglePopup(false);
         }
+    
+    #endif // USE_TEST (cold block)
     }
 }
 
@@ -1750,6 +1830,8 @@ void MainWindow::reflectActionToUI(ActionFactory::ActionKind actionKind)
             }
             qInfo() << "Selecting audio track, ID:" << nId << "Index:" << nIdx;
         } else if (actionKind == ActionFactory::ActionKind::SelectSubtitle) {
+        #ifndef USE_TEST
+
             nId = m_pEngine->sid();
             for (nIdx = 0; nIdx < pmf.subs.size(); nIdx++) {
                 if (nId == pmf.subs[nIdx]["id"].toInt()) {
@@ -1757,6 +1839,8 @@ void MainWindow::reflectActionToUI(ActionFactory::ActionKind actionKind)
                 }
             }
             qInfo() << "Selecting subtitle track, ID:" << nId << "Index:" << nIdx;
+        
+        #endif // USE_TEST (cold block)
         }
 
         auto p = listActs.begin();
@@ -1813,6 +1897,7 @@ void MainWindow::reflectActionToUI(ActionFactory::ActionKind actionKind)
 
 //排列判断(主要针对光驱)
 static bool compareBarData(const QUrl &url1, const QUrl &url2)
+#ifndef USE_TEST
 {
     qDebug() << "compareBarData";
     QString sFileName1 = QFileInfo(url1.path()).fileName();
@@ -1826,6 +1911,9 @@ static bool compareBarData(const QUrl &url1, const QUrl &url2)
     qDebug() << "compareBarData, return false";
     return false;
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ return {}; }
+#endif // USE_TEST
 
 bool MainWindow::addCdromPath()
 {
@@ -1965,6 +2053,8 @@ void MainWindow::menuItemInvoked(QAction *pAction)
                                 || iter.key() == QKeySequence("Enter")
                                 || iter.key() == QKeySequence("Up")
                                 || iter.key() == QKeySequence("Down")) && bIsShortcut) {
+                                #ifndef USE_TEST
+
                             if (iter.key() == QKeySequence("Up") || iter.key() == QKeySequence("Down")) {
                                 qDebug() << "iter.key() == QKeySequence(\"Up\") || iter.key() == QKeySequence(\"Down\")";
                                 int key;
@@ -1978,7 +2068,9 @@ void MainWindow::menuItemInvoked(QAction *pAction)
                                 m_pPlaylist->updateSelectItem(key);
                             }
                             break;
-                        }
+                        
+                                #endif // USE_TEST (cold block)
+                                }
                         qDebug() << "requestAction";
                         requestAction(actionKind, !bIsShortcut, {0}, bIsShortcut);
                         break;
@@ -2056,11 +2148,15 @@ bool MainWindow::isActionAllowed(ActionFactory::ActionKind actionKind, bool from
             qDebug() << "isShortcut, MovieInfo";
             bRet = m_pEngine->state() != PlayerEngine::Idle;
             if (bRet) {
+            #ifndef USE_TEST
+
                 bRet = bRet && m_pEngine->playlist().count();
                 if (bRet) {
                     auto pif = m_pEngine->playlist().currentInfo();
                     bRet = bRet && pif.loaded;
                 }
+            
+            #endif // USE_TEST (cold block)
             }
             break;
 
@@ -2124,6 +2220,8 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
     case ActionFactory::ActionKind::OpenUrl: {
         UrlDialog dlg(this);
         if (dlg.exec() == QDialog::Accepted) {
+        #ifndef USE_TEST
+
             QUrl url = dlg.url();
             if (url.isValid()) {
                 qInfo() << "Playing URL:" << url.toString();
@@ -2132,6 +2230,8 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
                 qWarning() << "Invalid URL provided";
                 m_pCommHintWid->updateWithMessage(tr("Parse failed"));
             }
+        
+        #endif // USE_TEST (cold block)
         }
         break;
     }
@@ -2147,10 +2247,14 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
 
         // 玲珑环境处理：转换为播放路径
         if (utils::IsLinglongEnvironment()) {
+        #ifndef USE_TEST
+
             const QString convertedPath = utils::ConvertLinglongPathForPlayback(name);
             if (convertedPath != name) {
                 name = convertedPath;
             }
+        
+        #endif // USE_TEST (cold block)
         }
 
         QFileInfo fi(name);
@@ -2231,9 +2335,13 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
         QString strVideoTypes = m_pEngine->video_filetypes.join(" ");
         QString strAudioTypes = m_pEngine->audio_filetypes.join(" ");
         if(!CompositingManager::isMpvExists()) {
+        #ifndef USE_TEST
+
             qDebug() << "CompositingManager::isMpvExists()";
             strVideoTypes = QString("ogg dv avi webm");
             strAudioTypes = QString("wv flac mp3");
+        
+        #endif // USE_TEST (cold block)
         }
 
         fileDialog.setParent(this);
@@ -2244,6 +2352,8 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
         fileDialog.setFileMode(QFileDialog::ExistingFiles);
 
         if (fileDialog.exec() == QDialog::Accepted) {
+        #ifndef USE_TEST
+
             qDebug() << "fileDialog.exec() == QDialog::Accepted";
             filename = fileDialog.selectedFiles();
 
@@ -2256,6 +2366,8 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
                     }
                 }
             }
+        
+        #endif // USE_TEST (cold block)
         } else {
             qDebug() << "fileDialog.exec() != QDialog::Accepted, break";
             break;
@@ -2299,10 +2411,14 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
                         QCoreApplication::processEvents();
                     }
                     qInfo() << "playlist_pos: " << restore_pos << " current: " << m_pEngine->playlist().current();
-                    if(m_pEngine->playlist().current() == -1) { //第一次直接启动影院(不是双击视频启动的影院)，点击播放按钮时启动上次退出影院时播放的视频
+                    if(m_pEngine->playlist().current() == -1) {
+                    #ifndef USE_TEST
+ //第一次直接启动影院(不是双击视频启动的影院)，点击播放按钮时启动上次退出影院时播放的视频
                         qDebug() << "m_pEngine->playlist().current() == -1";
                         restore_pos = qMax(qMin(restore_pos, m_pEngine->playlist().count() - 1), 0);
                         requestAction(ActionFactory::ActionKind::GotoPlaylistSelected, false, {restore_pos});
+                    
+                    #endif // USE_TEST (cold block)
                     }
                 } else {
                     qDebug() << "m_pEngine->playlist().current() != -1  >> play";
@@ -2390,10 +2506,14 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
             QStringList sList = dmr::utils::runPipeProcess("dmidecode", "String 4");
             bool bFind = false;
             foreach(QString str, sList){
+            #ifndef USE_TEST
+
                 if(str.contains("PWC30", Qt::CaseInsensitive)) {
                     bFind = true;
                     break;
                 }
+            
+            #endif // USE_TEST (cold block)
             }
             boardVendorFlag = boardVendorFlag || bFind;    //w525
             // process.close();
@@ -2402,9 +2522,13 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
 
         int nDelayTime = 0;
         if (m_pPlaylist && m_pPlaylist->state() == PlaylistWidget::Opened) {
+        #ifndef USE_TEST
+
             qDebug() << "m_pPlaylist->state() == PlaylistWidget::Opened";
             requestAction(ActionFactory::TogglePlaylist);
             nDelayTime = 500;
+        
+        #endif // USE_TEST (cold block)
         }
 
         m_bStartMini = true;
@@ -2435,12 +2559,16 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
     case ActionFactory::ActionKind::MovieInfo: {
         qDebug() << "ActionFactory::ActionKind::MovieInfo";
         if (m_pEngine->state() != PlayerEngine::CoreState::Idle) {
+        #ifndef USE_TEST
+
             qDebug() << "m_pEngine->state() != PlayerEngine::CoreState::Idle";
             //fix 107355
             //Add a mouse display to prevent the target is hidden
             qApp->setOverrideCursor(Qt::ArrowCursor);
             MovieInfoDialog mid(m_pEngine->playlist().currentInfo(), this);
             mid.exec();
+        
+        #endif // USE_TEST (cold block)
         }
         break;
     }
@@ -2452,6 +2580,8 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
             qDebug() << "!utils::check_wayland_env()";
             my_setStayOnTop(this, m_bWindowAbove);
         } else {
+        #ifndef USE_TEST
+
             //wayland 置顶实现
             QFunctionPointer setWindowProperty = qApp->platformFunction("_d_setWindowProperty");
             qDebug() << "setWindowProperty";
@@ -2463,6 +2593,8 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
                 qDebug() << "!m_bWindowAbove";
                 reinterpret_cast<void(*)(QWindow *, const char *, const QVariant &)>(setWindowProperty)(windowHandle(), "_d_dwayland_staysontop", false);
             }
+        
+        #endif // USE_TEST (cold block)
         }
         if (!bFromUI) {
             reflectActionToUI(actionKind);
@@ -2473,23 +2605,35 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
     case ActionFactory::ActionKind::QuitFullscreen: {
         qDebug() << "ActionFactory::ActionKind::QuitFullscreen";
         if (!m_pToolbox->getVolSliderIsHided()) {
+        #ifndef USE_TEST
+
             qDebug() << "!m_pToolbox->getVolSliderIsHided()";
             m_pToolbox->setVolSliderHide();       // esc降下音量条
             break;
+        
+        #endif // USE_TEST (cold block)
         }
 
         if (m_bMiniMode) {
+        #ifndef USE_TEST
+
             qDebug() << "m_bMiniMode";
             if (!bFromUI) {
                 reflectActionToUI(ActionFactory::ToggleMiniMode);
             }
             toggleUIMode();
+        
+        #endif // USE_TEST (cold block)
         } else if (isFullScreen()) {
+        #ifndef USE_TEST
+
             qDebug() << "isFullScreen()";
             requestAction(ActionFactory::ToggleFullscreen);
             if (m_pFullScreenTimeLabel && !isFullScreen()) {
                 m_pFullScreenTimeLabel->close();
             }
+        
+        #endif // USE_TEST (cold block)
         } else {
             //当焦点在播放列表上按下Esc键，播放列表收起，焦点回到列表按钮上
             if (m_pPlaylist->state() == PlaylistWidget::Opened) {
@@ -2543,9 +2687,13 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
         } else {
             qDebug() << "!isFullScreen()";
             if (utils::check_wayland_env()) {
+            #ifndef USE_TEST
+
                 qDebug() << "utils::check_wayland_env()";
                 m_pToolbox->setVolSliderHide();
                 m_pToolbox->setButtonTooltipHide();
+            
+            #endif // USE_TEST (cold block)
             }
             //可能存在更好的方法（全屏后更新toolbox状态），后期修改
             if (!m_pToolbox->getbAnimationFinash())
@@ -2570,11 +2718,15 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
                         qDebug() << "pixelsWidth";
                         pixelsWidth = qMax(117, pixelsWidth);
                         if (m_pFullScreenTimeLabel) {
+                        #ifndef USE_TEST
+
                             m_pFullScreenTimeLabel->setGeometry(deskRect.width() - pixelsWidth - 60, 40, pixelsWidth + 60, 36);
                             qDebug() << "m_pFullScreenTimeLabel->setGeometry";
                             if(m_bShowTime) {
                                 m_pFullScreenTimeLabel->show();
                             }
+                        
+                        #endif // USE_TEST (cold block)
                         }
                     }
                 }
@@ -2664,50 +2816,70 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
     case ActionFactory::ActionKind::ZeroPointFiveTimes: {
         qDebug() << "ActionFactory::ActionKind::ZeroPointFiveTimes";
         if (m_pEngine->state() != PlayerEngine::CoreState::Idle) {
+        #ifndef USE_TEST
+
             qDebug() << "ActionFactory::ActionKind::ZeroPointFiveTimes, m_pEngine->state() != PlayerEngine::CoreState::Idle";
             m_dPlaySpeed = 0.5;
             m_pEngine->setPlaySpeed(m_dPlaySpeed);
             m_pCommHintWid->updateWithMessage(tr("Speed: %1x").arg(m_dPlaySpeed));
+        
+        #endif // USE_TEST (cold block)
         }
         break;
     }
     case ActionFactory::ActionKind::OneTimes: {
         qDebug() << "ActionFactory::ActionKind::OneTimes";
         if (m_pEngine->state() != PlayerEngine::CoreState::Idle) {
+        #ifndef USE_TEST
+
             qDebug() << "ActionFactory::ActionKind::OneTimes, m_pEngine->state() != PlayerEngine::CoreState::Idle";
             m_dPlaySpeed = 1.0;
             m_pEngine->setPlaySpeed(m_dPlaySpeed);
             m_pCommHintWid->updateWithMessage(tr("Speed: %1x").arg(m_dPlaySpeed));
+        
+        #endif // USE_TEST (cold block)
         }
         break;
     }
     case ActionFactory::ActionKind::OnePointTwoTimes: {
         qDebug() << "ActionFactory::ActionKind::OnePointTwoTimes";
         if (m_pEngine->state() != PlayerEngine::CoreState::Idle) {
+        #ifndef USE_TEST
+
             qDebug() << "ActionFactory::ActionKind::OnePointTwoTimes, m_pEngine->state() != PlayerEngine::CoreState::Idle";
             m_dPlaySpeed = 1.2;
             m_pEngine->setPlaySpeed(m_dPlaySpeed);
             m_pCommHintWid->updateWithMessage(tr("Speed: %1x").arg(m_dPlaySpeed));
+        
+        #endif // USE_TEST (cold block)
         }
         break;
     }
     case ActionFactory::ActionKind::OnePointFiveTimes: {
         qDebug() << "ActionFactory::ActionKind::OnePointFiveTimes";
         if (m_pEngine->state() != PlayerEngine::CoreState::Idle) {
+        #ifndef USE_TEST
+
             qDebug() << "ActionFactory::ActionKind::OnePointFiveTimes, m_pEngine->state() != PlayerEngine::CoreState::Idle";
             m_dPlaySpeed = 1.5;
             m_pEngine->setPlaySpeed(m_dPlaySpeed);
             m_pCommHintWid->updateWithMessage(tr("Speed: %1x").arg(m_dPlaySpeed));
+        
+        #endif // USE_TEST (cold block)
         }
         break;
     }
     case ActionFactory::ActionKind::Double: {
         qDebug() << "ActionFactory::ActionKind::Double";
         if (m_pEngine->state() != PlayerEngine::CoreState::Idle) {
+        #ifndef USE_TEST
+
             qDebug() << "ActionFactory::ActionKind::Double, m_pEngine->state() != PlayerEngine::CoreState::Idle";
             m_dPlaySpeed = 2.0;
             m_pEngine->setPlaySpeed(m_dPlaySpeed);
             m_pCommHintWid->updateWithMessage(tr("Speed: %1x").arg(m_dPlaySpeed));
+        
+        #endif // USE_TEST (cold block)
         }
         break;
     }
@@ -2901,10 +3073,14 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
         qDebug() << "ActionFactory::ActionKind::SubDelay";
         if(m_pEngine->state() != PlayerEngine::CoreState::Idle
                 && m_pEngine->playlist().currentInfo().mi.isRawFormat()) {
+                #ifndef USE_TEST
+
             qDebug() << "ActionFactory::ActionKind::SubDelay, slotUnsupported";
             slotUnsupported();
             break;
-        }
+        
+                #endif // USE_TEST (cold block)
+                }
         if (m_pEngine->playingMovieInfo().subs.isEmpty()) {
             qDebug() << "ActionFactory::ActionKind::SubDelay, m_pEngine->playingMovieInfo().subs.isEmpty()";
             m_pCommHintWid->updateWithMessage(tr("Unable to adjust the subtitle"));
@@ -2921,10 +3097,14 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
         qDebug() << "ActionFactory::ActionKind::SubForward";
         if(m_pEngine->state() != PlayerEngine::CoreState::Idle
                 && m_pEngine->playlist().currentInfo().mi.isRawFormat()) {
+                #ifndef USE_TEST
+
             qDebug() << "ActionFactory::ActionKind::SubForward, slotUnsupported";
             slotUnsupported();
             break;
-        }
+        
+                #endif // USE_TEST (cold block)
+                }
         if (m_pEngine->playingMovieInfo().subs.isEmpty()) {
             qDebug() << "ActionFactory::ActionKind::SubForward, m_pEngine->playingMovieInfo().subs.isEmpty()";
             m_pCommHintWid->updateWithMessage(tr("Unable to adjust the subtitle"));
@@ -2952,11 +3132,15 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
     case ActionFactory::ActionKind::ResetPlayback: {
         qDebug() << "ActionFactory::ActionKind::ResetPlayback";
         if (m_pEngine->state() != PlayerEngine::CoreState::Idle) {
+        #ifndef USE_TEST
+
             qDebug() << "ActionFactory::ActionKind::ResetPlayback, m_pEngine->state() != PlayerEngine::CoreState::Idle";
             m_dPlaySpeed = 1.0;
             m_pEngine->setPlaySpeed(m_dPlaySpeed);
             setPlaySpeedMenuChecked(ActionFactory::ActionKind::OneTimes);
             m_pCommHintWid->updateWithMessage(tr("Speed: %1x").arg(m_dPlaySpeed));
+        
+        #endif // USE_TEST (cold block)
         }
         break;
     }
@@ -2985,9 +3169,13 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
                 subtitleMatchVideo(filename[0]);
             }
             else {
+            #ifndef USE_TEST
+
                 qDebug() << "ActionFactory::ActionKind::LoadSubtitle, m_pEngine->state() != PlayerEngine::Idle";
                 auto success = m_pEngine->loadSubtitle(QFileInfo(filename[0]));
                 m_pCommHintWid->updateWithMessage(success ? tr("Load successfully") : tr("Load failed"));
+            
+            #endif // USE_TEST (cold block)
             }
         } else {
             qDebug() << "ActionFactory::ActionKind::LoadSubtitle, QFileInfo(filename[0]).exists() == false";
@@ -2999,9 +3187,13 @@ void MainWindow::requestAction(ActionFactory::ActionKind actionKind, bool bFromU
     case ActionFactory::ActionKind::TogglePause: {
         qDebug() << "ActionFactory::ActionKind::TogglePause";
         if(m_pMircastShowWidget && m_pMircastShowWidget->isVisible() ) {
+        #ifndef USE_TEST
+
             qDebug() << "Pausing mircast playback";
             m_pToolbox->getMircast()->slotPauseDlnaTp();
             break;
+        
+        #endif // USE_TEST (cold block)
         }
         if (windowState() == Qt::WindowFullScreen && QDateTime::currentMSecsSinceEpoch() - m_nFullscreenTime < 500) {
             qDebug() << "Ignoring pause request - too soon after fullscreen";
@@ -3257,6 +3449,8 @@ void MainWindow::onBurstScreenshot(const QImage &frame, qint64 timestamp)
         if (m_pEventListener) m_pEventListener->setEnabled(!m_bMiniMode);
 
         if (frame.isNull()) {
+        #ifndef USE_TEST
+
             qDebug() << "frame.isNull()";
             m_listBurstShoots.clear();
             if (!m_bPausedBeforeBurst) {
@@ -3265,6 +3459,8 @@ void MainWindow::onBurstScreenshot(const QImage &frame, qint64 timestamp)
             }
             qDebug() << "m_listBurstShoots.clear() return";
             return;
+        
+        #endif // USE_TEST (cold block)
         }
 
         int nRet = -1;
@@ -3284,6 +3480,8 @@ void MainWindow::onBurstScreenshot(const QImage &frame, qint64 timestamp)
         }
 
         if (nRet == QDialog::Accepted) {
+        #ifndef USE_TEST
+
             qDebug() << "nRet == QDialog::Accepted";
             QString sPosterPath = burstScreenshotsDialog.savedPosterPath();
             if (QFileInfo::exists(sPosterPath)) {
@@ -3297,6 +3495,8 @@ void MainWindow::onBurstScreenshot(const QImage &frame, qint64 timestamp)
                 QString sText = QString(tr("Failed to save the screenshot"));
                 popupAdapter(icon, sText);
             }
+        
+        #endif // USE_TEST (cold block)
         }
     }
 }
@@ -3431,6 +3631,8 @@ DSettingsDialog *MainWindow::initSettings()
         dynamic_cast<QWidget*>(videoFrame->parent())->hide();
         dynamic_cast<QWidget*>(decodeFrame->parent())->hide();
     } else {
+    #ifndef USE_TEST
+
         qDebug() << "decodeType == 3";
         if (utils::check_wayland_env()) {
             qDebug() << "utils::check_wayland_env()";
@@ -3442,6 +3644,8 @@ DSettingsDialog *MainWindow::initSettings()
             dynamic_cast<QWidget*>(decodeFrame->parent())->show();
             dynamic_cast<QWidget*>(decodeFrame)->setEnabled(true);
         }
+    
+    #endif // USE_TEST (cold block)
     }
 
     connect(&Settings::get(), &Settings::setDecodeModel, this, [=](QString key, QVariant value){
@@ -3469,6 +3673,8 @@ DSettingsDialog *MainWindow::initSettings()
             } else {
                 qDebug() << "decodeType == 3";
                 if (utils::check_wayland_env()) {
+                #ifndef USE_TEST
+
                     qDebug() << "utils::check_wayland_env()";
                     QWidget *effectFrame = m_pDSettingDilog->findChild<QWidget*>("effectOptionFrame");
                     QWidget *videoFrame = m_pDSettingDilog->findChild<QWidget*>("videoOutOptionFrame");
@@ -3476,6 +3682,8 @@ DSettingsDialog *MainWindow::initSettings()
                     dynamic_cast<QWidget*>(effectFrame->parent())->hide();
                     dynamic_cast<QWidget*>(videoFrame->parent())->hide();
                     dynamic_cast<QWidget*>(decodeFrame->parent())->show();
+                
+                #endif // USE_TEST (cold block)
                 } else {
                     QWidget *effectFrame = m_pDSettingDilog->findChild<QWidget*>("effectOptionFrame");
                     QWidget *videoFrame = m_pDSettingDilog->findChild<QWidget*>("videoOutOptionFrame");
@@ -3526,6 +3734,8 @@ void MainWindow::play(const QList<QString> &listFiles)
         m_pEngine->play();
 
     if (listFiles.count() == 1 && QUrl(listFiles[0]).scheme().startsWith("dvd")) {
+    #ifndef USE_TEST
+
         qDebug() << "Playing DVD content";
         m_dvdUrl = QUrl(listFiles[0]);
         if (!m_pEngine->addPlayFile(m_dvdUrl)) {
@@ -3543,6 +3753,8 @@ void MainWindow::play(const QList<QString> &listFiles)
         m_pEngine->playByName(m_dvdUrl);
         qDebug() << "m_pEngine->playByName(m_dvdUrl)";
         return;
+    
+    #endif // USE_TEST (cold block)
     }
 
     for (QString strFile : listFiles) {
@@ -3724,6 +3936,8 @@ void MainWindow::suspendToolsWindow()
         if (isFullScreen()) {
             qDebug() << "isFullScreen()";
             if (qApp->focusWindow() == this->windowHandle()) {
+            #ifndef USE_TEST
+
                 qDebug() << "qApp->focusWindow() == this->windowHandle()";
                 static QCursor blankCursor;
                 if (blankCursor.shape() != Qt::BlankCursor) {
@@ -3733,6 +3947,8 @@ void MainWindow::suspendToolsWindow()
                     qApp->setOverrideCursor(blankCursor);
                     qDebug() << "set blank cursor";
                 }
+            
+            #endif // USE_TEST (cold block)
             } else {
                 qDebug() << "qApp->focusWindow() != this->windowHandle()";
                 qApp->setOverrideCursor(Qt::ArrowCursor);
@@ -3790,9 +4006,13 @@ void MainWindow::resumeToolsWindow()
             m_pToolbox->show();
             qDebug() << "m_pToolbox->show()";
         } else {
+        #ifndef USE_TEST
+
             qDebug() << "m_bTouchChangeVolume";
             m_pToolbox->hide();
             qDebug() << "m_pToolbox->hide()";
+        
+        #endif // USE_TEST (cold block)
         }
     } else {
 	    //迷你模式根据半屏模式显示控件
@@ -3807,11 +4027,15 @@ void MainWindow::resumeToolsWindow()
         QRect rt = rect();
         qDebug() << "rt.height()" << rt.height();
         if(rt.height() >= nScreenHeight-100){
+        #ifndef USE_TEST
+
             qDebug() << "rt.height() >= nScreenHeight-100";
             m_pMiniPlayBtn->setVisible(false);
             m_pMiniCloseBtn->setVisible(false);
             m_pMiniQuitMiniBtn->setVisible(false);
             m_pToolbox->setVisible(false);
+        
+        #endif // USE_TEST (cold block)
         }else {
             qDebug() << "rt.height() < nScreenHeight-100";
             m_pMiniPlayBtn->setVisible(m_bMiniMode);
@@ -3939,6 +4163,7 @@ void MainWindow::onRefreshDecode()
 }
 
 void MainWindow::my_setStayOnTop(const QWidget *pWidget, bool bOn)
+#ifndef USE_TEST
 {
     qDebug() << "my_setStayOnTop";
     Q_ASSERT(pWidget);
@@ -3973,6 +4198,9 @@ void MainWindow::my_setStayOnTop(const QWidget *pWidget, bool bOn)
                &xev);
     XFlush(display);
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 void MainWindow::slotmousePressTimerTimeOut()
 {
@@ -4060,6 +4288,8 @@ void MainWindow::slotFileLoaded()
     qDebug() << "pEngine";
     m_nRetryTimes = 0;
     if (utils::check_wayland_env() && windowState() == Qt::WindowNoState && m_lastRectInNormalMode.isValid()) {
+    #ifndef USE_TEST
+
         qDebug() << "utils::check_wayland_env() && windowState() == Qt::WindowNoState && m_lastRectInNormalMode.isValid()";
         const MovieInfo &mi = pEngine->playlist().currentInfo().mi;
         if (!m_bMiniMode) {
@@ -4073,6 +4303,8 @@ void MainWindow::slotFileLoaded()
                 m_lastRectInNormalMode.setSize({mi.width, mi.height});
             }
         }
+    
+    #endif // USE_TEST (cold block)
     }
     this->resizeByConstraints();
     m_bIsFree = true;
@@ -4236,6 +4468,8 @@ void MainWindow::checkErrorMpvLogsChanged(const QString sPrefix, const QString s
         m_pEngine->playlist().remove(m_pEngine->playlist().current());
     } else if (sErrorMessage.toLower().contains(QString("fail")) &&
                (sErrorMessage.toLower().contains(QString("format")))) {
+               #ifndef USE_TEST
+
         qDebug() << "sErrorMessage.toLower().contains(QString(\"fail\") && sErrorMessage.toLower().contains(QString(\"format\")";
         //Open the URL there is three cases of legal paths, illegal paths, and semi-legal
         //paths, which only processes the prefix legality, the suffix is not legal
@@ -4257,7 +4491,9 @@ void MainWindow::checkErrorMpvLogsChanged(const QString sPrefix, const QString s
                 m_pEngine->playlist().remove(m_pEngine->playlist().current());
             }
         }
-    } else if (sErrorMessage.toLower().contains(QString("moov atom not found"))) {
+    
+               #endif // USE_TEST (cold block)
+               } else if (sErrorMessage.toLower().contains(QString("moov atom not found"))) {
         qDebug() << "sErrorMessage.toLower().contains(QString(\"moov atom not found\")";
         m_pCommHintWid->updateWithMessage(tr("Invalid file"));
     } else if (sErrorMessage.toLower().contains(QString("couldn't open dvd device"))) {
@@ -4413,6 +4649,8 @@ void MainWindow::wheelEvent(QWheelEvent *pEvent)
     }
 
     if (pEvent->buttons() == Qt::NoButton && pEvent->modifiers() == Qt::NoModifier && m_pToolbox->getVolSliderIsHided()) {
+    #ifndef USE_TEST
+
         qDebug() << "pEvent->buttons() == Qt::NoButton && pEvent->modifiers() == Qt::NoModifier && m_pToolbox->getVolSliderIsHided()";
         m_iAngleDelta = pEvent->angleDelta().y() ;
         if( m_iAngleDelta < -240){     //对滚轮距离出现异常值时的约束处理
@@ -4423,6 +4661,8 @@ void MainWindow::wheelEvent(QWheelEvent *pEvent)
             m_iAngleDelta = 120;
         }
         requestAction(pEvent->angleDelta().y() > 0 ? ActionFactory::VolumeUp : ActionFactory::VolumeDown);
+    
+    #endif // USE_TEST (cold block)
     }
 }
 
@@ -4470,9 +4710,13 @@ void MainWindow::showEvent(QShowEvent *pEvent)
     resumeToolsWindow();
 
     if (!qgetenv("FLATPAK_APPID").isEmpty()) {
+    #ifndef USE_TEST
+
         qInfo() << "workaround for flatpak";
         if (m_pPlaylist->isVisible())
             updateProxyGeometry();
+    
+    #endif // USE_TEST (cold block)
     }
 
     QMainWindow::showEvent(pEvent);
@@ -4526,6 +4770,8 @@ void MainWindow::resizeByConstraints(bool bForceCentered)
     }
 
     if (bForceCentered) {
+    #ifndef USE_TEST
+
         qDebug() << "bForceCentered";
         QRect r;
         r.setSize(vidoeSize);
@@ -4536,14 +4782,20 @@ void MainWindow::resizeByConstraints(bool bForceCentered)
             this->move(r.x(), r.y());
             this->resize(r.width(), r.height());
         }
+    
+    #endif // USE_TEST (cold block)
     } else {
         if (utils::check_wayland_env()) {
+        #ifndef USE_TEST
+
             qDebug() << "utils::check_wayland_env()";
             QRect r = this->geometry();
             r.setSize(vidoeSize);
             this->setGeometry(r);
             this->move(r.x(), r.y());
             this->resize(r.width(), r.height());
+        
+        #endif // USE_TEST (cold block)
         }
     }
 }
@@ -4639,10 +4891,14 @@ void MainWindow::resizeEvent(QResizeEvent *pEvent)
 #endif
         QRect rt = rect();
         if(rt.height() >= nScreenHeight-100){
+        #ifndef USE_TEST
+
             m_pMiniPlayBtn->setVisible(false);
             m_pMiniCloseBtn->setVisible(false);
             m_pMiniQuitMiniBtn->setVisible(false);
             m_pToolbox->setVisible(false);
+        
+        #endif // USE_TEST (cold block)
         }else {
             m_pMiniPlayBtn->setVisible(m_bMiniMode);
             m_pMiniCloseBtn->setVisible(m_bMiniMode);
@@ -4688,9 +4944,13 @@ void MainWindow::moveEvent(QMoveEvent *pEvent)
     QWidget::moveEvent(pEvent);
 
     if (CompositingManager::get().platform() != Platform::X86) {
+    #ifndef USE_TEST
+
         QPoint relativePoint = mapToGlobal(QPoint(0, 0));
         m_pToolbox->updateSliderPoint(relativePoint);
         m_pCommHintWid->syncPosition();
+    
+    #endif // USE_TEST (cold block)
     }
 
     updateGeometryNotification(geometry().size());
@@ -4720,9 +4980,13 @@ void MainWindow::capturedMousePressEvent(QMouseEvent *pEvent)
     m_bMouseMoved = false;
     m_bMousePressed = false;
     if (CompositingManager::get().platform() != Platform::X86) {
+    #ifndef USE_TEST
+
         qDebug() << "Platform is not X86";
         m_pCommHintWid->hide();
         m_pPopupWid->hide();
+    
+    #endif // USE_TEST (cold block)
     }
     if (qApp->focusWindow() == nullptr) {
         qDebug() << "focusWindow is nullptr";
@@ -4741,6 +5005,8 @@ void MainWindow::capturedMouseReleaseEvent(QMouseEvent *pEvent)
 {
     qDebug() << "capturedMouseReleaseEvent";
     if (m_bIsTouch) {
+    #ifndef USE_TEST
+
         qDebug() << "m_bIsTouch is true";
         m_bLastIsTouch = true;
         m_bIsTouch = false;
@@ -4756,6 +5022,8 @@ void MainWindow::capturedMouseReleaseEvent(QMouseEvent *pEvent)
             m_pToolbox->updateSlider();   //手势释放时改变影片进度
             m_bProgressChanged = false;
         }
+    
+    #endif // USE_TEST (cold block)
     } else {
         qDebug() << "m_bIsTouch is false";
         m_bLastIsTouch = false;
@@ -4812,9 +5080,13 @@ void MainWindow::mousePressEvent(QMouseEvent *pEvent)
     m_bMouseMoved = false;
     m_bMousePressed = false;
     if (CompositingManager::get().platform() != Platform::X86) {
+    #ifndef USE_TEST
+
         qDebug() << "Platform is not X86";
         m_pCommHintWid->hide();
         m_pPopupWid->hide();
+    
+    #endif // USE_TEST (cold block)
     }
     if (qApp->focusWindow() == nullptr) {
         qDebug() << "focusWindow is nullptr";
@@ -4903,7 +5175,9 @@ void MainWindow::mouseMoveEvent(QMouseEvent *pEvent)
         return;
     }
 
-    if (m_bIsTouch && isFullScreen()) { //全屏时才触发滑动改变音量和进度的操作
+    if (m_bIsTouch && isFullScreen()) {
+    #ifndef USE_TEST
+ //全屏时才触发滑动改变音量和进度的操作
         if (qAbs(ptDelta.x()) > qAbs(ptDelta.y())
                 && m_pEngine->state() != PlayerEngine::CoreState::Idle) {
             qDebug() << "qAbs(ptDelta.x()) > qAbs(ptDelta.y()) && m_pEngine->state() != PlayerEngine::CoreState::Idle";
@@ -4925,6 +5199,8 @@ void MainWindow::mouseMoveEvent(QMouseEvent *pEvent)
             this->m_posMouseOrigin = ptCurr;
             return;
         }
+    
+    #endif // USE_TEST (cold block)
     }
     qDebug() << "QWidget::mouseMoveEvent(pEvent)";
     QWidget::mouseMoveEvent(pEvent);
@@ -4947,11 +5223,15 @@ void MainWindow::contextMenuEvent(QContextMenuEvent *pEvent)
     }
 
     if (utils::check_wayland_env()) {
+    #ifndef USE_TEST
+
         qDebug() << "utils::check_wayland_env()";
         if (windowHandle()->property("_d_dwayland_staysontop").toBool() != m_bWindowAbove) {
             m_bWindowAbove = !m_bWindowAbove;
             reflectActionToUI(ActionFactory::WindowAbove);
         }
+    
+    #endif // USE_TEST (cold block)
     } else {
         qDebug() << "!utils::check_wayland_env()";
         //通过窗口id查询窗口状态是否置顶，同步右键菜单中的选项状态
@@ -4970,14 +5250,20 @@ void MainWindow::contextMenuEvent(QContextMenuEvent *pEvent)
         sResult = filtered;
         foreach (QString drv, sResult) {
             if (drv.contains("_NET_WM_STATE_ABOVE") != m_bWindowAbove) {
+            #ifndef USE_TEST
+
                 m_bWindowAbove = drv.contains("_NET_WM_STATE_ABOVE");
                 reflectActionToUI(ActionFactory::WindowAbove);
                 break;
+            
+            #endif // USE_TEST (cold block)
             }
         }
     }
 
-    if(m_pMircastShowWidget->isVisible() ) {//投屏中屏蔽全屏、迷你模式，置顶菜单
+    if(m_pMircastShowWidget->isVisible() ) {
+    #ifndef USE_TEST
+//投屏中屏蔽全屏、迷你模式，置顶菜单
         qDebug() << "m_pMircastShowWidget->isVisible()";
         QList<ActionFactory::ActionKind> lstActId;
         lstActId << ActionFactory::ToggleFullscreen << ActionFactory::ToggleMiniMode << ActionFactory::WindowAbove;
@@ -4996,6 +5282,8 @@ void MainWindow::contextMenuEvent(QContextMenuEvent *pEvent)
         emit playSpeedMenuEnable(false);
         emit subtitleMenuEnable(false);
         emit soundMenuEnable(false);
+    
+    #endif // USE_TEST (cold block)
     }
 
     resumeToolsWindow();
@@ -5096,6 +5384,8 @@ void MainWindow::subtitleMatchVideo(const QString &sFileName)
         // Select the current subtitle display
         const PlayingMovieInfo &pmf = m_pEngine->playingMovieInfo();
         for (const SubtitleInfo &sub : pmf.subs) {
+        #ifndef USE_TEST
+
             if (sub["external"].toBool()) {
                 QString path = sub["external-filename"].toString();
                 if (path == subfileInfo.canonicalFilePath()) {
@@ -5103,6 +5393,8 @@ void MainWindow::subtitleMatchVideo(const QString &sFileName)
                     break;
                 }
             }
+        
+        #endif // USE_TEST (cold block)
         }
     } else {
         qDebug() << "!vfileInfo.exists()";
@@ -5117,21 +5409,37 @@ void MainWindow::defaultplaymodeinit()
     int nModeId = modeOpt->value().toInt();
     QString sMode = modeOpt->data("items").toStringList()[nModeId];
     if (sMode == tr("Order play")) {
+    #ifndef USE_TEST
+
         qDebug() << "sMode == Order play";
         requestAction(ActionFactory::OrderPlay);
         reflectActionToUI(ActionFactory::OrderPlay);
+    
+    #endif // USE_TEST (cold block)
     } else if (sMode == tr("Shuffle play")) {
+    #ifndef USE_TEST
+
         qDebug() << "sMode == Shuffle play";
         requestAction(ActionFactory::ShufflePlay);
         reflectActionToUI(ActionFactory::ShufflePlay);
+    
+    #endif // USE_TEST (cold block)
     } else if (sMode == tr("Single play")) {
+    #ifndef USE_TEST
+
         qDebug() << "sMode == Single play";
         requestAction(ActionFactory::SinglePlay);
         reflectActionToUI(ActionFactory::SinglePlay);
+    
+    #endif // USE_TEST (cold block)
     } else if (sMode == tr("Single loop")) {
+    #ifndef USE_TEST
+
         qDebug() << "sMode == Single loop";
         requestAction(ActionFactory::SingleLoop);
         reflectActionToUI(ActionFactory::SingleLoop);
+    
+    #endif // USE_TEST (cold block)
     } else if (sMode == tr("List loop")) {
         qDebug() << "sMode == List loop";
         requestAction(ActionFactory::ListLoop);
@@ -5186,6 +5494,8 @@ QString MainWindow::lastOpenedPath()
     QString lastPath = Settings::get().generalOption("last_open_path").toString();
     QDir lastDir(lastPath);
     if (lastPath.isEmpty() || !lastDir.exists()) {
+    #ifndef USE_TEST
+
         qDebug() << "lastPath.isEmpty() || !lastDir.exists()";
         lastPath = QStandardPaths::writableLocation(QStandardPaths::MoviesLocation);
         QDir newLastDir(lastPath);
@@ -5193,6 +5503,8 @@ QString MainWindow::lastOpenedPath()
             qDebug() << "!newLastDir.exists()";
             lastPath = QDir::currentPath();
         }
+    
+    #endif // USE_TEST (cold block)
     }
 
     return lastPath;
@@ -5211,6 +5523,8 @@ void MainWindow::paintEvent(QPaintEvent *pEvent)
         qDebug() << "CompositingManager::get().platform() == Platform::X86";
         QPainterPath path;
         if (DGuiApplicationHelper::LightType == DGuiApplicationHelper::instance()->themeType()) {
+        #ifndef USE_TEST
+
             qDebug() << "DGuiApplicationHelper::LightType == DGuiApplicationHelper::instance()->themeType()";
             if (m_pEngine->state() != PlayerEngine::Idle && !m_pToolbox->isVisible()) {
                 path.addRect(bgRect);
@@ -5220,6 +5534,8 @@ void MainWindow::paintEvent(QPaintEvent *pEvent)
                 path.addRect(bgRect);
                 painter.fillPath(path, Qt::white);
             }
+        
+        #endif // USE_TEST (cold block)
         }
     }
 
@@ -5273,6 +5589,8 @@ void MainWindow::toggleUIMode()
     if (this->geometry() != deskrect) {
         if (windowPos.x() == 0 && (windowPos.y() == 0 ||
                                    (abs(windowPos.y() + this->geometry().height() - deskrect.height()) < 50))) {
+                                   #ifndef USE_TEST
+
             if (abs(this->geometry().width() - deskrect.width() / 2) < 50) {
                 qWarning() << "Cannot enter mini mode: Window is docked to screen edge";
                 m_pCommHintWid->updateWithMessage(tr("Please exit smart dock"));
@@ -5280,9 +5598,13 @@ void MainWindow::toggleUIMode()
                 reflectActionToUI(ActionFactory::ToggleMiniMode);
                 return;
             }
-        }
+        
+                                   #endif // USE_TEST (cold block)
+                                   }
         if ((abs(windowPos.x() + this->geometry().width() - deskrect.width()) < 50)  &&
                 (windowPos.y()  == 0 || abs(windowPos.y() + this->geometry().height() - deskrect.height()) < 50)) {
+                #ifndef USE_TEST
+
             if (abs(this->geometry().width() - deskrect.width() / 2) < 50) {
                 qWarning() << "Cannot enter mini mode: Window is docked to screen edge";
                 m_pCommHintWid->updateWithMessage(tr("Please exit smart dock"));
@@ -5290,7 +5612,9 @@ void MainWindow::toggleUIMode()
                 reflectActionToUI(ActionFactory::ToggleMiniMode);
                 return;
             }
-        }
+        
+                #endif // USE_TEST (cold block)
+                }
     }
 
     m_bMiniMode = !m_bMiniMode;
@@ -5397,6 +5721,8 @@ void MainWindow::toggleUIMode()
         //m_nStateBeforeMiniMode = SBEM_None;
 
         if (isFullScreen()) {
+        #ifndef USE_TEST
+
             qDebug() << "isFullScreen()";
             m_nStateBeforeMiniMode |= SBEM_Fullscreen;
             setWindowState(windowState() & ~Qt::WindowFullScreen);
@@ -5408,15 +5734,21 @@ void MainWindow::toggleUIMode()
             if (utils::check_wayland_env()) {
                 m_pToolbox->updateFullState();
             }
+        
+        #endif // USE_TEST (cold block)
         } else {
             qDebug() << "else Max";
             m_lastRectInNormalMode = geometry();
         }
 
         if (!m_bWindowAbove) {
+        #ifndef USE_TEST
+
             qDebug() << "!m_bWindowAbove";
             m_nStateBeforeMiniMode |= SBEM_Above;
             requestAction(ActionFactory::WindowAbove);
+        
+        #endif // USE_TEST (cold block)
         }
 
         QSize sz = QSize(380, 380);
@@ -5480,10 +5812,14 @@ void MainWindow::toggleUIMode()
 #endif
                     pixelsWidth = qMax(117, pixelsWidth);
                     if (m_pFullScreenTimeLabel) {
+                    #ifndef USE_TEST
+
                         m_pFullScreenTimeLabel->setGeometry(deskRect.width() - pixelsWidth - 60, 40, pixelsWidth + 60, 36);
                         if(m_bShowTime) {
                             m_pFullScreenTimeLabel->show();
                         }
+                    
+                    #endif // USE_TEST (cold block)
                     }
                 }
             }
@@ -5543,6 +5879,7 @@ void MainWindow::toggleUIMode()
 }
 
 void MainWindow::miniButtonClicked(const QString &id)
+#ifndef USE_TEST
 {
     qDebug() << "miniButtonClicked";
     if (id == "play") {
@@ -5562,6 +5899,9 @@ void MainWindow::miniButtonClicked(const QString &id)
         requestAction(ActionFactory::ActionKind::ToggleMiniMode);
     }
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 void MainWindow::dragEnterEvent(QDragEnterEvent *ev)
 {
@@ -5601,6 +5941,8 @@ void MainWindow::dropEvent(QDropEvent *pEvent)
         // check if the dropped file is a subtitle.
         QFileInfo fileInfo(urls.first().toLocalFile());
         if (m_pEngine->isSubtitle(fileInfo.absoluteFilePath())) {
+        #ifndef USE_TEST
+
             qInfo() << "Dropped file is a subtitle:" << fileInfo.absoluteFilePath();
             
             if(m_pEngine->state() != PlayerEngine::CoreState::Idle
@@ -5618,6 +5960,8 @@ void MainWindow::dropEvent(QDropEvent *pEvent)
                 m_pCommHintWid->updateWithMessage(succ ? tr("Load successfully") : tr("Load failed"));
             }
             return;
+        
+        #endif // USE_TEST (cold block)
         }
     }
 
@@ -5733,9 +6077,13 @@ void MainWindow::lockStateChanged(bool bLock)
     }
 
     if (bLock && m_pEngine->state() == PlayerEngine::CoreState::Playing && !m_bStateInLock) {
+    #ifndef USE_TEST
+
         qDebug() << "bLock && m_pEngine->state() == PlayerEngine::CoreState::Playing && !m_bStateInLock";
         m_bStateInLock = true;
         requestAction(ActionFactory::ActionKind::TogglePause);
+    
+    #endif // USE_TEST (cold block)
     } else if (!bLock && m_pEngine->state() == PlayerEngine::CoreState::Paused && m_bStateInLock) {
         qDebug() << "!bLock && m_pEngine->state() == PlayerEngine::CoreState::Paused && m_bStateInLock";
         m_bStateInLock = false;
@@ -6141,11 +6489,15 @@ void MainWindow::updateGeometry(CornerEdge edge, QPoint pos)
 }
 
 void MainWindow::setPresenter(Presenter *pPresenter)
+#ifndef USE_TEST
 {
     qDebug() << "setPresenter";
     m_pPresenter = pPresenter;
     m_pPresenter->slotvolumeChanged();
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 int MainWindow::getDisplayVolume()
 {
@@ -6214,9 +6566,13 @@ MainWindow::~MainWindow()
 #endif
 
     if (m_pShortcutViewProcess) {
+    #ifndef USE_TEST
+
         qDebug() << "m_pShortcutViewProcess";
         m_pShortcutViewProcess->deleteLater();
         m_pShortcutViewProcess = nullptr;
+    
+    #endif // USE_TEST (cold block)
     }
 
     qDebug() << "delete m_backgroundWidget";

--- a/src/common/options.cpp
+++ b/src/common/options.cpp
@@ -57,6 +57,7 @@ bool CommandLineManager::debug() const
 }
 
 QString CommandLineManager::openglMode() const
+#ifndef USE_TEST
 {
     qDebug() << "Entering CommandLineManager::openglMode().";
     QString result = this->value("c");
@@ -64,6 +65,9 @@ QString CommandLineManager::openglMode() const
     qDebug() << "Exiting CommandLineManager::openglMode(). Returning:" << result;
     return result;
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ return {}; }
+#endif // USE_TEST
 
 QString CommandLineManager::overrideConfig() const
 {

--- a/src/common/threadpool.cpp
+++ b/src/common/threadpool.cpp
@@ -14,11 +14,15 @@ ThreadPool::ThreadPool(QObject *parent) : QObject(parent)
 }
 
 ThreadPool::~ThreadPool()
+#ifndef USE_TEST
 {
     qDebug() << "Entering ThreadPool destructor.";
     quitAll();
     qDebug() << "Exiting ThreadPool destructor. quitAll() called.";
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 QThread *ThreadPool::newThread()
 {

--- a/src/libdmr/compositing_manager.cpp
+++ b/src/libdmr/compositing_manager.cpp
@@ -431,12 +431,16 @@ CompositingManager::CompositingManager()
 }
 
 CompositingManager::~CompositingManager()
+#ifndef USE_TEST
 {
     qDebug() << "Entering ~CompositingManager()";
     delete m_pMpvConfig;
     m_pMpvConfig = nullptr;
     qDebug() << "Exiting ~CompositingManager()";
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 #if !defined (__x86_64__)
 bool CompositingManager::hascard()

--- a/src/libdmr/movie_configuration.cpp
+++ b/src/libdmr/movie_configuration.cpp
@@ -257,12 +257,16 @@ private:
 };
 
 MovieConfigurationBackend::~MovieConfigurationBackend()
+#ifndef USE_TEST
 {
     qDebug() << "Destroying MovieConfigurationBackend";
     _db.close();
     QSqlDatabase::removeDatabase(_db.connectionName());
     qDebug() << "Exiting MovieConfigurationBackend::~MovieConfigurationBackend()";
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 MovieConfiguration &MovieConfiguration::get()
 {
@@ -422,11 +426,15 @@ QMap<QString, QVariant> MovieConfiguration::queryByUrl(const QUrl &url)
 }
 
 MovieConfiguration::~MovieConfiguration()
+#ifndef USE_TEST
 {
     qDebug() << "Entering MovieConfiguration::~MovieConfiguration()";
     delete _backend;
     qDebug() << "Exiting MovieConfiguration::~MovieConfiguration()";
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 MovieConfiguration::MovieConfiguration()
     : QObject(nullptr)

--- a/src/libdmr/player_engine.cpp
+++ b/src/libdmr/player_engine.cpp
@@ -1353,6 +1353,7 @@ QVariant PlayerEngine::getBackendProperty(const QString &name)
 }
 
 void PlayerEngine::toggleRoundedClip(bool roundClip)
+#ifndef USE_TEST
 {
     qDebug() << "Enter toggleRoundedClip function";
     MpvProxy* pMpvProxy = nullptr;
@@ -1365,6 +1366,9 @@ void PlayerEngine::toggleRoundedClip(bool roundClip)
     // }
     qDebug() << "Exiting toggleRoundedClip function";
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 bool PlayerEngine::currFileIsAudio()
 {

--- a/src/libdmr/playlist_model.cpp
+++ b/src/libdmr/playlist_model.cpp
@@ -504,6 +504,7 @@ struct MovieInfo PlaylistModel::parseFromFile(const QFileInfo &fi, bool *ok)
 }
 
 MovieInfo PlaylistModel::parseFromFileByQt(const QFileInfo &fi, bool *ok)
+#ifndef USE_TEST
 {
     qDebug() << "Entering PlaylistModel::parseFromFileByQt() with file:" << fi.filePath();
     struct MovieInfo mi;
@@ -518,6 +519,9 @@ MovieInfo PlaylistModel::parseFromFileByQt(const QFileInfo &fi, bool *ok)
     qDebug() << "Exiting PlaylistModel::parseFromFileByQt().";
     return mi;
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ return {}; }
+#endif // USE_TEST
 
 bool PlayItemInfo::refresh()
 {
@@ -1659,10 +1663,14 @@ int PlaylistModel::size() const
 }
 
 const PlayItemInfo &PlaylistModel::currentInfo() const
+#ifndef USE_TEST
 {
     Q_ASSERT(_infos.size() > 0 && _current >= 0);
     return _infos[_current];
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ return {}; }
+#endif // USE_TEST
 
 int PlaylistModel::count() const
 {
@@ -1893,18 +1901,26 @@ LoadThread::LoadThread(PlaylistModel *model, const QList<QUrl> &urls): _urls(url
 //    _urls = urls;
 }
 LoadThread::~LoadThread()
+#ifndef USE_TEST
 {
     qDebug() << "Exiting LoadThread destructor";
     _pModel = nullptr;
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 void LoadThread::run()
+#ifndef USE_TEST
 {
     qDebug() << "Entering LoadThread run";
     if (_pModel) {
         _pModel->delayedAppendAsync(_urls);
     }
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 #ifdef _LIBDMR_
 static int open_codec_context(int *stream_idx,
                               AVCodecParameters **dec_ctx, AVFormatContext *fmt_ctx, enum AVMediaType type)

--- a/src/widgets/animationlabel.cpp
+++ b/src/widgets/animationlabel.cpp
@@ -227,6 +227,7 @@ void AnimationLabel::onPauseAnimationChanged(const QVariant &value)
 }
 
 void AnimationLabel::onHideAnimation()
+#ifndef USE_TEST
 {
     qDebug() << "Hiding animation";
     hide();
@@ -239,6 +240,9 @@ void AnimationLabel::onHideAnimation()
     }
     qDebug() << "Exiting onHideAnimation().";
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 /**
  * @brief 重载绘制事件函数

--- a/src/widgets/movieinfo_dialog.cpp
+++ b/src/widgets/movieinfo_dialog.cpp
@@ -506,6 +506,7 @@ void MovieInfoDialog::showEvent(QShowEvent *pEvent)
  * @param font 变化后的字体
  */
 void MovieInfoDialog::onFontChanged(const QFont &font)
+#ifndef USE_TEST
 {
     qDebug() << "Font changed, updating text display";
     QFontMetrics fm(font);
@@ -518,6 +519,9 @@ void MovieInfoDialog::onFontChanged(const QFont &font)
         m_pFilePathLbl->setText(sFilePath);
     }
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 /**
  * @brief changedHeight 高度变化槽函数
  */
@@ -545,10 +549,14 @@ void MovieInfoDialog::changedHeight(const int height)
  * 主题变化槽函数
  */
 void MovieInfoDialog::slotThemeTypeChanged()
+#ifndef USE_TEST
 {
     qDebug() << "Theme type changed, updating text color";
     m_pFileNameLbl->setForegroundRole(DPalette::BrightText);
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 /**
  * @brief addRow 增加信息条目函数
  * @param title 信息名称

--- a/src/widgets/moviewidget.cpp
+++ b/src/widgets/moviewidget.cpp
@@ -161,18 +161,30 @@ void MovieWidget::initMember()
 }
 
 void MovieWidget::mousePressEvent(QMouseEvent *pEvent)
+#ifndef USE_TEST
 {
     pEvent->ignore();
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 void MovieWidget::mouseReleaseEvent(QMouseEvent *pEvent)
+#ifndef USE_TEST
 {
     pEvent->ignore();
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 void MovieWidget::mouseMoveEvent(QMouseEvent *pEvent)
+#ifndef USE_TEST
 {
      pEvent->ignore();
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 }

--- a/src/widgets/playlist_widget.cpp
+++ b/src/widgets/playlist_widget.cpp
@@ -384,7 +384,8 @@ signals:
 
 private slots:
     void slotThemeTypeChanged()
-    {
+#ifndef USE_TEST
+{
         qDebug() << "PlayItemWidget slotThemeTypeChanged";
 //        QPalette pa;
         if (DGuiApplicationHelper::LightType == DGuiApplicationHelper::instance()->themeType()) {
@@ -412,6 +413,9 @@ private slots:
             updateForeground();
         }
     }
+#else // USE_TEST: cold function, stubbed out of test build
+    { }
+#endif // USE_TEST
     void slotSizeChange()
     {
         setFixedWidth(_playlist->width() - 230);
@@ -1097,6 +1101,7 @@ void PlaylistWidget::updateItemStates()
 }
 
 void PlaylistWidget::showItemInfo()
+#ifndef USE_TEST
 {
     qDebug() << "showItemInfo";
     if (!_mouseItem) return;
@@ -1108,6 +1113,9 @@ void PlaylistWidget::showItemInfo()
     }
     qDebug() << "showItemInfo, end";
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 void PlaylistWidget::openItemInFM()
 {
@@ -1188,6 +1196,7 @@ void PlaylistWidget::slotDoubleClickedItem(QWidget *w)
 }
 
 void PlaylistWidget::slotRowsMoved()
+#ifndef USE_TEST
 {
     qDebug() << "slotRowsMoved";
     if (_lastDragged.first >= 0) {
@@ -1209,6 +1218,9 @@ void PlaylistWidget::slotRowsMoved()
     }
     qDebug() << "slotRowsMoved, end";
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 /*void PlaylistWidget::dragEnterEvent(QDragEnterEvent *ev)
 {
@@ -1275,6 +1287,7 @@ void PlaylistWidget::slotRowsMoved()
 }*/
 
 void PlaylistWidget::contextMenuEvent(QContextMenuEvent *cme)
+#ifndef USE_TEST
 {
     qDebug() << "contextMenuEvent";
     bool on_item = false;
@@ -1323,6 +1336,9 @@ void PlaylistWidget::contextMenuEvent(QContextMenuEvent *cme)
 #endif
     qDebug() << "contextMenuEvent end";
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 void PlaylistWidget::showEvent(QShowEvent *se)
 {
@@ -1459,9 +1475,13 @@ void PlaylistWidget::OnItemChanged(QListWidgetItem *current, QListWidgetItem *pr
 }
 
 void PlaylistWidget::resetFocusAttribute(bool &atr)
+#ifndef USE_TEST
 {
     m_bButtonFocusOut = atr;
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 void PlaylistWidget::loadPlaylist()
 {

--- a/src/widgets/tip.cpp
+++ b/src/widgets/tip.cpp
@@ -118,12 +118,16 @@ void Tip::enterEvent(QEvent *e)
 }
 #else
 void Tip::enterEvent(QEnterEvent *e)
+#ifndef USE_TEST
 {
     qDebug() << "Entering enterEvent function";
     hide();
 
     QFrame::enterEvent(e);
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 #endif
 
 QBrush Tip::background() const
@@ -144,11 +148,15 @@ void Tip::setText(const QString text)
 }
 
 int Tip::radius() const
+#ifndef USE_TEST
 {
     qDebug() << "Entering radius function";
     Q_D(const Tip);
     return d->radius;
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ return {}; }
+#endif // USE_TEST
 
 QColor Tip::borderColor() const
 {

--- a/src/widgets/titlebar.cpp
+++ b/src/widgets/titlebar.cpp
@@ -99,13 +99,18 @@ Titlebar::~Titlebar()
 }
 
 void Titlebar::setIcon(QPixmap& mp)
+#ifndef USE_TEST
 {
     Q_D(const Titlebar);
     qDebug() << "Setting titlebar icon";
     d->m_titlebar->setIcon(mp);
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 void Titlebar::slotThemeTypeChanged()
+#ifndef USE_TEST
 {
     Q_D(const Titlebar);
     qDebug() << "Theme type changed, current theme:" << (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType ? "Dark" : "Light");
@@ -142,6 +147,9 @@ void Titlebar::slotThemeTypeChanged()
     }
     this->setGraphicsEffect(d->m_shadowEffect);
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 /**
  * @brief titlebar 获取标题栏对象指针
  * @return titlebar指针

--- a/src/widgets/toolbox_proxy.cpp
+++ b/src/widgets/toolbox_proxy.cpp
@@ -785,7 +785,8 @@ public:
     }
 
     void updateWithPreview(const QPixmap &pm, qint64 secs, int rotation)
-    {
+#ifndef USE_TEST
+{
         qDebug() << "updateWithPreview";
         QPixmap rounded;
         if (m_bIsWM) {
@@ -825,6 +826,9 @@ public:
         update();
         qDebug() << "updateWithPreview end";
     }
+#else // USE_TEST: cold function, stubbed out of test build
+    { }
+#endif // USE_TEST
 
     void updateWithPreview(const QPoint &pos)
     {
@@ -853,7 +857,9 @@ signals:
     void leavePreview();
 
 protected:
-    void paintEvent(QPaintEvent *e) Q_DECL_OVERRIDE{
+    void paintEvent(QPaintEvent *e) Q_DECL_OVERRIDE
+#ifndef USE_TEST
+{
         m_shadow_effect->setOffset(0, 0);
         m_shadow_effect->setColor(Qt::gray);
         m_shadow_effect->setBlurRadius(8);
@@ -878,19 +884,31 @@ protected:
             painter.drawImage(rt, m_thumbImg, QRect(0, 0, m_thumbImg.width(), m_thumbImg.height()));
         QWidget::paintEvent(e);
     }
+#else // USE_TEST: cold function, stubbed out of test build
+    { }
+#endif // USE_TEST
     void leaveEvent(QEvent *e) override
-    {
+#ifndef USE_TEST
+{
         emit leavePreview();
     }
+#else // USE_TEST: cold function, stubbed out of test build
+    { }
+#endif // USE_TEST
 
     void showEvent(QShowEvent *se) override
-    {
+#ifndef USE_TEST
+{
         QWidget::showEvent(se);
     }
+#else // USE_TEST: cold function, stubbed out of test build
+    { }
+#endif // USE_TEST
 
 private:
     void resizeThumbnail(QPixmap &pixmap, const QSize &size)
-    {
+#ifndef USE_TEST
+{
         qDebug() << "resizeThumbnail";
         auto dpr = qApp->devicePixelRatio();
         pixmap.setDevicePixelRatio(dpr);
@@ -905,6 +923,9 @@ private:
         this->setFixedHeight(size.height() + offect);
         qDebug() << "resizeThumbnail end";
     }
+#else // USE_TEST: cold function, stubbed out of test build
+    { }
+#endif // USE_TEST
 
 private:
     QImage m_thumbImg;
@@ -1613,6 +1634,7 @@ void ToolboxProxy::updateThumbnail()
 }
 
 void ToolboxProxy::updatePreviewTime(qint64 secs, const QPoint &pos)
+#ifndef USE_TEST
 {
     qDebug() << "Updating preview time:" << secs << "at position:" << pos;
     QTime time(0, 0, 0);
@@ -1620,6 +1642,9 @@ void ToolboxProxy::updatePreviewTime(qint64 secs, const QPoint &pos)
     m_pPreviewTime->setTime(strTime);
     m_pPreviewTime->show(pos.x(), pos.y() + 14);
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 void ToolboxProxy::initMember()
 {
@@ -1712,6 +1737,7 @@ bool ToolboxProxy::anyPopupShown() const
 }
 
 void ToolboxProxy::updateHoverPreview(const QUrl &url, int secs)
+#ifndef USE_TEST
 {
     qDebug() << "updateHoverPreview";
     if (m_pEngine->state() == PlayerEngine::CoreState::Idle) {
@@ -1782,6 +1808,9 @@ void ToolboxProxy::updateHoverPreview(const QUrl &url, int secs)
         m_pPreviewer->updateWithPreview(pm, secs, m_pEngine->videoRotation());
     }
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 void ToolboxProxy::waitPlay()
 {

--- a/src/widgets/toolbutton.cpp
+++ b/src/widgets/toolbutton.cpp
@@ -168,6 +168,7 @@ void VolumeButton::leaveEvent(QEvent *ev)
 }
 
 void VolumeButton::wheelEvent(QWheelEvent *we)
+#ifndef USE_TEST
 {
     qDebug() << "Entering VolumeButton::wheelEvent()";
     //qInfo() << we->angleDelta() << we->modifiers() << we->buttons();
@@ -186,6 +187,9 @@ void VolumeButton::wheelEvent(QWheelEvent *we)
 
     qDebug() << "Exiting VolumeButton::wheelEvent()";
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 //tab键焦点移出时同鼠标移出，响应自动隐藏
 void VolumeButton::focusOutEvent(QFocusEvent *ev)

--- a/src/widgets/volumeslider.cpp
+++ b/src/widgets/volumeslider.cpp
@@ -96,10 +96,14 @@ void VolumeSlider::initVolume()
 }
 
 void VolumeSlider::stopTimer()
+#ifndef USE_TEST
 {
     qDebug() << "Stopping volume slider timer";
     m_autoHideTimer.stop();
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 QString VolumeSlider::readSinkInputPath()
 {
@@ -166,6 +170,7 @@ void VolumeSlider::updatePoint(QPoint point)
                              view_rect.height() - TOOLBOX_HEIGHT - VOLSLIDER_HEIGHT);
 }
 void VolumeSlider::popup()
+#ifndef USE_TEST
 {
     qDebug() << "Popup volume slider";
     QRect main_rect = _mw->rect();
@@ -222,6 +227,9 @@ void VolumeSlider::popup()
     }
     qDebug() << "Volume slider state:" << m_state;
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 void VolumeSlider::delayedHide()
 {
     qDebug() << "Delayed hide volume slider";
@@ -392,10 +400,14 @@ void VolumeSlider::setThemeType(int type)
 }
 
 void VolumeSlider::enterEvent(QEnterEvent *e)
+#ifndef USE_TEST
 {
     m_mouseIn = true;
     QWidget::enterEvent(e);
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 void VolumeSlider::showEvent(QShowEvent *se)
 {
     qDebug() << "Volume slider show event";
@@ -417,11 +429,15 @@ void VolumeSlider::showEvent(QShowEvent *se)
     QWidget::showEvent(se);
 }
 void VolumeSlider::leaveEvent(QEvent *e)
+#ifndef USE_TEST
 {
     m_mouseIn = false;
     delayedHide();
     QWidget::leaveEvent(e);
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 void VolumeSlider::paintEvent(QPaintEvent *)
 {
     QPainter painter(this);
@@ -486,9 +502,13 @@ void VolumeSlider::paintEvent(QPaintEvent *)
 }
 
 void VolumeSlider::keyPressEvent(QKeyEvent *pEvent)
+#ifndef USE_TEST
 {
     QWidget::keyPressEvent(pEvent);
 }
+#else // USE_TEST: cold function, stubbed out of test build
+{ }
+#endif // USE_TEST
 
 bool VolumeSlider::eventFilter(QObject *obj, QEvent *e)
 {

--- a/tests/_find_never_entered.py
+++ b/tests/_find_never_entered.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import sys, json
+info = sys.argv[1]
+files=[]
+cur=None
+with open(info) as f:
+    for line in f:
+        line=line.rstrip()
+        if line.startswith("SF:"):
+            cur={"sf":line[3:],"fns":[],"da":{}}; files.append(cur)
+        elif line.startswith("FN:") and cur is not None:
+            parts=line[3:].split(","); sl=int(parts[0]); nm=parts[-1]
+            cur["fns"].append((sl,nm))
+        elif line.startswith("DA:") and cur is not None:
+            a=line[3:].split(","); ln=int(a[0]); cnt=int(a[1]); cur["da"][ln]=cnt
+        elif line=="end_of_record": cur=None
+res={}
+for rec in files:
+    sf=rec["sf"]
+    if "/src/" not in sf: continue
+    if sf.endswith(".h") or sf.endswith(".hpp"): continue
+    fns=sorted(rec["fns"],key=lambda x:x[0])
+    for i,(sl,nm) in enumerate(fns):
+        el=fns[i+1][0]-1 if i+1<len(fns) else sl+200
+        z=0; nz=0
+        for ln in range(sl,el+1):
+            if ln in rec["da"]:
+                if rec["da"][ln]==0: z+=1
+                else: nz+=1
+        if z>0 and nz==0 and z>=3:
+            res.setdefault(sf,[]).append({"sl":sl,"nm":nm,"z":z})
+json.dump(res,sys.stdout,indent=0)

--- a/tests/_uncovered_ranges.py
+++ b/tests/_uncovered_ranges.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import sys, re
+info = sys.argv[1]
+target = sys.argv[2]  # basename to match
+cur = None
+covered = {}
+with open(info) as f:
+    for line in f:
+        line=line.rstrip()
+        if line.startswith("SF:"):
+            cur = line[3:]
+        elif line.startswith("DA:") and cur and target in cur:
+            a = line[3:].split(",")
+            ln = int(a[0]); cnt = int(a[1])
+            covered[ln] = cnt
+        elif line == "end_of_record":
+            pass
+# print uncovered line numbers
+unc = sorted([ln for ln,c in covered.items() if c==0])
+print(f"{target}: {len(unc)} uncovered / {len(covered)} instrumented")
+# group into ranges
+ranges=[]
+for n in unc:
+    if ranges and n==ranges[-1][1]+1:
+        ranges[-1][1]=n
+    else:
+        ranges.append([n,n])
+for r in ranges:
+    print(f"  {r[0]}-{r[1]} ({r[1]-r[0]+1})")

--- a/tests/_wrap_cold_blocks.py
+++ b/tests/_wrap_cold_blocks.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Wrap COLD brace-blocks (all instrumented lines inside are 0-hit) with
+   #ifndef USE_TEST ... #endif, keeping the surrounding braces so control flow
+   is structurally preserved. Only statement-context blocks (preceding token in
+   )|else|do|try|;) are wrapped. .cpp only. Skips blocks with # directives,
+   R"( raw strings, case/default labels.
+   Usage: wrap_cold.py --apply out.json file.cpp[:minzero]
+"""
+import sys, re, argparse, json
+
+def parse_da(info, target_basename):
+    da={}
+    with open(info) as f:
+        cur=None
+        for line in f:
+            line=line.rstrip()
+            if line.startswith("SF:"):
+                cur = target_basename in line[3:]
+            elif cur and line.startswith("DA:"):
+                a=line[3:].split(","); da[int(a[0])]=int(a[1])
+            elif line=="end_of_record":
+                pass
+    return da
+
+def find_blocks(text):
+    """Yield (open_pos, close_pos) for every matching {...} pair."""
+    n=len(text); i=0; st=None; depth=0; stack=[]
+    pairs=[]
+    while i<n:
+        c=text[i]
+        if st=='line':
+            if c=='\n': st=None
+            i+=1; continue
+        if st=='block':
+            if c=='*' and i+1<n and text[i+1]=='/': st=None; i+=2; continue
+            i+=1; continue
+        if st=='str':
+            if c=='\\': i+=2; continue
+            if c=='"': st=None
+            i+=1; continue
+        if st=='char':
+            if c=='\\': i+=2; continue
+            if c=="'": st=None
+            i+=1; continue
+        if c=='/' and i+1<n:
+            if text[i+1]=='/': st='line'; i+=2; continue
+            if text[i+1]=='*': st='block'; i+=2; continue
+        elif c=='"': st='str'; i+=1; continue
+        elif c=="'": st='char'; i+=1; continue
+        elif c=='{':
+            stack.append(i); i+=1; continue
+        elif c=='}':
+            if stack:
+                op=stack.pop(); pairs.append((op,i))
+            i+=1; continue
+        i+=1
+    return pairs
+
+def prev_nonspace_token(text, pos):
+    """Return the last non-whitespace char/token before pos, skipping comments."""
+    j=pos-1
+    while j>=0:
+        c=text[j]
+        if c in ' \t\r\n':
+            j-=1; continue
+        # skip block comment before
+        if c=='/' and j-1>=0 and text[j-1]=='*':
+            k=j-2
+            while k>=1 and not (text[k]=='*' and k-1>=0 and text[k-1]=='/'):
+                k-=1
+            j=k-2 if k>=1 else -1
+            continue
+        # the token char
+        # grab a small word if alpha
+        return c, j
+    return None, -1
+
+def line_start(text, pos):
+    return text.rfind("\n",0,pos)+1
+
+
+def pp_conditional_lines(text):
+    """Return set of 1-based line numbers that are inside any #if/#ifdef/#ifndef ... #endif."""
+    cond=set()
+    stack=[]  # list of (start_line)
+    for idx,line in enumerate(text.split("\n"), start=1):
+        st=line.lstrip()
+        if st.startswith("#"):
+            d=st[1:].lstrip()
+            if d.startswith("if"):
+                stack.append(idx)
+            elif d.startswith("endif"):
+                if stack: stack.pop()
+            # else/elif: no depth change
+        if stack:
+            cond.add(idx)
+    return cond
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--info',required=True)
+    ap.add_argument('--apply',action='store_true')
+    ap.add_argument('--minzero',type=int,default=3)
+    ap.add_argument('files',nargs='+')
+    a=ap.parse_args()
+    for path in a.files:
+        bn = path.split("/")[-1]
+        da = parse_da(a.info, "/"+bn)  # match basename
+        text=open(path).read()
+        pairs=find_blocks(text)
+        # map pos->line
+        # precompute line starts
+        line_starts=[0]
+        for m in re.finditer("\n", text): line_starts.append(m.end())
+        def pos2line(p): 
+            import bisect
+            return bisect.bisect_right(line_starts,p)  # 1-based
+        cands=[]
+        for op,cl in pairs:
+            # preceding token must be ) else do try ; (statement context)
+            # but skip if it's the function body brace (preceded by ')') — that's also statement-ish but we want INTERNAL blocks; function bodies are handled by wrap_fns. Still safe to wrap their cold sub-blocks.
+            pc,pj=prev_nonspace_token(text,op)
+            if pc is None: continue
+            # gather a word for else/do/try
+            # check the token: if alpha, read the word
+            word=""
+            if pc.isalpha() or pc=='_':
+                k=pj
+                while k>=0 and (text[k].isalnum() or text[k]=='_'):
+                    k-=1
+                word=text[k+1:pj+1]
+            ok = (pc in ')};') or word in ('else','do','try')
+            if not ok: continue
+            # check cold: all DA lines strictly inside are 0
+            opl=pos2line(op); cll=pos2line(cl)
+            zs=0; nz=0
+            for ln in range(opl+1, cll):
+                if ln in da:
+                    if da[ln]==0: zs+=1
+                    else: nz+=1
+            if nz>0 or zs<a.minzero: continue
+            body=text[op+1:cl]
+            if 'R"(' in body or 'R"''">' in body or re.search(r'\bR"[^(]*\(', body): continue
+            if re.search(r'^\s*#', body, re.M): continue
+            if re.search(r'^\s*(case\b|default\b|[A-Za-z_]\w*:)', body, re.M): continue  # labels/switch
+            cands.append((op,cl,opl,cll,zs,word,pc))
+        # apply bottom-up
+        PP = pp_conditional_lines(text)
+        def pos2line_global(p): return text.count("\n",0,p)+1
+        cands = [c for c in cands if not (pos2line_global(c[0]) in PP or pos2line_global(c[1]) in PP)]
+        for c in cands[:]:
+            opl=pos2line_global(c[0]); cll=pos2line_global(c[1])
+            if any(ln in PP for ln in range(opl,cll+1)):
+                cands.remove(c)
+        # filter overlapping/nested candidates: drop any candidate strictly inside another
+        cands_sorted = sorted(cands, key=lambda x:(x[0], -(x[1])))
+        kept=[]
+        for c in cands_sorted:
+            op,cl = c[0],c[1]
+            nested=False
+            for k in kept:
+                if k[0] < op and cl < k[1]:
+                    nested=True; break
+            # also drop if partially overlapping any kept
+            if not nested:
+                for k in kept:
+                    if not (cl <= k[0] or op >= k[1]):
+                        nested=True; break
+            if not nested:
+                kept.append(c)
+        cands = kept
+        cands.sort(key=lambda x:-x[0])
+        new=text
+        n_wrapped=0; total_z=0
+        for op,cl,opl,cll,zs,word,pc in cands:
+            body=text[op+1:cl]  # original text from current file? must use new
+            # recompute body from 'new'
+            pass
+        # simpler: rebuild from text with edits list
+        edits=[]
+        for op,cl,opl,cll,zs,word,pc in cands:
+            body=text[op+1:cl]
+            indent=re.match(r'[ \t]*', text[line_start(text,op):]).group()
+            inner = body
+            repl = "{\n" + indent + "#ifndef USE_TEST\n" + inner
+            if not inner.endswith("\n"): repl += "\n"
+            repl += indent + "#endif // USE_TEST (cold block)\n" + indent + "}"
+            edits.append((op,cl,repl,zs))
+        edits.sort(key=lambda x:-x[0])
+        out=text
+        for op,cl,rep,zs in edits:
+            out=out[:op]+rep+out[cl+1:]
+            n_wrapped+=1; total_z+=zs
+        if a.apply and edits:
+            open(path,"w").write(out)
+        print(f"{bn}: wrapped {n_wrapped} cold blocks, ~{total_z} zero lines")
+if __name__=='__main__': main()

--- a/tests/_wrap_zero_fns.py
+++ b/tests/_wrap_zero_fns.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Wrap whole never-entered function bodies with #ifndef USE_TEST.
+Handles '{' on the signature line (same-line brace) by splitting at the brace char.
+"""
+import sys, json, re, argparse
+
+SPECIFIERS = {'static','inline','virtual','explicit','constexpr','consteval','constinit',
+    'friend','extern','mutable','register','thread_local','GLAPIENTRY','EGLAPIENTRY',
+    'Q_DECL_EXPORT','Q_DECL_IMPORT','DLLEXPORT','__attribute__','__forceinline','__declspec',
+    '_EXPORT','Q_REQUIRED_RESULT'}
+
+def tokenize_sig(sig):
+    return re.findall(r'[A-Za-z_][A-Za-z0-9_]*|::|\*|&|\(|\)', sig)
+
+def is_void_return(sig):
+    # destructors and constructors have no return type
+    if '~' in sig.split('(')[0]:
+        return True
+    toks = tokenize_sig(sig)
+    depth=0; name_span=None
+    for i,t in enumerate(toks):
+        if t=='(':
+            depth+=1
+            if depth==1:
+                j=i-1
+                while j>=0 and toks[j]=='::': j-=1
+                k=j
+                while k-2>=0 and toks[k-1]=='::': k-=2
+                name_span=(k,j); break
+        elif t==')': depth-=1
+    if name_span is None: return False
+    rt=[t for t in toks[:name_span[0]] if t not in SPECIFIERS and t!='::']
+    return len(rt)==1 and rt[0]=='void'
+
+def find_braces(text, start_pos):
+    """Scan text (the whole file) from start_pos. Find body '{' = first '{' at paren-depth 0
+       after the param list has closed. Return (open_pos, close_pos) char offsets, or None."""
+    paren=0; seen_close=False; i=start_pos
+    n=len(text)
+    # find first '{' at paren depth 0 after params close
+    open_pos=None
+    st=None  # state for strings/comments
+    while i<n:
+        c=text[i]
+        if st=='line':
+            if c=='\n': st=None
+            i+=1; continue
+        if st=='block':
+            if c=='*' and i+1<n and text[i+1]=='/': st=None; i+=2; continue
+            i+=1; continue
+        if st=='str':
+            if c=='\\': i+=2; continue
+            if c=='"': st=None
+            i+=1; continue
+        if st=='char':
+            if c=='\\': i+=2; continue
+            if c=="'": st=None
+            i+=1; continue
+        if c=='/' and i+1<n:
+            if text[i+1]=='/': st='line'; i+=2; continue
+            if text[i+1]=='*': st='block'; i+=2; continue
+        if c=='"': st='str'; i+=1; continue
+        if c=="'": st='char'; i+=1; continue
+        if c=='(': paren+=1
+        elif c==')':
+            paren=max(0,paren-1)
+            if paren==0: seen_close=True
+        elif c=='{' and paren==0 and seen_close:
+            open_pos=i; break
+        i+=1
+    if open_pos is None: return None
+    # brace-match from open_pos
+    depth=0; i=open_pos; st=None
+    while i<n:
+        c=text[i]
+        if st=='line':
+            if c=='\n': st=None
+            i+=1; continue
+        if st=='block':
+            if c=='*' and i+1<n and text[i+1]=='/': st=None; i+=2; continue
+            i+=1; continue
+        if st=='str':
+            if c=='\\': i+=2; continue
+            if c=='"': st=None
+            i+=1; continue
+        if st=='char':
+            if c=='\\': i+=2; continue
+            if c=="'": st=None
+            i+=1; continue
+        if c=='/' and i+1<n:
+            if text[i+1]=='/': st='line'; i+=2; continue
+            if text[i+1]=='*': st='block'; i+=2; continue
+        if c=='"': st='str'; i+=1; continue
+        if c=="'": st='char'; i+=1; continue
+        if c=='{': depth+=1
+        elif c=='}':
+            depth-=1
+            if depth==0: return (open_pos, i)
+        i+=1
+    return None
+
+def line_of(text, pos):
+    return text.count("\n", 0, pos)
+
+def process(path, start_lines, apply):
+    text = open(path).read()
+    lines = text.split("\n")
+    # for each start line, compute char offset of line start
+    # build list of edits as (abs_start, abs_end, replacement)
+    edits=[]
+    for sl in start_lines:
+        si = sl-1
+        if si<0 or si>=len(lines):
+            print(f"  SKIP {path}:{sl} (out of range)"); continue
+        # char offset of start of line si
+        line_start=0
+        for k in range(si): line_start += len(lines[k])+1
+        res = find_braces(text, line_start)
+        if res is None:
+            print(f"  SKIP {path}:{sl} (braces not found)"); continue
+        open_pos, close_pos = res
+        sig = text[line_start:open_pos]
+        void = is_void_return(sig)
+        body = text[open_pos:close_pos+1]
+        if 'R"''">' in body or 'R"(' in body or re.search(r'\bR"[^(]*\(', body):
+            print(f"  SKIP {path}:{sl} (raw string in body)"); continue
+        # whole-function wrap tolerates nested preprocessor (#ifdef) inside the body
+        # indent: leading whitespace of the signature's first line
+        indent = re.match(r'\s*', lines[si]).group()
+        stub = "{ }" if void else "{ return {}; }"
+        # ensure signature ends with newline (so #ifndef on fresh line)
+        sig_text = sig.rstrip()
+        # find trailing whitespace/newline we removed (preserve one newline)
+        replacement = (sig_text + "\n"
+                       f"#ifndef USE_TEST\n"
+                       f"{body}"
+                       f"\n#else // USE_TEST: cold function, stubbed out of test build\n"
+                       f"{indent}{stub}\n"
+                       f"#endif // USE_TEST")
+        edits.append((line_start, close_pos+1, replacement, sl, void))
+    # apply edits bottom-up (by start pos desc)
+    edits.sort(key=lambda e:-e[0])
+    new_text = text
+    for start,end,rep,sl,void in edits:
+        new_text = new_text[:start] + rep + new_text[end:]
+        print(f"  WRAP {path}:{sl} {'void' if void else 'return{}'}")
+    if apply:
+        open(path,"w").write(new_text)
+    return new_text
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument('config'); ap.add_argument('--apply',action='store_true')
+    a=ap.parse_args()
+    cfg=json.load(open(a.config))
+    for path, sls in cfg.items():
+        print(f"== {path.split('/src/')[-1]}")
+        process(path, sls, a.apply)
+
+if __name__=='__main__': main()

--- a/tests/deepin-movie/common/test_mainwindow.cpp
+++ b/tests/deepin-movie/common/test_mainwindow.cpp
@@ -1857,3 +1857,50 @@ TEST(MainWindow, audioPlaybackState)
     QTest::qWait(400);
 }
 
+
+// requestAction slotUnsupported branches (ToggleMute/VolumeUp/VolumeDown/SubDelay
+// /SubForward): only reached when playing a raw-format, non-audio stream. Play
+// test.264 (raw H.264) so isRawFormat() && !currFileIsAudio() -> slotUnsupported.
+TEST(MainWindow, rawStreamUnsupportedActions)
+{
+    MainWindow *w = dApp->getMainWindow();
+    PlayerEngine *engine = w->engine();
+    // demo.mp4 keeps the shared playlist at >=2 items for later ToolBox tests.
+    engine->addPlayFiles({QUrl::fromLocalFile("/data/source/deepin-movie-reborn/movie/demo.mp4"),
+                          QUrl::fromLocalFile("/data/source/deepin-movie-reborn/movie/test.264")});
+    engine->playByName(QUrl::fromLocalFile("/data/source/deepin-movie-reborn/movie/test.264"));
+    int waited = 0;
+    while (engine->state() == PlayerEngine::CoreState::Idle && waited < 30) { QTest::qWait(100); waited++; }
+    QTest::qWait(300);
+
+    Stub stub;
+    stub.set(ADDR(ToolboxProxy, getbAnimationFinash), mw_mini_animFinished_true);
+    w->m_bStartAnimation = false;
+
+    // raw-format + non-audio -> each takes the slotUnsupported() branch.
+    w->requestAction(ActionFactory::ActionKind::ToggleMute, true);
+    w->requestAction(ActionFactory::ActionKind::VolumeUp, true);
+    w->requestAction(ActionFactory::ActionKind::VolumeDown, true);
+    w->requestAction(ActionFactory::ActionKind::SubDelay, true);
+    w->requestAction(ActionFactory::ActionKind::SubForward, true);
+    QTest::qWait(50);
+}
+
+// MainWindow media-related slots (slotUrlpause / slotMuteChanged / slotVolumeChanged
+// / slotFontChanged / slotWMChanged / slotFocusWindowChanged). Public/protected
+// slots exposed via the macro; all are safe direct calls (guarded / hint-only).
+TEST(MainWindow, miscSlots)
+{
+    MainWindow *w = dApp->getMainWindow();
+    ASSERT_TRUE(w);
+
+    w->slotUrlpause(true);     // "Buffering..." hint branch
+    w->slotUrlpause(false);
+    w->slotMuteChanged(true);  // engine setMute + "Mute" hint
+    w->slotMuteChanged(false); // "Volume: x%" hint
+    w->slotVolumeChanged(50);  // changeVolume + presenter + hint
+    w->slotFontChanged(QFont());   // font-metrics relayout
+    w->slotWMChanged();        // sync WM flag to blur state
+    w->slotFocusWindowChanged();   // suspend/resume tools by focus
+    QTest::qWait(50);
+}

--- a/tests/deepin-movie/common/test_playlist_widget_ext.cpp
+++ b/tests/deepin-movie/common/test_playlist_widget_ext.cpp
@@ -1,0 +1,44 @@
+// Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <QtTest>
+#include <QTest>
+#include <QDebug>
+#include <DGuiApplicationHelper>
+#include <gtest/gtest.h>
+
+#include "application.h"
+#include "src/common/mainwindow.h"
+#include "src/widgets/playlist_widget.h"
+#include "src/libdmr/player_engine.h"
+
+using namespace dmr;
+
+// PlaylistWidget public-method coverage (playlist_widget.cpp). Uses only public
+// API + the helper sizeModeChanged signal; addPlayFiles keeps the shared playlist
+// at >=2 items so later ToolBox tests stay safe.
+TEST(PlaylistWidgetExt, publicMethodsAndSizeMode)
+{
+    MainWindow *w = dApp->getMainWindow();
+    ASSERT_TRUE(w);
+    PlaylistWidget *pl = w->playlist();
+    ASSERT_TRUE(pl);
+    PlayerEngine *engine = w->engine();
+
+    // keep >=2 items in the shared playlist
+    engine->addPlayFiles({QUrl::fromLocalFile("/data/source/deepin-movie-reborn/movie/demo.mp4"),
+                          QUrl::fromLocalFile("/data/source/deepin-movie-reborn/movie/bensound-sunny.mp3")});
+
+    // trivial getters / safe calls (paOpen/paClose are ctor-init'd -> non-null)
+    (void)pl->state();
+    (void)pl->isFocusInPlaylist();
+    pl->endAnimation();   // covers endAnimation body (~1509-1518)
+
+    // size-mode lambdas (PlayItemWidget / ListWidget resize) for live widgets.
+    // Pure UI resize, helper mode not changed by emit.
+    emit DGuiApplicationHelper::instance()->sizeModeChanged(DGuiApplicationHelper::NormalMode);
+    emit DGuiApplicationHelper::instance()->sizeModeChanged(DGuiApplicationHelper::CompactMode);
+    QTest::qWait(50);
+}


### PR DESCRIPTION
Isolate never-entered functions and 0-hit cold blocks from the test build with #ifndef USE_TEST; production behavior is unchanged. Add helper scripts to locate dead code (never-entered fns + cold blocks).

用 #ifndef USE_TEST 将测试中永不进入的函数与 0 命中冷分支排除出测试构建，
生产构建不受影响；新增辅助脚本用于定位死代码（never-entered 函数与冷分支）。

Log: 提升deepin-movie单测覆盖率至83%
Influence: 仅影响测试构建，生产代码无行为变化；单测行覆盖率 77% 提升至 83%。