### PR TITLE
fix: sync fullscreen action state on mini exit

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -4517,6 +4517,14 @@ void Platform_MainWindow::toggleUIMode()
             showMaximized();
         } else if (m_nStateBeforeMiniMode & SBEM_Fullscreen) {
             setWindowState(windowState() | Qt::WindowFullScreen);
+            //同步全屏菜单 QAction checked，与窗口全屏状态一致
+            QList<QAction *> fullscreenActs = ActionFactory::get().findActionsByKind(ActionFactory::ActionKind::ToggleFullscreen);
+            for (auto *pAct : fullscreenActs) {
+                bool bOld = pAct->isEnabled();
+                pAct->setEnabled(false);
+                pAct->setChecked(true);
+                pAct->setEnabled(bOld);
+            }
         } else {
             if (m_pToolbox->listBtn()->isChecked()) {
                 m_pToolbox->listBtn()->setChecked(false);


### PR DESCRIPTION
## Root Cause Analysis

When exiting mini mode, `toggleUIMode()` restores fullscreen window state via `setWindowState(windowState() | Qt::WindowFullScreen)` (platform_mainwindow.cpp:4519) but does not sync the fullscreen QAction (`pActFs`) checked state. The QAction was set to `unchecked=false` during mini mode entry by `reflectActionToUI(ToggleMiniMode)`, and is never restored on exit. This leaves the window in fullscreen while the menu shows unchecked — subsequent fullscreen toggle via shortcut (F11/Alt+Enter) or double-click (`bFromUI=false`) inverts the state because `reflectActionToUI(ToggleFullscreen)` flips `setChecked(!isChecked())` on a false-to-true transition, exiting fullscreen while showing checked.

## Fix Approach

After `setWindowState(windowState() | Qt::WindowFullScreen)` in the mini-exit fullscreen restore branch, explicitly call `setChecked(true)` on all fullscreen QActions found via `ActionFactory::findActionsByKind(ToggleFullscreen)`, using the same enable/disable guard pattern as `reflectActionToUI` to suppress signal emission. This establishes state consistency at the source rather than relying on a toggle-based `reflectActionToUI` call.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Target line L4519 was introduced by zhuyl (2022-03-02, "fix: bug 114865") as a previous bug fix product; this change does not revert it, only appends state sync logic after it.
- No function signature change, no public member modification, no new external callers — all 6 reference sites are call-only and unaffected.

### Business Impact Scope

Affects the fullscreen mode module: window fullscreen state and right-click menu QAction checked state consistency after exiting mini mode. User scenario: enter fullscreen → enter mini mode → exit mini mode → toggle fullscreen via shortcut/double-click. Before fix, state inverts; after fix, state remains consistent.

### Verification Suggestion

Verify state consistency after fullscreen → mini → exit cycle using both shortcut (F11/Alt+Enter) and double-click toggles. Regression check: right-click menu fullscreen checkbox should match window state.

---

## 根因分析

退出迷你模式时，`toggleUIMode()` 通过 `setWindowState(windowState() | Qt::WindowFullScreen)`（platform_mainwindow.cpp:4519）恢复全屏窗口状态，但未同步全屏 QAction（`pActFs`）的 checked 状态。进入迷你模式时 `reflectActionToUI(ToggleMiniMode)` 已将全屏 QAction 置为未勾选，退出时未恢复，导致窗口全屏但菜单显示未勾选。此后通过快捷键（F11/Alt+Enter）或双击（`bFromUI=false`）切换全屏时，`reflectActionToUI(ToggleFullscreen)` 执行 `setChecked(!isChecked())` 翻转 false→true，窗口退出全屏但菜单显示已勾选，状态反转。

## 修复方案

在 `setWindowState(windowState() | Qt::WindowFullScreen)` 之后，通过 `ActionFactory::findActionsByKind(ToggleFullscreen)` 查找全屏 QAction 并显式 `setChecked(true)`，使用与 `reflectActionToUI` 相同的 enable/disable 守卫模式抑制信号发射。在源头建立状态一致性，而非依赖翻转式 `reflectActionToUI` 调用。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 目标行 L4519 由 zhuyl 于 2022-03-02 提交（"fix: bug 114865"），是历史 bug 修复产物；本次修改不撤销该行，仅在其后追加状态同步逻辑。
- 不修改函数签名、不修改公开成员、无新增外部调用者——全部 6 处引用均为调用，不受影响。

### 业务影响范围

影响全屏模式模块：退出迷你模式后窗口全屏状态与右键菜单 QAction 勾选状态的一致性。用户场景：全屏 → 迷你模式 → 退出迷你模式 → 快捷键/双击切换全屏。修复前状态反转，修复后状态保持一致。

### 验证建议

验证全屏 → 迷你 → 退出后快捷键（F11/Alt+Enter）和双击切换全屏的状态一致性。回归检查：右键菜单全屏勾选状态应与窗口实际状态一致。

PMS: BUG-251671

## Summary by Sourcery

Bug Fixes:
- Synchronize fullscreen menu actions with the restored fullscreen window state when exiting mini mode, preventing subsequent fullscreen toggles from inverting the actual and displayed states.