### PR TITLE
fix: prevent path injection in subtitle download

### DIFF
--- a/src/libdmr/online_sub.cpp
+++ b/src/libdmr/online_sub.cpp
@@ -114,8 +114,11 @@ void OnlineSubtitle::subtitlesDownloadComplete()
 
 QString OnlineSubtitle::findAvailableName(const QString &tmpl, int id)
 {
-    QString name_tmpl = tmpl;
-    int i = tmpl.lastIndexOf('.');
+    QString name_tmpl = QFileInfo(tmpl).fileName();
+    if (name_tmpl.isEmpty() || name_tmpl == "." || name_tmpl == "..") {
+        return QString();
+    }
+    int i = name_tmpl.lastIndexOf('.');
     if (i >= 0) {
         name_tmpl.replace(i, 1, "[%1].");
     } else {
@@ -130,7 +133,7 @@ QString OnlineSubtitle::findAvailableName(const QString &tmpl, int id)
         }
         c++;
     } while (c < (1 << 16));
-    return tmpl;
+    return QString();
 }
 
 void OnlineSubtitle::replyReceived(QNetworkReply *reply)
@@ -278,11 +281,7 @@ void OnlineSubtitle::downloadSubtitles()
 
     for (auto &sub : _subs) {
         QNetworkRequest req;
-        //QUrl url(sub.link.toUtf8());
-        auto s = sub.link;
-        s.replace("https://", "http://");
-        QUrl url(s);
-        url.setScheme("http");
+        QUrl url(sub.link);
         req.setUrl(url);
 
         auto *reply = _nam->get(req);


### PR DESCRIPTION
## Root Cause Analysis

The online subtitle download feature in deepin-movie-reborn parses the `filename` field from the HTTP `Content-Disposition` response header without any path filtering, then concatenates it directly with the subtitle storage directory path in `findAvailableName()` (`src/libdmr/online_sub.cpp:127`). An attacker (a malicious subtitle server or MITM) can craft a `filename` containing `../` traversal sequences (e.g. `../../.bashrc`) to escape the subtitle directory and overwrite arbitrary user-writable files. Additionally, `downloadSubtitles()` explicitly downgrades HTTPS to HTTP (`online_sub.cpp:283-285`), making it easy for a MITM attacker to tamper with responses and inject malicious filenames.

## Fix Approach

Use `QFileInfo::fileName()` in `findAvailableName()` to extract only the basename from the parsed filename, stripping all path prefixes and `../` sequences; reject empty or path-only names by returning an empty string (a path that `QFile` cannot open, so no write occurs). Remove the HTTPS→HTTP downgrade in `downloadSubtitles()` to preserve the original URL scheme and transport encryption. The implementation follows the analysis report's fix suggestion (section 9, items 1 and 3); item 4 (player_engine.cpp file removal hardening) was intentionally not added since the primary fix already neutralizes the controllable path (root-cause fix principle).

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The path sanitization is internal to `findAvailableName()` with no signature change; the HTTPS downgrade removal is internal to `downloadSubtitles()`. Blame/pickaxe history confirms neither behavior was a prior bug fix — both are original implementation flaws from 2017 code refactoring, so this change does not revert any historical fix.
- Highest-risk affected callers: `replyReceived()` at `online_sub.cpp:222` (calls `findAvailableName`, return value remains a writable path inside the subtitle dir or an empty string on failure) and `online_sub.cpp:186` (calls `downloadSubtitles`, original `sub.link` scheme preserved) — both semantically compatible.

### Business Impact Scope

Affects the online subtitle download feature — the flow where a user plays a video and the app searches/downloads subtitles via the shooter.cn API. Normal subtitle download behavior is unchanged; only filenames containing path separators are sanitized to basename. HTTPS subtitle links are now downloaded over their original scheme instead of being downgraded to HTTP.

### Verification Suggestion

Test the normal subtitle search/download flow (search → download → save → auto-load), verify HTTPS subtitle links download correctly without downgrade, and confirm that a malicious `Content-Disposition` filename containing `../` or an absolute path cannot escape the subtitle storage directory.

---

## 根因分析

deepin-movie-reborn 的在线字幕下载功能从 HTTP `Content-Disposition` 响应头解析 `filename` 字段时未做任何路径过滤，随后在 `findAvailableName()`（`src/libdmr/online_sub.cpp:127`）中直接拼接到字幕存储目录路径。攻击者（恶意字幕服务器或中间人）可构造含 `../` 路径遍历序列的 `filename`（如 `../../.bashrc`），逃逸字幕目录覆盖任意用户可写文件。此外，`downloadSubtitles()` 显式将 HTTPS 降级为 HTTP（`online_sub.cpp:283-285`），使中间人攻击者可轻易篡改响应注入恶意 filename。

## 修复方案

在 `findAvailableName()` 中使用 `QFileInfo::fileName()` 提取纯文件名，剥离所有路径前缀和 `../` 序列；对空或仅路径的名称返回空串（`QFile` 无法打开空串路径即不写入）。移除 `downloadSubtitles()` 中的 HTTPS→HTTP 降级，保留原始 URL scheme 与传输加密。实现遵循分析报告修复建议（第九节第 1、3 条）；第 4 条（player_engine.cpp 文件删除加固）因主修复已消除可控路径风险，遵循根因修复原则未额外追加。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 路径净化改动仅限 `findAvailableName()` 函数体内部，签名不变；HTTPS 降级移除仅限 `downloadSubtitles()` 函数体。blame/pickaxe 历史确认两处行为均非历史 bug 修复产物，而是 2017 年代码重构引入的初始实现缺陷，本次改动不会撤销历史修复。
- 风险最高的受影响调用者：`replyReceived()`（`online_sub.cpp:222`，调用 `findAvailableName`，返回值仍为字幕目录内可写路径或失败时空串）与 `online_sub.cpp:186`（调用 `downloadSubtitles`，保留原始 `sub.link` scheme）——均语义兼容。

### 业务影响范围

影响在线字幕下载功能——用户播放视频时通过 shooter.cn API 搜索并下载字幕的流程。正常字幕下载行为不变，仅含路径分隔符的文件名被净化为纯文件名；HTTPS 字幕链接不再被降级为 HTTP，按原始协议下载。

### 验证建议

测试在线字幕搜索/下载正常流程（搜索 → 下载 → 保存 → 自动加载），验证 HTTPS 字幕链接能正常下载且不再降级，并确认含 `../` 或绝对路径的恶意 `Content-Disposition` 文件名无法逃逸字幕存储目录。

## Summary by Sourcery

Harden online subtitle downloads against path traversal and transport downgrade attacks.

Bug Fixes:
- Prevent subtitle downloads from escaping the subtitle storage directory through malicious path components in response filenames.
- Preserve HTTPS for subtitle downloads instead of downgrading requests to HTTP.