### PR TITLE
fix(movie): notify user when no graphics driver detected on startup

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -1032,6 +1032,14 @@ MainWindow::MainWindow(QWidget *parent)
     m_pDVDHintWid->setAnchorPoint(QPoint(30, 58));
     m_pDVDHintWid->hide();
 
+    // 未检测到显卡驱动时提示用户将使用软件渲染（PMS-337305）
+    QTimer::singleShot(0, this, [this]() {
+        if (!CompositingManager::get().property("directRendering").toBool()) {
+            m_pCommHintWid->updateWithMessage(
+                tr("No graphics driver detected, software rendering will be used"));
+        }
+    });
+
 #ifdef USE_DXCB
     m_pEventListener = new MainWindowEventListener(this);
     this->windowHandle()->installEventFilter(m_pEventListener);

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -1069,6 +1069,14 @@ Platform_MainWindow::Platform_MainWindow(QWidget *parent)
     m_pDVDHintWid->setAnchorPoint(QPoint(30, 58));
     m_pDVDHintWid->hide();
 
+    // 未检测到显卡驱动时提示用户将使用软件渲染（PMS-337305）
+    QTimer::singleShot(0, this, [this]() {
+        if (!CompositingManager::get().property("directRendering").toBool()) {
+            m_pCommHintWid->updateWithMessage(
+                tr("No graphics driver detected, software rendering will be used"));
+        }
+    });
+
 #ifdef USE_DXCB
     connect(qApp, &QGuiApplication::applicationStateChanged,
             this, &Platform_MainWindow::onApplicationStateChanged);


### PR DESCRIPTION
## 根因分析

PMS 337305：【1070u3】无 GPU 驱动时影院无提示。

驱动加载状态在启动期已被 `CompositingManager` 正确检测（`src/libdmr/compositing_manager.cpp:212-213` 调 `isDriverLoadedCorrectly()` 解析 `/var/log/Xorg.0.log`，结果写入 `directRendering` 属性），但该状态只被 `src/backends/mpv/mpv_proxy.cpp:374-435` 用于 mpv 后端的静默 vo/hwdec 选择，从未被桥接到面向用户的提示控件——主窗口 `m_pCommHintWid`（`src/common/mainwindow.cpp:1024` 与 `src/common/platform/platform_mainwindow.cpp:1061`）的约 50 处 `updateWithMessage` 调用中无一以驱动状态为触发条件，`directRendering`/`hascard()` 在主窗口侧零引用。结论级别：**强根因**。

## 修复方案

在两个主窗口构造函数中创建 `m_pCommHintWid` 之后，追加 `QTimer::singleShot(0, this, ...)` 延时判断：当 `!CompositingManager::get().property("directRendering").toBool()`（显卡驱动未正确加载）时，调用 `m_pCommHintWid->updateWithMessage(tr("No graphics driver detected, software rendering will be used"))` 提示用户。延时到 `show()` 之后触发，复用既有提示控件与既有自动消失时序，**不修改任何 vo/hwdec 解码/渲染逻辑**。有驱动的机器 `directRendering=true` → 不触发 → 零行为变化。

## 改动安全评估

低风险。纯增量改动（+16 行，2 文件），无函数签名变更、未修改任何既有行；目标区块无外部调用者（`References=0`）；`CompositingManager::get()` 与 `m_pCommHintWid->updateWithMessage` 均为两文件既有可见符号/API。详见 `change-safety.md`。

## 改动文件

- `src/common/mainwindow.cpp`（合成路径，Wayland ARM64 无驱动走此）
- `src/common/platform/platform_mainwindow.cpp`（非合成路径，X11 ARM64 无驱动走此）

## 测试说明

- 未新增/运行单元测试（按项目约定）。
- 建议在无 GPU 驱动的 ARM64 镜像（如 PMS 所述 `uos-desktop-20-e-1074-arm64.iso` + 5.10 内核）上启动影院验证提示出现；在有驱动环境验证提示不出现、播放行为不变。
- 提示中文翻译条目待产品/UX 确认文案后补入 `translations/deepin-movie*.ts`。

## 关联

- PMS: https://pms.uniontech.com/bug-view-337305.html
- 根因分析报告：见 `analysis-report.md`

## Summary by Sourcery

Display a startup hint in the movie main window when no graphics driver is detected so users know software rendering will be used.

Bug Fixes:
- Notify users at startup when no GPU driver is detected instead of silently falling back to software rendering.

Enhancements:
- Hook the compositor's directRendering state into the existing common hint widget for both main window variants to surface graphics driver issues to the user.