### PR TITLE
fix: revert Arise1020 vaapi-only rendering, use vaapi + gpu

### DIFF
--- a/src/libdmr/compositing_manager.cpp
+++ b/src/libdmr/compositing_manager.cpp
@@ -183,8 +183,7 @@ static bool detect550Series()
                 QString deviceIdStr = deviceId.mid(2);
                 // Match with lspci format: vendor:device
                 if ((vendorIdStr == "1002" && deviceIdStr == "699f") ||
-                    (vendorIdStr == "1002" && deviceIdStr == "6987") ||
-                    (vendorIdStr == "6766" && deviceIdStr == "3d02")) {
+                    (vendorIdStr == "1002" && deviceIdStr == "6987")) {
                     qInfo() << "Detected 550 series GPU" << vendorId << deviceId;
                     return true;
                 }


### PR DESCRIPTION
Remove 6766:3d02 (Glenfly Arise1020) from detect550Series() so the GPU is no longer forced to hwdec=vaapi + vo=vaapi. It falls back to the ZX integrated-graphics path with vo=gpu, restoring GPU rendering features such as rotation while keeping vaapi hardware decode.

Log: restore vo=gpu rendering for Arise1020
Bug: https://pms.uniontech.com/bug-view-372003.html

## Summary by Sourcery

Adjust GPU series detection so Glenfly Arise1020 is no longer treated as a 550 series GPU, restoring the standard GPU rendering path while keeping VAAPI hardware decoding.

Bug Fixes:
- Stop forcing Arise1020 to use VAAPI-only rendering, allowing vo=gpu features such as rotation to work again.

Enhancements:
- Align Arise1020 with the ZX integrated-graphics detection path for more consistent rendering behavior across devices.