### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/deepin-movie.desktop
+++ b/deepin-movie.desktop
@@ -12,6 +12,7 @@ Type=Application
 X-Deepin-ManualID=deepin-movie
 X-Deepin-TurboType=dtkwidget
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

Enhancements:
- Add X-Deepin-Singleton=true to the deepin-movie desktop file so the application is recognized as a singleton by the app manager.