### PR TITLE
fix: 补齐紧凑模式音量按钮 setIconSize，修复图标错位 (#165847)

### DIFF
--- a/src/widgets/platform/platform_toolbox_proxy.cpp
+++ b/src/widgets/platform/platform_toolbox_proxy.cpp
@@ -1239,6 +1239,7 @@ void Platform_ToolboxProxy::setup()
         m_pNextBtn->setFixedSize(26, 33);
         m_pFullScreenBtn->setIconSize(QSize(24, 24));
         m_pFullScreenBtn->setFixedSize(33, 33);
+        m_pVolBtn->setIconSize(QSize(24, 24));
         m_pVolBtn->setFixedSize(33, 33);
         m_pMircastBtn->setIconSize(QSize(16, 16));
         m_pMircastBtn->setFixedSize(33, 33);
@@ -1259,6 +1260,7 @@ void Platform_ToolboxProxy::setup()
             m_pNextBtn->setFixedSize(40, 50);
             m_pFullScreenBtn->setIconSize(QSize(36, 36));
             m_pFullScreenBtn->setFixedSize(50, 50);
+            m_pVolBtn->setIconSize(QSize(36, 36));
             m_pVolBtn->setFixedSize(50, 50);
             m_pMircastBtn->setIconSize(QSize(24, 24));
             m_pMircastBtn->setFixedSize(50, 50);
@@ -1276,6 +1278,7 @@ void Platform_ToolboxProxy::setup()
             m_pNextBtn->setFixedSize(26, 33);
             m_pFullScreenBtn->setIconSize(QSize(24, 24));
             m_pFullScreenBtn->setFixedSize(33, 33);
+            m_pVolBtn->setIconSize(QSize(24, 24));
             m_pVolBtn->setFixedSize(33, 33);
             m_pMircastBtn->setIconSize(QSize(16, 16));
             m_pMircastBtn->setFixedSize(33, 33);

--- a/src/widgets/toolbox_proxy.cpp
+++ b/src/widgets/toolbox_proxy.cpp
@@ -1354,6 +1354,7 @@ void ToolboxProxy::setup()
         m_pNextBtn->setFixedSize(26, 33);
         m_pFullScreenBtn->setIconSize(QSize(24, 24));
         m_pFullScreenBtn->setFixedSize(33, 33);
+        m_pVolBtn->setIconSize(QSize(24, 24));
         m_pVolBtn->setFixedSize(33, 33);
         m_pMircastBtn->setIconSize(QSize(16, 16));
         m_pMircastBtn->setFixedSize(33, 33);
@@ -1374,6 +1375,7 @@ void ToolboxProxy::setup()
             m_pNextBtn->setFixedSize(40, 50);
             m_pFullScreenBtn->setIconSize(QSize(36, 36));
             m_pFullScreenBtn->setFixedSize(50, 50);
+            m_pVolBtn->setIconSize(QSize(36, 36));
             m_pVolBtn->setFixedSize(50, 50);
             m_pMircastBtn->setIconSize(QSize(24, 24));
             m_pMircastBtn->setFixedSize(50, 50);
@@ -1391,6 +1393,7 @@ void ToolboxProxy::setup()
             m_pNextBtn->setFixedSize(26, 33);
             m_pFullScreenBtn->setIconSize(QSize(24, 24));
             m_pFullScreenBtn->setFixedSize(33, 33);
+            m_pVolBtn->setIconSize(QSize(24, 24));
             m_pVolBtn->setFixedSize(33, 33);
             m_pMircastBtn->setIconSize(QSize(16, 16));
             m_pMircastBtn->setFixedSize(33, 33);


### PR DESCRIPTION
## 修复 Bug #165847：点击音量按钮时音量图标显示错位

### Bug 信息
- 单号：#165847
- 标题：点击音量按钮时音量图标显示错位
- PMS：https://pms.uniontech.com/bug-view-165847.html

### 根因

紧凑模式（`DGuiApplicationHelper::CompactMode`）下，工具栏音量按钮 `m_pVolBtn` 仅被 `setFixedSize(33, 33)` 缩小了按钮尺寸，但漏调用 `setIconSize`，导致图标尺寸恒为 `VolumeButton` 构造函数设定的 36×36（`src/widgets/toolbutton.cpp:16`）。

结果：36×36 图标装入 33×33 按钮 → **图标尺寸 > 按钮尺寸 → 渲染溢出/错位**。

常规模式下按钮为 50×50，36 < 50 正常，解释了「仅紧凑模式错位」的现象。

### 修复内容

为 `m_pVolBtn` 在 6 处补齐 `setIconSize`（紧凑模式 24×24、常规模式 36×36），与同一代码块中 `m_pPrevBtn`/`m_pPlayBtn`/`m_pNextBtn`/`m_pFullScreenBtn`/`m_pMircastBtn`/`m_pListBtn` 成对执行 `setIconSize`+`setFixedSize` 的写法保持一致：

| 文件 | 改动 |
|---|---|
| `src/widgets/toolbox_proxy.cpp` | 3 处新增 `setIconSize` |
| `src/widgets/platform/platform_toolbox_proxy.cpp` | 3 处新增 `setIconSize` |

6 处必须同时改，以保证紧凑↔常规模式切换后图标尺寸同步更新，不残留错位。

### 改动安全

- 仅补齐遗漏的 `setIconSize` 调用，使 `m_pVolBtn` 与相邻按钮尺寸设置模式一致。
- 不改变条件分支、信号槽连接、布局结构。
- 常规模式显式设 36×36 与构造函数默认值相同，不影响已有正常表现。
- 低风险，无回归面。

## Summary by Sourcery

Bug Fixes:
- 修复紧凑模式下音量按钮图标尺寸与按钮不匹配导致的显示错位。