### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/deepin-movie.desktop
+++ b/deepin-movie.desktop
@@ -211,6 +211,6 @@ Name[uk]=Відео Deepin
 Name[vi]=Trình xem phim Deepin
 Name[lo]=Deepin ໜັງ
 Name[zh_CN]=影院
-Name[zh_HK]=Deepin 電影
-Name[zh_TW]=Deepin 電影
+Name[zh_HK]=電影
+Name[zh_TW]=電影
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Enhancements:
- Clean up zh_CN/zh_HK/zh_TW Name and Comment translations in the deepin-movie.desktop file by removing "深度"/"deepin"/"Deepin" prefixes.