### PR TITLE
fix(driver): extend detection for zx/cx series graphics drivers

### DIFF
--- a/src/libdmr/compositing_manager.cpp
+++ b/src/libdmr/compositing_manager.cpp
@@ -160,22 +160,22 @@ CompositingManager::CompositingManager()
         qInfo() << "Special controls set for 550 series:" << m_setSpecialControls;
     }
 
-    bool isI915 = false;
-    qDebug() << "Starting DRM card existence check for i915.";
+    bool hasSpecialDriver = false;
+    qDebug() << "Starting DRM card existence check for i915/arise/cx4/zx/cx.";
     for (int id = 0; id <= 10; id++) {
         if (!QFile::exists(QString("/sys/class/drm/card%1").arg(id))) break;
         if (is_device_viable(id)) {
-            qDebug() << "Device" << id << "is viable. Checking for i915/arise drivers.";
-            vector<string> drivers = {"i915", "arise"};
-            isI915 = is_card_exists(id, drivers);
-            qDebug() << "is_card_exists for device" << id << "returned:" << isI915;
+            qDebug() << "Device" << id << "is viable. Checking for i915/arise/cx4/zx/cx drivers.";
+            vector<string> drivers = {"i915", "arise", "cx4", "zx", "cx"};
+            hasSpecialDriver = is_card_exists(id, drivers);
+            qDebug() << "is_card_exists for device" << id << "returned:" << hasSpecialDriver;
             break;
         }
     }
-    if (isI915) {
-        qInfo() << "Detected i915 graphics";
+    if (hasSpecialDriver) {
+        qInfo() << "Detected i915/arise/cx4/zx/cx graphics";
     }
-    m_bZXIntgraphics = isI915 ? isI915 : m_bZXIntgraphics;
+    m_bZXIntgraphics = hasSpecialDriver ? hasSpecialDriver : m_bZXIntgraphics;
     qDebug() << "m_bZXIntgraphics set to:" << m_bZXIntgraphics;
 
 #ifndef USE_TEST


### PR DESCRIPTION
Add support for cx4, zx, and cx drivers in graphics detection logic. Rename variable isI915 to hasSpecialDriver for clarity.

扩展显卡驱动检测，新增 cx4、zx、cx 驱动支持。
优化变量命名，提升代码可读性。

Log: 扩展兆芯ZX/CX系列显卡驱动检测
PMS: BUG-361961
Influence: 支持更多兆芯显卡型号，提升硬件兼容性。