### PR TITLE
fix(platform): anchor volume slider to volume button as child widget (355653)

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -3849,8 +3849,7 @@ void Platform_MainWindow::resizeEvent(QResizeEvent *pEvent)
     m_pMircastShowWidget->resize(rect().size());
     m_pMircastShowWidget->move(0, 0);
 
-    QPoint relativePoint = mapToGlobal(QPoint(0, 0));
-    m_pToolbox->updateSliderPoint(relativePoint);
+    m_pToolbox->updateSliderPoint();
     if(m_bMiniMode) { //迷你模式显示与半屏模式处理
         int nScreenHeight = QApplication::desktop()->availableGeometry().height();
         QRect rt = rect();
@@ -3896,8 +3895,7 @@ void Platform_MainWindow::moveEvent(QMoveEvent *pEvent)
     qInfo() << __func__ << "进入moveEvent";
     QWidget::moveEvent(pEvent);
     m_pCommHintWid->syncPosition();
-    QPoint relativePoint = mapToGlobal(QPoint(0, 0));
-    m_pToolbox->updateSliderPoint(relativePoint);
+    m_pToolbox->updateSliderPoint();
     updateGeometryNotification(geometry().size());
 }
 

--- a/src/widgets/platform/platform_toolbox_proxy.cpp
+++ b/src/widgets/platform/platform_toolbox_proxy.cpp
@@ -1128,7 +1128,7 @@ void Platform_ToolboxProxy::setup()
     m_pVolBtn->setObjectName(VOLUME_BUTTON);
     m_pVolBtn->setAccessibleName(VOLUME_BUTTON);
 
-    m_pVolSlider = new Platform_VolumeSlider(m_pMainWindow, m_pMainWindow);
+    m_pVolSlider = new Platform_VolumeSlider(m_pMainWindow, m_pVolBtn, m_pMainWindow);
     m_pVolSlider->setObjectName(VOLUME_SLIDER_WIDGET);
 
     connect(m_pVolBtn, &VolumeButton ::sigUnsupported, this, &Platform_ToolboxProxy::sigUnsupported);
@@ -2679,9 +2679,9 @@ void Platform_ToolboxProxy::initThumbThread()
  * @brief updateSliderPoint 非x86平台下更新音量条控件位置
  * @param point 传入主窗口左上角顶点在屏幕的位置
  */
-void Platform_ToolboxProxy::updateSliderPoint(QPoint &point)
+void Platform_ToolboxProxy::updateSliderPoint()
 {
-    m_pVolSlider->updatePoint(point);
+    m_pVolSlider->updatePoint();
 }
 
 /**

--- a/src/widgets/platform/platform_toolbox_proxy.h
+++ b/src/widgets/platform/platform_toolbox_proxy.h
@@ -329,7 +329,7 @@ public:
      * @brief updateSliderPoint 非x86平台下更新音量条控件位置
      * @param point 传入主窗口左上角顶点在屏幕的位置
      */
-    void updateSliderPoint(QPoint &point);
+    void updateSliderPoint();
     /**
      * @brief volumeUp 鼠标滚轮增加音量
      */

--- a/src/widgets/platform/platform_volumeslider.cpp
+++ b/src/widgets/platform/platform_volumeslider.cpp
@@ -5,20 +5,21 @@
 
 #include "platform_volumeslider.h"
 #include "platform_toolbox_proxy.h"
