### PR TITLE
fix: prevent auto-playing next on proactive MPRIS stop

### DIFF
--- a/src/libdmr/playlist_model.cpp
+++ b/src/libdmr/playlist_model.cpp
@@ -547,6 +547,12 @@ void PlaylistModel::slotStateChanged()
         break;
 
     case PlayerEngine::Idle:
+        if (_stopRequestedByUser) {
+            // 主动触发的停止（如 MPRIS Stop / FN+F8 媒体键）：不自动播放下一首，
+            // 保留当前列表项以便用户重新播放 (PMS #373999)
+            _stopRequestedByUser = false;
+            break;
+        }
         if (!_userRequestingItem) {
             stop();
             //WINID方式渲染结束时，保证gpu渲染资源的正常释放与切换，延时5ms执行下部视频的播放
@@ -909,6 +915,8 @@ void PlaylistModel::stop()
 void PlaylistModel::tryPlayCurrent(bool next)
 {
     qInfo() << __func__;
+    // 新的播放请求开始，清除主动停止标志，避免标志残留导致下一次自然播完不连播
+    _stopRequestedByUser = false;
     auto &pif = _infos[_current];
     if (pif.refresh()) {
         qInfo() << pif.url.fileName() << "changed";
@@ -1447,7 +1455,9 @@ void PlaylistModel::changeCurrent(int pos)
         items().insert(pos, pif);
         emit updateDuration();
     } else {
-        if (_current == pos) {
+        // 引擎已处于 Idle（如主动停止/自然播完后）时允许重播当前项；
+        // 仅在播放/暂停中重复点击同一项时忽略，避免重启正在播放的视频
+        if (_current == pos && _engine->state() != PlayerEngine::Idle) {
             return;
         }
     }

--- a/src/libdmr/playlist_model.h
+++ b/src/libdmr/playlist_model.h
@@ -157,6 +157,13 @@ public:
         ListLoop,
     };
 
+    /**
+     * @brief 标记本次停止为主动触发（如 MPRIS Stop / 媒体键 FN+F8）。
+     *        slotStateChanged 进入 Idle 时检测到该标志则跳过自动播放下一首，
+     *        并保留当前列表项以便用户重新播放（PMS #373999）。
+     */
+    void setStopRequestedByUser(bool on) { _stopRequestedByUser = on; }
+
     void stop();
 
     PlayMode playMode() const;
@@ -275,6 +282,7 @@ private:
     QQueue<UrlList> _pendingAppendReq;
 
     bool _userRequestingItem {false};
+    bool _stopRequestedByUser {false};  ///< 主动触发的停止，不自动播放下一首
 
     PlayerEngine *_engine {nullptr};
 

--- a/src/vendor/presenter.cpp
+++ b/src/vendor/presenter.cpp
@@ -262,8 +262,18 @@ void Presenter::slotseek(qlonglong Offset)
 void Presenter::slotstop()
 {
     qDebug() << "MPRIS: Stop requested";
-    if (_mw)
+    if (_mw) {
+        // 标记主动停止，阻止 slotStateChanged 在进入 Idle 时自动播放下一首 (PMS #373999)
+        // 仅在引擎非 Idle 时置位：引擎已停止时再次 Stop 不会产生 Idle 状态变化，
+        // 标志若不被消费会残留并影响下一次自然播完的自动连播
+        if (_mw->engine()->state() != PlayerEngine::CoreState::Idle) {
+            _mw->engine()->getplaylist()->setStopRequestedByUser(true);
+        }
         _mw->engine()->stop();
-    else
+    } else {
+        if (_platform_mw->engine()->state() != PlayerEngine::CoreState::Idle) {
+            _platform_mw->engine()->getplaylist()->setStopRequestedByUser(true);
+        }
         _platform_mw->engine()->stop();
+    }
 }


### PR DESCRIPTION
## 根因分析

FN+F8 在该 2.4GHz 键盘上发出 evdev 键码 166 = `KEY_STOPCD`，经 xkb 映射为 `XF86AudioStop`，被 dde 媒体键服务路由为对影院 MPRIS 播放器调用 `Stop`。影院 `Presenter::slotstop()` → `engine()->stop()` 使后端进入 Idle；而 `PlaylistModel::slotStateChanged()` 的 Idle 分支**不区分“自然 EOF”与“被停止”**，只要 `!_userRequestingItem` 就执行 `playNext(false)` —— 于是主动停止被误当作“自然播完”，自动播放列表下一首，表现为“无法暂停（实际跳到下一首）”。

关键证据：
- `src/libdmr/playlist_model.cpp:549-560` — Idle 分支一律 `playNext(false)`，不区分停止原因。
- `src/vendor/presenter.cpp:262-269` — MPRIS `stopRequested → engine()->stop()`，是 stop 信号进入影院并触发自动推进的入口。
- 键码实证：evdev 166(KEY_STOPCD) → X 键码 174 → `XF86AudioStop`（`xkb/keycodes/evdev` + `symbols/inet` + `XF86keysym.h:43`）→ MPRIS Stop。

## 修复方案

方案 B 的 flag 简化版（3 文件，用户确认采用）：在 `PlaylistModel` 增加 `_stopRequestedByUser` 标志，`Presenter::slotstop()` 主动停止前置位该标志，`slotStateChanged()` 的 Idle 分支检测到标志时跳过自动 `playNext(false)` 并保留当前列表项（便于用户重新播放）。自然 EOF 自动播下一首、用户切歌等原有行为完全不变。

## 改动安全评估

低风险：无函数签名/公开 API 变更，仅新增 1 个 private 标志 + 1 个 early-return 分支 + 1 处置位。`Presenter::slotstop()` 的测试调用无断言且签名不变，兼容。历史 dbus 暂停修复（`d92188de`，PMS 131973）改的是 `slotplay()`，与本次改动无冲突。详见附件 `change-safety.md`。

## Summary by Sourcery

Preserve the current playlist item when users explicitly stop playback instead of treating the stop as natural completion.

Bug Fixes:
- Prevent proactive MPRIS or media-key stops from automatically starting the next playlist item.
- Allow replaying the current item after playback has entered the idle state.