### PR TITLE
fix: render mircast popup as opaque rounded panel without ARGB shadow

### DIFF
--- a/src/widgets/mircastwidget.cpp
+++ b/src/widgets/mircastwidget.cpp
@@ -13,6 +13,8 @@
 #include "../accessibility/ac-deepin-movie-define.h"
 
 #include <QVBoxLayout>
+#include <QPainter>
+#include <QPainterPath>
 #include <QListWidget>
 #include <QAbstractListModel>
 #include <QNetworkReply>
@@ -30,14 +32,17 @@
 using namespace dmr;
 
 MircastWidget::MircastWidget(QWidget *mainWindow, void *pEngine)
-: DFloatingWidget(mainWindow), m_pEngine(pEngine)
+: QWidget(mainWindow), m_pEngine(pEngine)
 {
     setAttribute(Qt::WA_NoMousePropagation, true);//鼠标事件不进入父窗口
     if(!CompositingManager::get().composited())
         setAttribute(Qt::WA_NativeWindow);
     qRegisterMetaType<DlnaPositionInfo>("DlnaPositionInfo");
     setFixedSize(MIRCASTWIDTH + 14, MIRCASTHEIGHT + 12);
-    setFramRadius(8);
+    // 使用掩码将窗口裁剪为圆角，不依赖 ARGB 透明合成，避免在透明合成不可用的平台（如兆芯 KX-6000 C-960）出现四周白边
+    QPainterPath mircastMaskPath;
+    mircastMaskPath.addRoundedRect(rect(), 8, 8);
+    setMask(QRegion(mircastMaskPath.toFillPolygon().toPolygon()));
     m_bIsToggling = false;
     m_mircastState = Idel;
     m_nPlayStatus = MircastWidget::NoState;
@@ -54,10 +59,12 @@ MircastWidget::MircastWidget(QWidget *mainWindow, void *pEngine)
     connect(&m_mircastTimeOut, &QTimer::timeout, this, &MircastWidget::slotMircastTimeout);
 
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
-    mainLayout->setContentsMargins(1, 0, 0, 0);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->setSpacing(0);
     setLayout(mainLayout);
-    setContentsMargins(0, 0, 0, 0);
+    // 原 DFloatingWidget 通过 Polish 事件设置阴影边距作为内容边距；改基类为 QWidget 后自行设置内边距，
+    // 使 240×188 的内容在 254×200 的圆角面板中居中（去掉阴影边距）
+    setContentsMargins(7, 6, 7, 6);
 
     QWidget *topWdiget = new QWidget(this);
     topWdiget->setFixedHeight(40);
@@ -185,6 +192,25 @@ void MircastWidget::seekMircast(int nSec)
         slotSeekMircast(nSeek);
     }
 }
+/**
+ * @brief paintEvent 自绘不透明圆角面板，替代 DFloatingWidget 的 ARGB 软阴影装饰
+ */
+void MircastWidget::paintEvent(QPaintEvent *pEvent)
+{
+    Q_UNUSED(pEvent);
+
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(palette().window());
+    painter.drawRoundedRect(rect(), 8, 8);
+
+    // 细边框保留浮层观感，替代原 ARGB 软阴影
+    painter.setBrush(Qt::NoBrush);
+    painter.setPen(QPen(palette().window().color().darker(110), 1));
+    painter.drawRoundedRect(QRectF(rect()).adjusted(0.5, 0.5, -0.5, -0.5), 8, 8);
+}
+
 /**
  * @brief togglePopup 工具栏投屏窗口显示与隐藏
  */

--- a/src/widgets/mircastwidget.h
+++ b/src/widgets/mircastwidget.h
@@ -10,7 +10,7 @@
 #define _MIRCASTWIDGET_H
 
 #include <DWidget>
-#include <DFloatingWidget>
+#include <QWidget>
 #include <DLabel>
 #include <DSpinner>
 
@@ -129,7 +129,7 @@ private:
     DLabel   *m_refreBtn;
 };
 
