### PR TITLE
fix: use wid mode for Sietium GPU to restore vaapi zero-copy hwdec

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -1444,7 +1444,8 @@ void MpvProxy::refreshDecode()
 
         // 设置芯瞳显卡硬解
         if(utils::isSietiumGPUPresent()) {
-            my_set_property(m_handle, "hwdec", "vaapi-copy");
+            my_set_property(m_handle, "hwdec", "vaapi");
+            my_set_property(m_handle, "vo", "gpu");
         }
 
         if (!CompositingManager::get().composited()) {
@@ -1517,7 +1518,8 @@ void MpvProxy::refreshDecode()
 
         // 设置芯瞳显卡硬解
         if(utils::isSietiumGPUPresent()) {
-            my_set_property(m_handle, "hwdec", "vaapi-copy");
+            my_set_property(m_handle, "hwdec", "vaapi");
+            my_set_property(m_handle, "vo", "gpu");
         }
 
         PlaylistModel *playMode = dynamic_cast<PlayerEngine *>(m_pParentWidget)->getplaylist();

--- a/src/libdmr/compositing_manager.cpp
+++ b/src/libdmr/compositing_manager.cpp
@@ -328,6 +328,10 @@ CompositingManager::CompositingManager()
     if (QFile::exists("/sys/bus/pci/drivers/ljmcore"))
         _composited = false;
 
+    // 芯瞳显卡走 wid 模式，由 mpv 自主创建 GL context 渲染
+    if (utils::isSietiumGPUPresent())
+        _composited = false;
+
     if (m_setSpecialControls)
         _composited = false;
 


### PR DESCRIPTION
Set composited=false when Sietium GPU is detected, so the app uses Platform_MainWindow (wid mode) where mpv creates its own GL context. Restore hwdec=vaapi + vo=gpu instead of vaapi-copy.

Log: restore vaapi zero-copy for Sietium GPU
Bug: https://pms.uniontech.com/bug-view-370457.html