### PR TITLE
chore: Update version to 6.5.55

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+deepin-movie-reborn (6.5.55) unstable; urgency=medium
+
+  * chore: Update version to 6.5.55
+  * feat: add VoName dconfig for video output engine name
+  * feat: add IsSpecialVo dconfig for special video output toggle
+  * feat: add HwdecName dconfig for hardware decoding engine name
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 30 Jul 2026 15:15:27 +0800
+
 deepin-movie-reborn (6.5.54) unstable; urgency=medium
 
   * chore: Update version to 6.5.54

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.54.1
+  version: 6.5.55.1
   kind: app
   description: |
     movie for deepin os.


### PR DESCRIPTION
- update version to 6.5.55

log: update version to 6.5.55

## Summary by Sourcery

Bump project version metadata to 6.5.55.1.

Build:
- Update linglong package manifest to version 6.5.55.1.

Chores:
- Adjust release/changelog metadata to reflect version 6.5.55.1.