-class MircastWidget: public DFloatingWidget
+class MircastWidget: public QWidget
 {
     Q_OBJECT
 public:
@@ -188,6 +188,9 @@ public:
     RefreButtonWidget *getRefreshBtn() {return m_refreshBtn;}
     void setMircastState(MircastState state) {m_mircastState = state;}
     void setMircastPlayState(MircastPlayState state) {m_nPlayStatus = state;}
+
+protected:
+    void paintEvent(QPaintEvent *pEvent) override;
 public slots:
     /**
      * @brief togglePopup 工具栏投屏窗口显示与隐藏


### PR DESCRIPTION
## 根因分析

投屏窗口 `MircastWidget`（`src/widgets/mircastwidget.h:132`）继承 DTK 的 `DFloatingWidget` 且未开启模糊背景。`DFloatingWidget` 的面板装饰由 DTK `DStyle::PE_FloatingWidget`（dtkwidget `dstyle.cpp:1326`）绘制：在四周阴影边距区画 ARGB 软阴影（`Format_ARGB32_Premultiplied`、黑 0.25 alpha），内容区用 palette 背景填充圆角矩形，透明区依赖 Alpha 合成。在兆芯 KX-6000 C-960 GPU 平台上该 ARGB 透明合成不可用（`_composited=false` → `WA_NativeWindow` → 原生不透明 X 子窗口无法渲染 ARGB 透明，属已知 X11/Qt 平台限制），本应透明的边距/圆角外区域被渲染为不透明白色 → 四周一圈白色边框。

关键证据：
- 张洪源 2024-10-23 对照实验：将父类由 `DFloatingWidget` 改成 `QWidget` 后白边消失，功能不变。
- 对比 `ToolboxProxy`（同继承 `DFloatingWidget` 但调用 `setBlurBackgroundEnabled(true)`，走 `noBackground=true` 不白填路径）→ 工具栏无白边，仅投屏窗口出现，印证 `noBackground=false` + ARGB 装饰为病因。

## 修复方案

采纳方案 A（根因复核已确认通过）：
- 将 `MircastWidget` 基类由 `DFloatingWidget` 改为 `QWidget`，不再依赖 DTK 的 ARGB 软阴影/圆角填充装饰。
- 新增 `paintEvent` 自绘不透明圆角面板（palette 背景填充 + 1px 细边框），去除四周阴影边距。
- 构造中以 `QPainterPath` 圆角区域 `setMask` 裁剪窗口，圆角由窗口系统裁剪、不依赖 ARGB 透明合成。
- 自行设置内容内边距 `(7,6,7,6)`，使 240×188 内容在 254×200 面板中居中，替代原 `DFloatingWidget` Polish 事件设置的阴影边距。
- 移除 `setFramRadius(8)` 与 `DFloatingWidget` 头文件包含。

布局、状态机、设备搜索、DLNA/HTTP 逻辑均未改动。

## 改动安全评估

低风险。`MircastWidget` 仅使用一个 `DFloatingWidget` 专有 API（`setFramRadius`，已移除）；调用者 `ToolboxProxy`/`Platform_ToolboxProxy` 对 `m_mircastWidget` 的全部 71 处引用均为 `QWidget` 公共 API（`hide/show/move/width/height/geometry/isVisible/togglePopup/getMircastState` 等）与自身枚举，基类改为 `QWidget` 后全部仍可用，无需改动调用者。无函数签名变更。`ToolboxProxy` 走模糊背景路径，本次未改动，不受影响（建议目标硬件回归验证）。

## 关联

- PMS: https://pms.uniontech.com/bug-view-278859.html
- 根因分析报告：见 issue 附件 `analysis-report.md`

## Summary by Sourcery

Render the Mircast popup as an opaque rounded QWidget panel instead of a DFloatingWidget-based ARGB shadow panel to eliminate white borders on non-composited platforms.

Bug Fixes:
- Fix white border artifacts around the Mircast popup on platforms where ARGB transparency composition is unavailable.

Enhancements:
- Redesign the Mircast popup visuals as a simple rounded panel with a solid background and thin border, removing soft shadow margins while keeping layout and behavior unchanged.