### PR TITLE
fix: guard toolbox/pause popup with active-window check on state change

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -1436,7 +1436,7 @@ void Platform_MainWindow::animatePlayState()
     }
 
     if (!m_bInBurstShootMode && m_pEngine->state() == PlayerEngine::CoreState::Paused
-            && !m_bMiniMode && !m_pMircastShowWidget->isVisible()) {
+            && !m_bMiniMode && !m_pMircastShowWidget->isVisible() && isActiveWindow()) {
             if (CompositingManager::get().platform() == Platform::X86) {
                 m_pAnimationlabel->resize(100, 100);
             } else {
@@ -3416,7 +3416,8 @@ void Platform_MainWindow::slotPlayerStateChanged()
     PlayerEngine *pEngine = dynamic_cast<PlayerEngine *>(sender());
     if (!pEngine) return;
     setInit(pEngine->state() != PlayerEngine::Idle);
-    resumeToolsWindow();
+    if (isActiveWindow())
+        resumeToolsWindow();
     updateWindowTitle();
 
     // delayed checking if engine is still idle, in case other videos are schedulered (next/prev req)


### PR DESCRIPTION
## Bug: #251657 影院播放视频拔出耳机暂停图标悬浮最顶层

### 问题现象
在影院播放视频时，如果其他应用窗口覆盖了影院窗口，拔出耳机后暂停图标和控制栏会越过覆盖的应用窗口，悬浮在最顶层。

### 根因分析
1. **缺少焦点/激活态守卫（主因）**：拔出耳机 → 音频设备变化 → mpv `pause` 属性变化 → `stateChanged` 信号触发 → `slotPlayerStateChanged()`（`platform_mainwindow.cpp:3419`）无条件调用 `resumeToolsWindow()`，`animatePlayState()`（`platform_mainwindow.cpp:1450`）无条件调用 `pauseAnimation()`。两处均未检查主窗口是否处于激活/焦点态。
2. **窗口标志绕过 WM 堆叠（放大因素）**：`Platform_ToolboxProxy` 使用 `Qt::BypassWindowManagerHint`（`platform_toolbox_proxy.cpp:868`），`Platform_AnimationLabel` 使用 `Qt::Tool`（`platform_animationlabel.cpp:34`），两者为独立顶层窗口，`show()` 不受窗口管理器 z-order 约束。

### 修复方案
在 `slotPlayerStateChanged()` 和 `animatePlayState()` 中增加 `isActiveWindow()` 守卫：
- `slotPlayerStateChanged()`：仅当主窗口为激活窗口时才调用 `resumeToolsWindow()`。
- `animatePlayState()`：在暂停动画显示条件中追加 `&& isActiveWindow()`。

当用户切回影院窗口时，`slotFocusWindowChanged()` 会照常恢复工具栏。

`isActiveWindow()` 是同文件已有的调用模式（line 1231），复用现有 API，改动最小。

### 影响范围
- 仅修改非合成（`composited=false`）Platform 路径的 `platform_mainwindow.cpp`。
- 合成分支（`mainwindow.cpp`）使用子控件且无 bypass-window-manager 标志，不受影响。

### 改动文件
- `src/common/platform/platform_mainwindow.cpp`（3 行增，2 行删）

## Summary by Sourcery

Guard playback pause overlays and tool-window restoration with the main window's active state.

Bug Fixes:
- Prevent pause indicators and toolbox windows from appearing above other applications when the cinema window is inactive.

Enhancements:
- Restore playback tools and pause animations only when the cinema window is active, while preserving normal restoration when focus returns.