### PR TITLE
fix: sync fullscreen check on mini mode exit

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -4517,6 +4517,10 @@ void Platform_MainWindow::toggleUIMode()
             showMaximized();
         } else if (m_nStateBeforeMiniMode & SBEM_Fullscreen) {
             setWindowState(windowState() | Qt::WindowFullScreen);
+            QList<QAction *> fullscreenActs = ActionFactory::get().findActionsByKind(ActionFactory::ActionKind::ToggleFullscreen);
+            if (!fullscreenActs.isEmpty() && fullscreenActs[0]) {
+                fullscreenActs[0]->setChecked(true);
+            }
         } else {
             if (m_pToolbox->listBtn()->isChecked()) {
                 m_pToolbox->listBtn()->setChecked(false);


### PR DESCRIPTION
## Root Cause Analysis

In the platform version of deepin-movie-reborn, when entering mini mode via the F2 shortcut, `reflectActionToUI(ToggleMiniMode)` actively unchecks the fullscreen QAction (`setChecked(false)` at `platform_mainwindow.cpp:1605`). However, when exiting mini mode, `toggleUIMode()` restores the fullscreen window state via `setWindowState(windowState() | Qt::WindowFullScreen)` but does **not** re-check the fullscreen QAction — creating a desync where the window is fullscreen but the menu checkmark shows unchecked. Because `ToggleFullscreen` uses flip semantics (`setChecked(!isChecked())`), this desync persists and reverses on subsequent toggles. The non-platform version does not have this issue because its `reflectActionToUI(ToggleMiniMode)` never touches the fullscreen QAction.

Key evidence: `platform_mainwindow.cpp:1605` (enter mini → uncheck fullscreen) and `platform_mainwindow.cpp:4519` (exit mini → restore fullscreen window state without syncing QAction check). The deterministic trigger is **F2 shortcut entering mini mode** — `reflectActionToUI(ToggleMiniMode)` only unchecks when `!bFromUI`, and `menuItemInvoked` sets `bFromUI = !bIsShortcut` (menu click origin != "shortcut"), so menu-click entry does not trigger the uncheck.

## Fix

In the `restore-fullscreen` branch of `toggleUIMode()` (after `setWindowState(windowState() | Qt::WindowFullScreen)` at line 4519), sync the fullscreen QAction check state to `true`, matching the synchronization already done in `contextMenuEvent`. This is the minimal change (Plan A from the analysis report) — 4 lines added, no function signature or caller changes. The actual implementation matches the analysis report's recommended fix exactly, with no deviation.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The fix adds 4 lines inside a single existing branch of `toggleUIMode()` — no signature changes, no new callers, no deletion of existing logic. Blame history confirms the target branch was introduced for restoring fullscreen window state on mini-mode exit; this change only appends a QAction check sync, not reverting any prior fix.
- All callers of `toggleUIMode()` (ToggleMiniMode action handler at line 2162, QuitFullscreen/Esc at line 2203) are compatible — the added sync only runs in the fullscreen-restore path, making check state consistent with window state.

### Business Impact Scope

Affected: fullscreen ↔ mini mode switching in the platform version. Specifically, the scenario where a user enters fullscreen, presses F2 to enter mini mode, then exits mini mode (F2/Esc/menu) — the fullscreen menu checkmark will now correctly reflect the fullscreen window state. Non-platform version and non-fullscreen mini mode cycles are unaffected.

### Verification Suggestion

Enter fullscreen (Alt+Enter or menu) → press F2 to enter mini mode → exit mini mode → verify the fullscreen action is checked. Then toggle fullscreen via Alt+Enter and verify check state always matches window state. Also regress the maximized → mini → exit path to ensure no impact.

---

## 根因分析

Platform 版影院在全屏模式下经快捷键 F2 进入迷你模式时，`reflectActionToUI(ToggleMiniMode)` 主动取消全屏 QAction 勾选（`platform_mainwindow.cpp:1605` 的 `setChecked(false)`）。退出迷你模式时 `toggleUIMode()` 通过 `setWindowState(windowState() | Qt::WindowFullScreen)` 恢复了全屏窗口状态（第 4519 行），但**未同步恢复全屏 QAction 勾选** → 窗口已全屏、菜单勾选未选（错位）。由于 `ToggleFullscreen` 使用 flip 语义（`setChecked(!isChecked())`），错位持续叠加。非 platform 版的 `reflectActionToUI(ToggleMiniMode)` 不触碰全屏 QAction，故无此问题。

关键证据：`platform_mainwindow.cpp:1605`（进入迷你取消全屏勾选）+ `platform_mainwindow.cpp:4519`（退出迷你恢复全屏窗口状态但未同步勾选）。确定性触发入口为**快捷键 F2 进入迷你模式**——`reflectActionToUI(ToggleMiniMode)` 仅在 `!bFromUI` 时取消勾选，而 `menuItemInvoked` 令 `bFromUI = !bIsShortcut`（菜单点击 origin != "shortcut"），故菜单点击进入不触发取消勾选。

## 修复方案

在 `toggleUIMode()` 退出迷你模式恢复全屏窗口状态的分支中（第 4519 行 `setWindowState` 之后），同步设置全屏 QAction 勾选为 `true`，与 `contextMenuEvent` 中已有的同步逻辑一致。此为分析报告推荐的最小改动方案（方案 A），新增 4 行，不改变函数签名、不新增调用者。实际实现与分析报告方案完全一致，无偏离。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 修复仅在 `toggleUIMode()` 退出迷你恢复全屏分支内追加 4 行 QAction 勾选同步语句，不改动函数签名、不删除公开成员、不新增调用者，属同函数内微调。blame 历史显示目标分支由 `muyuankai` 引入用于恢复全屏窗口状态，本次修复仅在其后追加同步语句，不撤销既有逻辑。
- `toggleUIMode` 全部调用者（ToggleMiniMode action 处理第 2162 行、QuitFullscreen/Esc 第 2203 行）均兼容——新增同步仅在恢复全屏路径执行，使勾选与窗口状态一致。历史 revert 的时序修复（`cf12836d`/`f8f298620`）及时序替代修复（`7a32d4f0`）均不涉及 QAction 勾选同步，无回归风险。

### 业务影响范围

受影响：platform 版全屏↔迷你模式切换。用户在全屏下按 F2 进入迷你模式、再退出迷你模式回到全屏后，全屏菜单勾选状态正确反映当前全屏状态。非 platform 版及非全屏状态下的迷你模式切换不受影响。

### 验证建议

进入全屏（Alt+Enter 或菜单）→ 按 F2 进迷你 → 退出迷你 → 确认全屏菜单勾选为已勾选。退出迷你后连续 Alt+Enter 切换全屏，确认勾选与窗口状态始终一致。同时回归最大化→迷你→退出恢复最大化路径，确保不受影响。

## Summary by Sourcery

Bug Fixes:
- Synchronize the fullscreen menu action with the restored fullscreen window state when exiting mini mode in the platform version.