+#include "toolbutton.h"
 #include "dbusutils.h"
 
 DWIDGET_USE_NAMESPACE
 
 namespace dmr {
 
-Platform_VolumeSlider::Platform_VolumeSlider(Platform_MainWindow *mw, QWidget *parent)
-    : QWidget(parent), _mw(mw)
+Platform_VolumeSlider::Platform_VolumeSlider(Platform_MainWindow *mw, VolumeButton *volBtn, QWidget *parent)
+    : QWidget(parent), _mw(mw), m_pVolBtn(volBtn)
 {
-    if (CompositingManager::get().platform() != Platform::X86) {
-        setWindowFlags(Qt::ToolTip | Qt::FramelessWindowHint);
-    } else {
-        setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
-    }
+    // 作为主窗口的子控件（本地坐标定位），而非顶层 ToolTip/Tool 窗口，
+    // 避免在 wid（非合成）模式下 _mw->mapToGlobal(QPoint(0,0)) 与工具栏实际屏位
+    // 错位导致音量条漂移；与 Platform_ToolboxProxy 一致使用原生子窗口 + raise() 保证 z-order。
+    setWindowFlags(Qt::FramelessWindowHint | Qt::BypassWindowManagerHint);
+    setAttribute(Qt::WA_NativeWindow);
     m_iStep = 0;
     m_bIsWheel = false;
     m_nVolume = 100;
@@ -146,12 +147,29 @@ void Platform_VolumeSlider::setMute(bool muted)
     return;
 }
 
-void Platform_VolumeSlider::updatePoint(QPoint point)
+// 依据音量按钮在主窗口中的实际位置计算音量条矩形（主窗口本地坐标）。
+// - X 锚定音量按钮水平居中：消除原 width 硬编码偏移在紧凑模式/布局变化下的失配；
+// - Y 与工具栏同源的高度公式：保持竖直位置不变，且不再依赖 mapToGlobal 锚点。
+QRect Platform_VolumeSlider::sliderRectFromButton() const
 {
-    QRect main_rect = _mw->rect();
-    QRect view_rect = main_rect.marginsRemoved(QMargins(1, 1, 1, 1));
-    m_point = point + QPoint(view_rect.width() - (TOOLBOX_BUTTON_WIDTH * 3 + 40 + (VOLSLIDER_WIDTH - TOOLBOX_BUTTON_WIDTH) / 2),
-                             view_rect.height() - TOOLBOX_HEIGHT - VOLSLIDER_HEIGHT);
+    QPoint btnTopLeft = m_pVolBtn->mapTo(_mw, QPoint(0, 0));
+    int x = btnTopLeft.x() + (TOOLBOX_BUTTON_WIDTH - VOLSLIDER_WIDTH) / 2;
+
+    int toolboxH = TOOLBOX_HEIGHT;
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    if (DGuiApplicationHelper::instance()->sizeMode() == DGuiApplicationHelper::CompactMode) {
+        toolboxH = TOOLBOX_DSIZEMODE_HEIGHT;
+    }
+#endif
+    int y = _mw->rect().marginsRemoved(QMargins(1, 1, 1, 1)).height() - toolboxH - VOLSLIDER_HEIGHT;
+
+    return QRect(x, y, VOLSLIDER_WIDTH, VOLSLIDER_HEIGHT);
+}
+
+void Platform_VolumeSlider::updatePoint()
+{
+    // 主窗口本地坐标系内定位，不再经 _mw->mapToGlobal(QPoint(0,0)) 锚点
+    m_point = sliderRectFromButton().topLeft();
     // 控件顶点更新后，同步移动控件到正确位置
     move(m_point);
 }
@@ -205,10 +223,11 @@ void Platform_VolumeSlider::popup()
 void Platform_VolumeSlider::delayedHide()
 {
     const int nGap = 18;   // 音量条和音量按钮之间的间距
-    QRect adRect = QRect(m_point + QPoint(6, VOLSLIDER_HEIGHT), m_point + QPoint(6 + VOLSLIDER_WIDTH, VOLSLIDER_HEIGHT + nGap));
+    // 音量条现为子控件，hit-test 在控件本地坐标系内进行
+    QRect adRect(6, VOLSLIDER_HEIGHT, VOLSLIDER_WIDTH, nGap);
 
     m_mouseIn = false;
-    if(adRect.contains(QCursor::pos())){
+    if(adRect.contains(mapFromGlobal(QCursor::pos()))){
         DUtil::TimerSingleShot(2000, [=]() {
             if (!m_mouseIn)
                 hide();
@@ -353,20 +372,11 @@ void Platform_VolumeSlider::enterEvent(QEvent *e)
 }
 void Platform_VolumeSlider::showEvent(QShowEvent *se)
 {
-    QRect main_rect = _mw->rect();
-    QRect view_rect = main_rect.marginsRemoved(QMargins(1, 1, 1, 1));
-
-    int x = view_rect.width() - (TOOLBOX_BUTTON_WIDTH * 3 + 40 + (VOLSLIDER_WIDTH - TOOLBOX_BUTTON_WIDTH) / 2);
-    int y = view_rect.height() - TOOLBOX_HEIGHT - VOLSLIDER_HEIGHT;
-#ifdef DTKWIDGET_CLASS_DSizeMode
-    if (DGuiApplicationHelper::instance()->sizeMode() == DGuiApplicationHelper::CompactMode) {
-        x += 50;
-        y += 30;
-    }
-#endif
-    QPoint p = _mw->mapToGlobal(QPoint(0, 0));
-    QRect end(x + p.x(), y + p.y(), VOLSLIDER_WIDTH, VOLSLIDER_HEIGHT);
+    // 主窗口本地坐标定位（锚定音量按钮 + 工具栏同源高度公式），不再 mapToGlobal
+    QRect end = sliderRectFromButton();
+    m_point = end.topLeft();
     setGeometry(end);
+    raise();  // 子控件需置顶，避免被视频原生子窗口/工具栏遮挡
 
     QWidget::showEvent(se);
 }

--- a/src/widgets/platform/platform_volumeslider.h
+++ b/src/widgets/platform/platform_volumeslider.h
@@ -25,6 +25,8 @@ DWIDGET_USE_NAMESPACE
 
 namespace dmr {
 
+class VolumeButton;
+
 class Platform_VolumeSlider: public QWidget
 {
     Q_OBJECT
@@ -40,14 +42,14 @@ signals:
     void sigMuteStateChanged(bool bMute);
 
 public:
-    Platform_VolumeSlider(Platform_MainWindow *mw, QWidget *parent);
+    Platform_VolumeSlider(Platform_MainWindow *mw, VolumeButton *volBtn, QWidget *parent);
     ~Platform_VolumeSlider();
 
     State state() const {return m_state;}
     void initVolume();   //初始化音量
     void stopTimer();
     void popup();        //弹起音量条
-    void updatePoint(QPoint point);
+    void updatePoint();
     bool getsliderstate();
     int getVolume();   //获取当前实际音量
     void changeVolume(int nVolume);    //改变控件音量
@@ -77,11 +79,14 @@ private:
 //    void setAudioVolume(int volume);   //回设dock栏应用音量
     void setMute(bool muted);          //回设dock栏应用静音状态
 
+    QRect sliderRectFromButton() const;  //按音量按钮在主窗口中的实际位置计算音量条矩形(本地坐标)
+
 private:
     DToolButton *m_pBtnChangeMute {nullptr};
     DLabel *m_pLabShowVolume {nullptr};
     DSlider *m_slider;
     Platform_MainWindow *_mw;
+    VolumeButton *m_pVolBtn {nullptr};   //音量按钮，用于锚定音量条位置
     QTimer m_autoHideTimer;
     bool m_bIsMute {false};
     bool m_bFinished {false};


### PR DESCRIPTION
## 背景 / PMS 355653

【1070u5】切换解码模式后音量栏位置异常：在「设置-解码方式」切到专业解码 `OpenGL/OpenGL/OMX` 后重启生效，再调节音量时音量调节栏（`Platform_VolumeSlider`）位置异常（必现）。

- PMS: https://pms.uniontech.com/bug-view-355653.html
- 子 Issue: WS-1121
- 基线: `release/eagle` @ `b485309cd412b5ad9bb50c9aa6495477168b54f4`

## 根因（结构性）

音量条 `Platform_VolumeSlider` 原为顶层 `Qt::ToolTip` 窗口，位置锚点依赖 `_mw->mapToGlobal(QPoint(0,0))` + `_mw->rect()` 硬编码偏移，**仅在主窗口 resize/move** 时经 `updateSliderPoint` 同步；而工具栏 `Platform_ToolboxProxy` 是主窗口**子 widget**，以本地坐标 `setGeometry`/`move` 定位并在 `paintEvent` 自校正。两控件定位基准不对称，在切专业解码后（`composited`/wid 模式由运行时 `config.conf` 与 GPU 共同决定，wid 触发链非无条件）出现错位。精确机理 case A/B 详见根因分析报告；本次采用与 case 无关的兜底方案 A1。

## 修复方案 A1（根因复核通过，推荐兜底）

将音量条由顶层 `ToolTip` 改为**主窗口的子 widget**（本地坐标定位），彻底消除 `mapToGlobal` 依赖，兼修 case A（原点失真）+ case B（偏移失配）。

### 改动

- `src/widgets/platform/platform_volumeslider.{h,cpp}`
  - 去掉 `Qt::ToolTip`/`Qt::Tool` 窗口类型 → 主窗口子控件；加 `WA_NativeWindow` + `raise()` 保证 z-order（镜像 `Platform_ToolboxProxy`，避免被视频原生子窗口/工具栏遮挡）。
  - 新增 `sliderRectFromButton()`：**X 锚定音量按钮水平居中**（`m_pVolBtn->mapTo(_mw, ...)`，消除原 `width` 硬编码偏移在紧凑模式/布局变化下的失配）；**Y 与工具栏同源的高度公式**（保持竖直位置不变）——全部主窗口本地坐标，不再 `mapToGlobal`。
  - `updatePoint()` / `showEvent()` 改用 `sliderRectFromButton()`；`delayedHide()` 的鼠标 hit-test 改为控件本地坐标系。
- `src/widgets/platform/platform_toolbox_proxy.{h,cpp}`
  - 向音量条传入 `m_pVolBtn`；`updateSliderPoint()` 不再接收全局点。
- `src/common/platform/platform_mainwindow.cpp`
  - `resizeEvent`/`moveEvent` 调用 `updateSliderPoint()` 去掉 `mapToGlobal`。

### 行为变化

- 合成模式（`libmpv,opengl-cb`）：本地坐标等价于原「全局 − 原点」，Y 公式不变 → 竖直位置不变；X 由按钮居中 → 修正原 `width-196` 较按钮偏左约 10px 的失配，自动跟随紧凑模式/布局变化。
- wid（非合成）模式：不再经 `mapToGlobal` 锚点 → 消除原点失真导致的漂移；原生子窗口 + `raise()` 保证音量条位于视频面之上。

## 影响范围

仅音量条弹层定位逻辑，不触碰解码/播放/渲染管线；工具栏/投屏窗/通知提示等各自独立定位，不受影响。

## 风险 / 待回归

- 需在 **合成** 与 **wid** 两模式回归：音量条相对音量按钮对齐、可见性（`raise()` z-order）、交互；窗口移动/缩放跟随；多屏/HiDPI；播放列表展开；紧凑模式。
- 本工作环境无目标硬件（芯瞳 GPU / UOS 1070u5），未做运行时编译/运行验证（依赖缺失，CMake 无法配置）；改动已做逐行静态复核。如运行时打印（根因报告 v2 第六节决策表）能区分 case A/B，可据结果评估是否改用更轻量方案，但本 A1 兜底不依赖该数据。

## 关联

- 根因复核通过（评论 9eff17aa）；根因分析报告 v2 见子 Issue 附件 `analysis-report.md`。
- 历史关联 `07514e2`（PMS 338753，音量条跟随窗口移动）——本方案一并规避该类回归。

## Summary by Sourcery

Anchor the volume slider as a child widget of the main window, positioning it relative to the volume button instead of using global coordinates, to eliminate misalignment across compositing modes.

Bug Fixes:
- Fix incorrect volume slider position after switching to professional decoding modes by removing reliance on mapToGlobal-based anchoring.

Enhancements:
- Align the volume slider horizontally to the volume button and keep its vertical position consistent with the toolbox height, including compact mode adjustments.
- Ensure the volume slider uses a native child window with proper z-order and local hit-testing so it remains visible and interactive above video content.
- Simplify toolbox-to-slider coordination by updating the slider position without passing global points from the main window.