### PR TITLE
fix: prevent pause icon floating above other windows

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -1447,7 +1447,8 @@ void Platform_MainWindow::animatePlayState()
                     m_pAnimationlabel->setGeometry(width() / 2 - 100, height() / 2 - 100, 200, 200);
                 }
             }
-            m_pAnimationlabel->pauseAnimation();
+            if (isActiveWindow())
+                m_pAnimationlabel->pauseAnimation();
         }
 }
 
@@ -3416,7 +3417,8 @@ void Platform_MainWindow::slotPlayerStateChanged()
     PlayerEngine *pEngine = dynamic_cast<PlayerEngine *>(sender());
     if (!pEngine) return;
     setInit(pEngine->state() != PlayerEngine::Idle);
-    resumeToolsWindow();
+    if (isActiveWindow())
+        resumeToolsWindow();
     updateWindowTitle();
 
     // delayed checking if engine is still idle, in case other videos are schedulered (next/prev req)


### PR DESCRIPTION
## Root Cause Analysis

In the non-composited (`composited=false`) Platform path, when another application window covers the movie player and headphones are unplugged, the pause animation icon and toolbox float above all windows. The root cause is that `slotPlayerStateChanged()` (`platform_mainwindow.cpp:3419`) and `animatePlayState()` (`platform_mainwindow.cpp:1450`) unconditionally call `resumeToolsWindow()` / `pauseAnimation()` on the `stateChanged` signal without checking whether the main window is the active window. Since `Platform_ToolboxProxy` uses `Qt::BypassWindowManagerHint` (`platform_toolbox_proxy.cpp:868`) and `Platform_AnimationLabel` uses `Qt::Tool` (`platform_animationlabel.cpp:34`), both are independent top-level windows whose `show()` bypasses the window manager z-order, so they stack above covering windows.

## Fix

Add an `isActiveWindow()` guard before `resumeToolsWindow()` in `slotPlayerStateChanged()` and before `pauseAnimation()` in `animatePlayState()`, so the toolbox and pause icon are not shown when another application window covers the player. This mirrors the existing focus-check pattern in `slotFocusWindowChanged()` (`platform_mainwindow.cpp:3444`). The actual implementation matches the analysis recommendation with no deviation.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The change only adds an `isActiveWindow()` early-return guard to two functions; no signature, public-member, or caller-behavior change. The approach is consistent with the prior Bug #247791 fix (`commit 20e5f869`, which added an `isMinimized()` guard to `animatePlayState()` for the same `Qt::Tool` stacking issue) and does not revert it.
- Affected callers (`stateChanged` → both slots) remain compatible: non-active-window state simply skips the toolbox/pause-icon show; playback state itself and `updateWindowTitle()` are unaffected.

### Business Impact Scope

- **Player toolbox display** (non-composited mode): toolbox/control bar show/hide now respects window active state.
- **Pause animation icon display**: the centered pause animation no longer appears when the player is covered by another window.
- User scenario: while playing video with another app covering the player, unplugging headphones (triggering pause) no longer floats the pause icon and toolbox above all windows; switching back to the player restores normal display.
- Composited mode (`composited=true`) path is unaffected (`Platform_*` classes are only used when `composited=false`).

### Verification Suggestion

Verify toolbox and pause animation display correctly when the player is active, and that unplugging headphones with another app covering the player does not float the pause icon/toolbox. Regression-test the minimized-player pause icon (Bug #247791).

---

## 根因分析

在非合成（`composited=false`）Platform 路径下，当其他应用窗口覆盖播放器且拔出耳机时，暂停动画图标和工具栏悬浮于所有窗口最顶层。根因是 `slotPlayerStateChanged()`（`platform_mainwindow.cpp:3419`）和 `animatePlayState()`（`platform_mainwindow.cpp:1450`）在 `stateChanged` 信号触发时无条件调用 `resumeToolsWindow()` / `pauseAnimation()`，未检查主窗口是否处于活动态。由于 `Platform_ToolboxProxy` 使用 `Qt::BypassWindowManagerHint`（`platform_toolbox_proxy.cpp:868`）、`Platform_AnimationLabel` 使用 `Qt::Tool`（`platform_animationlabel.cpp:34`），两者为独立顶层窗口，`show()` 绕过窗口管理器 z-order 堆叠，从而浮于覆盖窗口之上。

## 修复方案

在 `slotPlayerStateChanged()` 的 `resumeToolsWindow()` 前增加 `isActiveWindow()` 守卫，在 `animatePlayState()` 的 `pauseAnimation()` 前增加 `isActiveWindow()` 守卫，使其他应用覆盖播放器时不弹出工具栏和暂停图标。该方式与 `slotFocusWindowChanged()`（`platform_mainwindow.cpp:3444`）已有的焦点检查模式一致。实际实现与分析建议一致，无偏离。

## 改动安全评估

### 代码安全评估

- **风险等级**：低风险
- 本次改动仅在两个函数中增加 `isActiveWindow()` 前置守卫（early-return），不改变函数签名、不修改公开成员变量、不影响调用者行为。思路与历史 Bug #247791 修复（commit `20e5f869`，曾为 `animatePlayState()` 增加 `isMinimized()` 守卫解决同一 `Qt::Tool` 堆叠问题）一致，且未撤销该修复。
- 受影响调用者（`stateChanged` → 两个 slot）保持兼容：非活动窗口态仅跳过工具栏/暂停图标显示，播放状态本身及 `updateWindowTitle()` 不受影响。

### 业务影响范围

- **播放器工具栏显示**（非合成模式）：工具栏/控制栏的显示与隐藏现在遵循窗口活动态。
- **暂停动画图标显示**：播放器被其他窗口覆盖时，中心暂停动画不再出现。
- 用户场景：播放视频时有其他应用覆盖播放器，拔耳机触发暂停后暂停图标和工具栏不再浮于最顶层；切回播放器后恢复正常显示。
- 合成模式（`composited=true`）路径不受影响（`Platform_*` 类仅在 `composited=false` 时使用）。

### 验证建议

验证播放器活动态下工具栏和暂停动画正常显示，以及其他应用覆盖播放器时拔耳机不弹出暂停图标/工具栏。回归测试最小化时暂停图标不显示（Bug #247791）。

## Summary by Sourcery

Bug Fixes:
- Prevent the pause animation and player toolbox from appearing above other application windows when the player is inactive.