### PR TITLE
fix: 连拍截图后影院界面变成透明色 (#166187)

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -2827,7 +2827,7 @@ void MainWindow::onBurstScreenshot(const QImage &frame, qint64 timestamp)
         }
 
         int nRet = -1;
-        BurstScreenshotsDialog burstScreenshotsDialog(m_pEngine->playlist().currentInfo());
+        BurstScreenshotsDialog burstScreenshotsDialog(m_pEngine->playlist().currentInfo(), this);
         burstScreenshotsDialog.updateWithFrames(m_listBurstShoots);
 #ifdef USE_TEST
         burstScreenshotsDialog.show();

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -2854,7 +2854,7 @@ void Platform_MainWindow::onBurstScreenshot(const QImage &frame, qint64 timestam
         }
 
         int nRet = -1;
-        BurstScreenshotsDialog burstScreenshotsDialog(m_pEngine->playlist().currentInfo());
+        BurstScreenshotsDialog burstScreenshotsDialog(m_pEngine->playlist().currentInfo(), this);
         burstScreenshotsDialog.updateWithFrames(m_listBurstShoots);
 #ifdef USE_TEST
         burstScreenshotsDialog.show();

--- a/src/widgets/burst_screenshots_dialog.cpp
+++ b/src/widgets/burst_screenshots_dialog.cpp
@@ -17,8 +17,8 @@ namespace dmr {
 * @brief BurstScreenshotsDialog 构造函数
 * @param strPlayItemInfo 播放项信息
 */
-BurstScreenshotsDialog::BurstScreenshotsDialog(const PlayItemInfo &PlayItemInfo)
-    : DAbstractDialog(nullptr)
+BurstScreenshotsDialog::BurstScreenshotsDialog(const PlayItemInfo &PlayItemInfo, QWidget *parent)
+    : DAbstractDialog(parent)
 {
     MovieInfo strMovieInfo = PlayItemInfo.mi;
 

--- a/src/widgets/burst_screenshots_dialog.h
+++ b/src/widgets/burst_screenshots_dialog.h
@@ -55,8 +55,9 @@ public:
     /**
      * @brief BurstScreenshotsDialog 构造函数
      * @param strPlayItemInfo 播放项信息
+     * @param parent 父窗口
      */
-    explicit BurstScreenshotsDialog(const PlayItemInfo &strPlayItemInfo);
+    explicit BurstScreenshotsDialog(const PlayItemInfo &strPlayItemInfo, QWidget *parent = nullptr);
     /**
      * @brief updateWithFrames 更新截图图像
      * @param frames 截图图像


### PR DESCRIPTION
## Bug
- PMS: #166187
- 标题：连拍截图后影院界面变成透明色
- 产品：影院V23

## Root Cause
`BurstScreenshotsDialog` was constructed with `nullptr` as its parent (`DAbstractDialog(nullptr)`). Under Wayland, while the modal dialog blocked the event loop during burst screenshot, the compositor invalidated the main window GL surface; after the dialog closed the player window rendered transparent.

## Fix
Add a `QWidget *parent` parameter to `BurstScreenshotsDialog` and pass the main window (`this`) at **both** call sites so the dialog is a transient child of the player window and the GL surface stays valid:

- `src/widgets/burst_screenshots_dialog.h` — constructor signature adds `QWidget *parent = nullptr`
- `src/widgets/burst_screenshots_dialog.cpp` — pass `parent` to `DAbstractDialog(parent)`
- `src/common/mainwindow.cpp` — pass `this` as parent
- `src/common/platform/platform_mainwindow.cpp` — pass `this` as parent

## Notes
- Reference: historical commit `b02a14da` fixed only `mainwindow.cpp`; this change also covers `platform_mainwindow.cpp` (the Wayland/V23 path) to avoid an incomplete fix.
- No behavior change for normal dialog display; only establishes the parent-window relationship.

## Test
1. On Wayland: play a video, trigger burst screenshot (Alt+S), verify the window does not become transparent after the dialog closes.
2. On X11: verify burst screenshot works with no regression.
3. Verify fullscreen burst screenshot display.

## Summary by Sourcery

Bug Fixes:
- Prevent the player window from becoming transparent after burst screenshots by associating the screenshot dialog with its main window on all supported paths.