### PR TITLE
fix: fix black block on fullscreen pause/play animation

### DIFF
--- a/src/widgets/animationlabel.cpp
+++ b/src/widgets/animationlabel.cpp
@@ -30,6 +30,7 @@ AnimationLabel::AnimationLabel(QWidget *parent, QWidget *pMainWindow)
 {
     initMember(pMainWindow);
     setAttribute(Qt::WA_TransparentForMouseEvents);
+    setAttribute(Qt::WA_TranslucentBackground, true);
 
     resize(200, 200);
 }

--- a/src/widgets/platform/platform_animationlabel.cpp
+++ b/src/widgets/platform/platform_animationlabel.cpp
@@ -15,6 +15,7 @@
 
 #include "platform_animationlabel.h"
 #include "mainwindow.h"
+#include "utility.h"
 #include <DWindowManagerHelper>
 #include <DForeignWindow>
 
@@ -55,6 +56,9 @@ void Platform_AnimationLabel::pauseAnimation()
     else
         setFixedSize(100, 100);
     if(!isShowPopup()) return;
+    // 全屏绕过合成器期间，顶层 Tool 动效窗口的半透明背景会失效为黑块，
+    // 显示动效前临时取消主窗口的绕过合成器，使半透明背景能被合成器正常混合。
+    setMainWindowBypassCompositor(false);
     m_pPlayAnimationGroup->start();
     if(!isVisible()) {
         show();
@@ -74,6 +78,8 @@ void Platform_AnimationLabel::playAnimation()
     else
         setFixedSize(100, 100);
     if(!isShowPopup()) return;
+    // 同 pauseAnimation：显示动效前临时取消主窗口的绕过合成器。
+    setMainWindowBypassCompositor(false);
     m_pPauseAnimationGroup->start();
     if(!isVisible()) {
         show();
@@ -83,6 +89,22 @@ void Platform_AnimationLabel::playAnimation()
 void Platform_AnimationLabel::setWM(bool isWM)
 {
     m_bIsWM = isWM;
+}
+
+/**
+ * @brief 显示/隐藏动效期间临时切换主窗口的"绕过合成器"状态
+ * @param bypass true 恢复绕过合成器（全屏功耗优化），false 临时取消以使半透明动效正常混合
+ *
+ * 仅在主窗口处于全屏时生效：非全屏时主窗口本就未设置绕过合成器，无需改动，
+ * 避免给非全屏窗口错误地设置该属性。Wayland 下 setBypassCompositor 自身会直接返回。
+ */
+void Platform_AnimationLabel::setMainWindowBypassCompositor(bool bypass)
+{
+    if (!m_pMainWindow || !m_pMainWindow->isFullScreen())
+        return;
+    if (QWindow *window = m_pMainWindow->windowHandle()) {
+        Utility::setBypassCompositor(static_cast<quint32>(window->winId()), bypass);
+    }
 }
 
 /**
@@ -257,6 +279,8 @@ void Platform_AnimationLabel::onHideAnimation()
     if(m_pMainWindow) {
         m_pMainWindow->update();
     }
+    // 动效隐藏后，若主窗口仍处于全屏则恢复绕过合成器，继续享受功耗优化。
+    setMainWindowBypassCompositor(true);
 }
 
 /**

--- a/src/widgets/platform/platform_animationlabel.h
+++ b/src/widgets/platform/platform_animationlabel.h
@@ -67,6 +67,11 @@ private:
      * @return true为显示
      */
     bool isShowPopup();
+    /**
+     * @brief 显示/隐藏动效期间临时切换主窗口的"绕过合成器"状态
+     * @param bypass true 恢复绕过合成器，false 临时取消以使半透明动效正常混合
+     */
+    void setMainWindowBypassCompositor(bool bypass);
 
 public slots:
     /**


### PR DESCRIPTION
## 根因分析

PMS 373499：【1070u5】影院 app 全屏暂停有大黑方块（联想开天 X5z G2d / 兆芯 KX-7000 / zx 集显）。

- **根因**：全屏"绕过合成器"功耗优化（回归提交 `e94d128`「allow bypassing the compositor when fullscreen」，task 384659）在 `mipsShowFullScreen()` 对主窗口置 `_NET_WM_BYPASS_COMPOSITOR=1`，kwin 据此挂起合成；而暂停/播放动效控件 `Platform_AnimationLabel` 是顶层 `Qt::Tool` 窗口 + `WA_TranslucentBackground`，其半透明背景依赖合成器混合。合成器被挂起后，动效窗口 alpha 无从混合，ARGB 表面回退为不透明黑 → 中央大黑方块。
- **关键证据**：
  - `src/common/platform/platform_mainwindow.cpp:1806`（普通版 `mainwindow.cpp:1729`）`setBypassCompositor(winId, true)`；`src/common/utility_x11.cpp:39` 原子 `_NET_WM_BYPASS_COMPOSITOR`。
  - `src/widgets/platform/platform_animationlabel.cpp:37-38` 顶层 `Qt::Tool` + `WA_TranslucentBackground`；`:60` `show()` 显隐。
  - 运行时路径：`src/main.cpp:388-443` 按 `composited()` 二选一；`src/libdmr/compositing_manager.cpp:291-296,737` X86 + zx 集显 → `composited()==false` → KX-7000 走 Platform 路径。
- **并列隐患**：普通版 `AnimationLabel`（`src/widgets/animationlabel.cpp:39`）从未设置 `WA_TranslucentBackground`（`composited()==true` 路径下 200×200 黑方块隐患），建议一并修。

## 修复方案

1. `Platform_AnimationLabel`：显示动效前（`pauseAnimation`/`playAnimation` 在 `isShowPopup()` 通过后、`show()` 前）临时取消主窗口的绕过合成器，使顶层半透明 Tool 窗口能被合成器正常混合；动效隐藏后（`onHideAnimation()`）若主窗口仍处于全屏则恢复绕过合成器，保留功耗优化。新增私有辅助 `setMainWindowBypassCompositor(bool)`，非全屏/Wayland/空句柄时跳过，避免误设。
2. 普通版 `AnimationLabel`：构造补齐 `setAttribute(Qt::WA_TranslucentBackground, true)`，与平台版保持一致，消除动效背景不透明隐患。

改动最小、可审：仅 3 个文件 +30 行，未触碰渲染/解码/窗口状态机等核心逻辑；功耗优化在非动效期间不受影响。

## 改动安全评估

- **风险等级：低**。新增私有辅助函数（无签名变更、无外部调用者），仅在动效显隐两处调用；`WA_TranslucentBackground` 为标准 Qt 属性，与同仓库平台版控件用法一致。blame 显示目标行为初始提交 `b62ec4c`，中间 `88cccbfd`（bug 255849）的 `isShowPopup()` 守卫未被破坏（本修复在其之后插入）。无 >5 处调用者受影响。
- **历史洞察**：回归源 `e94d128`（2026-01，task 384659）即开发备注"功耗需求引入的问题"所指；本修复不撤销该功耗特性，仅在其与动效显隐之间补一个临时联动。
- **复核确认项**（已在根因分析报告 §十 列出，不阻塞修复）：复现机实测 `composited()` 取值确认主因在 Platform 路径（预期 false）；`qdbus org.kde.KWin /Compositor active` 佐证合成器挂起。

## Summary by Sourcery

Temporarily disable fullscreen compositor bypass while showing pause/play animations to fix the black block issue, then restore it afterward, and ensure the non-platform animation label uses a translucent background.

Bug Fixes:
- Resolve black block artifact when showing fullscreen pause/play animations by coordinating compositor bypass with animation visibility.

Enhancements:
- Align the standard AnimationLabel with the platform variant by enabling a translucent background for its animation window.