### PR TITLE
fix: add no-GPU-driver prompt on non-x86 playback

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -431,8 +431,13 @@ mpv_handle *MpvProxy::mpv_init()
         m_sInitVo = "gpu,x11";
 #elif defined (__aarch64__)
         if (!utils::isJjwGPUPresent()) { //2.1.1景嘉微
-            my_set_property(pHandle, "vo", "gpu,xv,x11");
-            m_sInitVo = "gpu,xv,x11";
+            if (!CompositingManager::get().hascard()) {
+                my_set_property(pHandle, "vo", "x11");
+                m_sInitVo = "x11";
+            } else {
+                my_set_property(pHandle, "vo", "gpu,xv,x11");
+                m_sInitVo = "gpu,xv,x11";
+            }
         }
 #else
         //去除9200显卡适配

--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -3481,6 +3481,12 @@ void MainWindow::slotFileLoaded()
     }
     this->resizeByConstraints();
     m_bIsFree = true;
+#if !defined (__x86_64__)
+    if (!m_bNoGpuDriverPrompted && !CompositingManager::get().hascard()) {
+        m_bNoGpuDriverPrompted = true;
+        m_pCommHintWid->updateWithMessage(tr("No graphics card driver detected. Software decoding will be used, which may affect playback experience."));
+    }
+#endif
 }
 
 void MainWindow::slotUrlpause(bool bStatus)

--- a/src/common/mainwindow.h
+++ b/src/common/mainwindow.h
@@ -566,6 +566,7 @@ private:
     QProcess *m_pShortcutViewProcess;
     int m_nDisplayVolume;                            ///记录播放音量
     bool m_bIsFree;                                  ///播放器是否空闲，和IDel的定义不同
+    bool m_bNoGpuDriverPrompted {false};            ///无显卡驱动时的一次性提示标记
     static int m_nRetryTimes;                        ///播放失败后重试次数
     //add by heyi 解决触屏右键菜单bug
     int m_nLastPressX;                               ///左键按下时保存的点

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -3466,6 +3466,12 @@ void Platform_MainWindow::slotFileLoaded()
     m_platform_nRetryTimes = 0;
     this->resizeByConstraints();
     m_bIsFree = true;
+#if !defined (__x86_64__)
+    if (!m_bNoGpuDriverPrompted && !CompositingManager::get().hascard()) {
+        m_bNoGpuDriverPrompted = true;
+        m_pCommHintWid->updateWithMessage(tr("No graphics card driver detected. Software decoding will be used, which may affect playback experience."));
+    }
+#endif
 }
 
 void Platform_MainWindow::slotUrlpause(bool bStatus)

--- a/src/common/platform/platform_mainwindow.h
+++ b/src/common/platform/platform_mainwindow.h
@@ -563,6 +563,7 @@ private:
     QProcess *m_pShortcutViewProcess;
     int m_nDisplayVolume;                            ///记录播放音量
     bool m_bIsFree;                                  ///播放器是否空闲，和IDel的定义不同
+    bool m_bNoGpuDriverPrompted {false};            ///无显卡驱动时的一次性提示标记
     static int m_platform_nRetryTimes;                        ///播放失败后重试次数
     //add by heyi 解决触屏右键菜单bug
     int m_nLastPressX;                               ///左键按下时保存的点


### PR DESCRIPTION
## Root Cause

On Arm64 systems without GPU driver (e.g. 1070u3), `CompositingManager` correctly detects the absence (`m_bHasCard=false`) and `mpv_proxy` silently falls back to software decode, but the main window never reads `hascard()` to inform the user. The detection→fallback→prompt chain breaks at the prompt stage — a design-level logic gap.

## Fix

1. **MainWindow / Platform_MainWindow**: In `slotFileLoaded()`, added a `#if !defined(__x86_64__)` guarded block that checks `!CompositingManager::get().hascard()` once (via `m_bNoGpuDriverPrompted` flag) and shows a prompt via the existing `m_pCommHintWid->updateWithMessage()` channel: "No graphics card driver detected. Software decoding will be used, which may affect playback experience."
2. **mpv_proxy**: On `__aarch64__` when no JJW GPU is present, additionally check `!hascard()` — if no card, lower VO to `x11` directly instead of trying `gpu,xv,x11`, avoiding failed output attempts.

## Impact

- Arm64 users without GPU driver now see a clear one-time prompt on first video playback.
- Existing x86_64 builds are unaffected (all new code is behind `#if !defined(__x86_64__)` guards).
- Systems with GPU driver are unaffected (prompt only triggers when `!hascard()`).

## PMS

- PMS: BUG-337305
- Bug: https://pms.uniontech.com/bug-view-337305.html

## Summary by Sourcery

Improve non-x86 playback fallback and user feedback when GPU drivers are unavailable.

New Features:
- Notify non-x86 users when no graphics driver is detected and software decoding will be used.

Bug Fixes:
- Use a direct X11 video output fallback on Arm64 systems without a GPU driver, avoiding unavailable hardware-output attempts.