### PR TITLE
feat: pick playmode dconfig from release/eagle

### DIFF
--- a/assets/org.deepin.movie.playmode.json
+++ b/assets/org.deepin.movie.playmode.json
@@ -1,0 +1,16 @@
+{
+  "magic": "dsg.config.meta",
+  "version": "1.0",
+  "contents": {
+      "HwdecName": {
+          "value": "",
+          "serial": 0,
+          "flags": ["global"],
+          "name": "The name of the hardware decoding engine",
+          "name[zh_CN]": "硬件解码引擎名称",
+          "description": "The name of the hardware decoding engine",
+          "permissions": "readwrite",
+          "visibility": "private"
+      }
+  }
+}

--- a/assets/org.deepin.movie.playmode.json
+++ b/assets/org.deepin.movie.playmode.json
@@ -21,6 +21,16 @@
           "description": "Whether to use special video output",
           "permissions": "readwrite",
           "visibility": "private"
+      },
+      "VoName": {
+          "value": "",
+          "serial": 0,
+          "flags": ["global"],
+          "name": "The name of the video output engine",
+          "name[zh_CN]": "视频输出引擎名称",
+          "description": "The name of the video output engine",
+          "permissions": "readwrite",
+          "visibility": "private"
       }
   }
 }

--- a/assets/org.deepin.movie.playmode.json
+++ b/assets/org.deepin.movie.playmode.json
@@ -11,6 +11,16 @@
           "description": "The name of the hardware decoding engine",
           "permissions": "readwrite",
           "visibility": "private"
+      },
+      "IsSpecialVo": {
+          "value": 0,
+          "serial": 0,
+          "flags": ["global"],
+          "name": "Whether to use special video output",
+          "name[zh_CN]": "是否使用特殊视频输出",
+          "description": "Whether to use special video output",
+          "permissions": "readwrite",
+          "visibility": "private"
       }
   }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,7 @@ if (Qt6_FOUND)
         ${PROJECT_SOURCE_DIR}/assets/org.deepin.movie.power.json
         ${PROJECT_SOURCE_DIR}/assets/org.deepin.movie.restart.json
         ${PROJECT_SOURCE_DIR}/assets/org.deepin.movie.specialhwdec.json
+        ${PROJECT_SOURCE_DIR}/assets/org.deepin.movie.playmode.json
     )
     if (DEFINED DSG_DATA_DIR)
         message("-- DConfig is supported by DTK")
@@ -211,6 +212,7 @@ else()
         ${PROJECT_SOURCE_DIR}/assets/org.deepin.movie.power.json
         ${PROJECT_SOURCE_DIR}/assets/org.deepin.movie.restart.json
         ${PROJECT_SOURCE_DIR}/assets/org.deepin.movie.specialhwdec.json
+        ${PROJECT_SOURCE_DIR}/assets/org.deepin.movie.playmode.json
     )
     if (DEFINED DSG_DATA_DIR)
         message("-- DConfig is supported by DTK")

--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -547,7 +547,12 @@ mpv_handle *MpvProxy::mpv_init()
             qInfo() << "修改音视频同步模式";
             my_set_property(pHandle, "video-sync", "desync");
         }
-        if (!utils::isJjwGPUPresent() && !mtfi.exists()) {
+        // 检测特殊机型，使用配置的 VO 渲染
+        if (CompositingManager::get().shouldUseSpecialVo()) {
+            QString voName = CompositingManager::get().getSpecialVoName();
+            my_set_property(pHandle, "vo", voName.toUtf8().constData());
+            m_sInitVo = voName;
+        } else if (!utils::isJjwGPUPresent() && !mtfi.exists()) {
             if(CompositingManager::get().property("directRendering").toBool()) {
                 qDebug() << "DEBUG: Loongarch: Direct rendering enabled. Setting vo to gpu,x11.";
                 my_set_property(pHandle, "vo", "gpu,x11");
@@ -566,7 +571,12 @@ mpv_handle *MpvProxy::mpv_init()
         my_set_property(pHandle, "vo", "gpu,x11");
         m_sInitVo = "gpu,x11";
 #elif defined (__aarch64__)
-        if (!utils::isJjwGPUPresent()) { //2.1.1景嘉微
+        // 检测特殊机型，使用配置的 VO 渲染
+        if (CompositingManager::get().shouldUseSpecialVo()) {
+            QString voName = CompositingManager::get().getSpecialVoName();
+            my_set_property(pHandle, "vo", voName.toUtf8().constData());
+            m_sInitVo = voName;
+        } else if (!utils::isJjwGPUPresent()) { //2.1.1景嘉微
             qDebug() << "DEBUG: AARCH64: No Jingjiawei GPU detected. Setting vo to x11,gpu,xv.";
             my_set_property(pHandle, "vo", "gpu,xv,x11");
             m_sInitVo = "gpu,xv,x11";

--- a/src/libdmr/compositing_manager.cpp
+++ b/src/libdmr/compositing_manager.cpp
@@ -151,6 +151,7 @@ CompositingManager::CompositingManager()
     setProperty("directRendering", isDriverLoaded); //是否支持直接渲染
     qInfo() << "Driver loaded status:" << isDriverLoaded;
     softDecodeCheck();   //检测是否是kunpeng920（是否走软解码）
+    detectSpecialVoFromConfig(); // 检测特殊机型（仅决定渲染策略）
     qDebug() << "softDecodeCheck() called.";
 
     // 检测是否为 AMD 550 系列显卡，若为则走vaapi
@@ -696,6 +697,37 @@ bool CompositingManager::isSpecialControls()
     return result;
 }
 
+void CompositingManager::detectSpecialVoFromConfig()
+{
+#ifdef DTKCORE_CLASS_DConfigFile
+    DConfig *dconfig = DConfig::create("org.deepin.movie", "org.deepin.movie.playmode");
+    if (dconfig && dconfig->isValid()) {
+        const QStringList &keys = dconfig->keyList();
+        if (keys.contains("IsSpecialVo") && dconfig->value("IsSpecialVo").toInt() == 1) {
+            if (keys.contains("VoName")) {
+                QString voName = dconfig->value("VoName").toString().trimmed();
+                if (!voName.isEmpty()) {
+                    m_bUseSpecialVo = true;
+                    m_specialVoName = voName;
+                    qInfo() << "Detected special VO from dconfig, vo:" << m_specialVoName;
+                }
+            }
+        }
+    }
+    delete dconfig;
+#endif
+}
+
+bool CompositingManager::shouldUseSpecialVo()
+{
+    return m_bUseSpecialVo;
+}
+
+QString CompositingManager::getSpecialVoName()
+{
+    return m_specialVoName.isEmpty() ? QString("gpu") : m_specialVoName;
+}
+
 void CompositingManager::detectOpenGLEarly()
 {
     qDebug() << "Entering CompositingManager::detectOpenGLEarly()";
@@ -1081,6 +1113,8 @@ void CompositingManager::initMember()
 
     m_bZXIntgraphics = false;
     m_bHasCard = false;
+    m_bUseSpecialVo = false;
+    m_specialVoName.clear();
     qDebug() << "Exiting initMember()";
 }
 

--- a/src/libdmr/compositing_manager.h
+++ b/src/libdmr/compositing_manager.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -105,8 +105,11 @@ public:
     static void detectPciID();
     static bool runningOnNvidia();
     void softDecodeCheck();
+    void detectSpecialVoFromConfig(); // 从配置检测是否需要使用特殊 VO
     bool isOnlySoftDecode();
     bool isSpecialControls();
+    bool shouldUseSpecialVo();  // 检测是否需要使用特殊 VO
+    QString getSpecialVoName(); // 获取特殊机型的 VO 名称
     void getMpvConfig(QMap<QString, QString> *&aimMap);
     int enablePower() const;
     QPair<QString, QString>getEnablePowerConfig() const;
@@ -136,6 +139,8 @@ private:
     bool m_bHasCard;
     bool m_bOnlySoftDecode {false};  //kunpeng920走软解码
     bool m_setSpecialControls {false};
+    bool m_bUseSpecialVo {false};  // 特殊机型需要使用特殊 VO
+    QString m_specialVoName;  // 特殊机型的 VO 名称
     bool m_bZXIntgraphics;
     //保存配置
     QMap<QString, QString> *m_pMpvConfig;


### PR DESCRIPTION
## 概述

从 `release/eagle` 分支 pick `org.deepin.movie.playmode` dconfig 配置到 `master` 分支，包含配置文件及对应的源码使用。

## Pick 的配置项

| 配置项 | 说明 |
|--------|------|
| HwdecName | 硬件解码引擎名称 |
| IsSpecialVo | 是否使用特殊视频输出 |
| VoName | 视频输出引擎名称 |

## 提交记录

- `5753609c` feat: add HwdecName dconfig for hardware decoding engine name
- `427111ba` feat: add IsSpecialVo dconfig for special video output toggle
- `caa3d463` feat: add VoName dconfig for video output engine name

pick from: 331b203c

## 改动范围

- `assets/org.deepin.movie.playmode.json` — 新增 dconfig 配置文件
- `src/CMakeLists.txt` — 注册 playmode.json 到安装列表
- `src/libdmr/compositing_manager.h/cpp` — 新增 `detectSpecialVoFromConfig()`、`shouldUseSpecialVo()`、`getSpecialVoName()` 及成员变量
- `src/backends/mpv/mpv_proxy.cpp` — loongarch 和 aarch64 平台增加特殊 VO 渲染检测逻辑

## 测试

- [x] master&master 编译通过
$6

## Summary by Sourcery

Add configurable special video output (VO) support via playmode DConfig and apply it in mpv initialization on specific architectures.

New Features:
- Introduce DConfig-based detection of special VO settings for org.deepin.movie.playmode to drive rendering strategy.
- Allow mpv backend on loongarch and aarch64 to use a configurable VO name when special VO is enabled.

Enhancements:
- Register the new playmode DConfig JSON asset in the build so it is installed with the application.