### PR TITLE
fix: unify playlist geometry in togglePopup with updateProxyGeometry

### DIFF
--- a/src/widgets/platform/platform_playlist_widget.cpp
+++ b/src/widgets/platform/platform_playlist_widget.cpp
@@ -1355,9 +1355,17 @@ void Platform_PlaylistWidget::togglePopup(bool isShortcut)
 #endif
 
     QRect fixed;
-    // y坐标下移5个像素点,避免播放列表上部超出toolbox范围
-    fixed.setRect(10, (view_rect.height() - (TOOLBOX_SPACE_HEIGHT + toolbox_height + 10) + 5),
-                  view_rect.width() - 20, TOOLBOX_SPACE_HEIGHT + 10);
+#ifndef __sw_64__
+    fixed.setRect(10, (view_rect.height() - (TOOLBOX_SPACE_HEIGHT + toolbox_height + 5)),
+                  view_rect.width() - 20, TOOLBOX_SPACE_HEIGHT);
+    if (utils::check_wayland_env()) {
+        fixed.setRect(10, (view_rect.height() - (TOOLBOX_SPACE_HEIGHT + toolbox_height)),
+                      view_rect.width() - 20, TOOLBOX_SPACE_HEIGHT);
+    }
+#else
+    fixed.setRect(10, (view_rect.height() - (TOOLBOX_SPACE_HEIGHT + toolbox_height - 1)),
+                  view_rect.width() - 20, TOOLBOX_SPACE_HEIGHT);
+#endif
 
     QRect shrunk = fixed;
     shrunk.setHeight(0);

--- a/src/widgets/playlist_widget.cpp
+++ b/src/widgets/playlist_widget.cpp
@@ -1356,14 +1356,17 @@ void PlaylistWidget::togglePopup(bool isShortcut)
  * 基于 MainWindow::updateProxyGeometry所设置的初始状态 以及 是否是紧凑模式 定位PlaylistWidget的起始位置和终止位置。
 */
     QRect fixed;
-    if(CompositingManager::get().platform() == X86) {
-        fixed.setRect(10, (view_rect.height() - (TOOLBOX_SPACE_HEIGHT + toolbox_height + 10)),
-                      view_rect.width() - 20, TOOLBOX_SPACE_HEIGHT + 10);
+#ifndef __sw_64__
+    fixed.setRect(10, (view_rect.height() - (TOOLBOX_SPACE_HEIGHT + toolbox_height + 5)),
+                  view_rect.width() - 20, TOOLBOX_SPACE_HEIGHT);
+    if (utils::check_wayland_env()) {
+        fixed.setRect(10, (view_rect.height() - (TOOLBOX_SPACE_HEIGHT + toolbox_height)),
+                      view_rect.width() - 20, TOOLBOX_SPACE_HEIGHT);
     }
-    else {
-        fixed.setRect(10, (view_rect.height() - (TOOLBOX_SPACE_HEIGHT + toolbox_height + 10) + 5),
-                      view_rect.width() - 20, TOOLBOX_SPACE_HEIGHT + 10);
-    }
+#else
+    fixed.setRect(10, (view_rect.height() - (TOOLBOX_SPACE_HEIGHT + toolbox_height - 1)),
+                  view_rect.width() - 20, TOOLBOX_SPACE_HEIGHT);
+#endif
 
     QRect shrunk = fixed;
     shrunk.setHeight(0);


### PR DESCRIPTION
## Root Cause Analysis

The playlist widget's expand/collapse function `togglePopup()` and the resize/fullscreen handler `updateProxyGeometry()` used inconsistent geometry formulas: height differed by 10px, Y offset was inconsistent, and `togglePopup` lacked a Wayland branch. When a fullscreen toggle triggered `resizeEvent → updateProxyGeometry`, the playlist was repositioned to a slightly different position than `togglePopup` had set, causing a visible 5-10px jump on the top edge. Key evidence: `togglePopup` (playlist_widget.cpp:1356) used `TOOLBOX_SPACE_HEIGHT + 10` height with no Wayland guard, while `updateProxyGeometry` (mainwindow.cpp:3143) used `TOOLBOX_SPACE_HEIGHT` with a Wayland branch.

## Fix Approach

Unified `togglePopup()`'s playlist geometry formula to exactly match `updateProxyGeometry()`: replaced the X86/non-X86 platform branches with `#ifndef __sw_64__` / Wayland / `#else` structure, matching the height (`TOOLBOX_SPACE_HEIGHT`), Y offset (`+5` non-Wayland, `+0` Wayland, `-1` sw_64), and added the missing Wayland branch. Applied to both composited path (`src/widgets/playlist_widget.cpp`) and platform path (`src/widgets/platform/platform_playlist_widget.cpp`).

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The modified lines were last touched by commits fixing compact-mode toolbox height (PMS #225507, #262c9ea8). This fix preserves the dynamic `toolbox_height` variable — it does not revert those historical fixes.
- All 4 callers of `togglePopup` (mainwindow.cpp:1280, mainwindow.cpp:2064, platform_mainwindow.cpp:1341, platform_mainwindow.cpp:2119) only use the expand/collapse behavior, not the internal geometry values — no caller is affected.

### Business Impact Scope

Affects the playlist display module — the expand/collapse animation start and end positions. Users will no longer see a 5-10px jump when toggling fullscreen with the playlist open, on both X11 and Wayland.

### Verification Suggestion

Focus regression testing on: fullscreen toggle with playlist open (both window→fullscreen and fullscreen→window), Wayland environment, and compact mode (DSizeMode).

---

## 根因分析

播放列表展开/收起函数 `togglePopup()` 与 resize/全屏处理函数 `updateProxyGeometry()` 使用了不一致的几何公式：高度差 10px、Y 偏移不一致、`togglePopup` 缺 Wayland 分支。全屏切换触发 `resizeEvent → updateProxyGeometry` 时，播放列表被重定位到与 `togglePopup` 设定值略有不同的位置，导致顶边出现 5-10px 可见跳变。关键证据：`togglePopup`（playlist_widget.cpp:1356）使用 `TOOLBOX_SPACE_HEIGHT + 10` 高度且无 Wayland 守卫，而 `updateProxyGeometry`（mainwindow.cpp:3143）使用 `TOOLBOX_SPACE_HEIGHT` 并有 Wayland 分支。

## 修复方案

将 `togglePopup()` 的播放列表几何公式统一为与 `updateProxyGeometry()` 完全一致：将 X86/非X86 平台分支替换为 `#ifndef __sw_64__` / Wayland / `#else` 结构，匹配高度（`TOOLBOX_SPACE_HEIGHT`）、Y 偏移（非Wayland `+5`、Wayland `+0`、sw_64 `-1`），并补充缺失的 Wayland 分支。composited 路径（`src/widgets/playlist_widget.cpp`）与 platform 路径（`src/widgets/platform/platform_playlist_widget.cpp`）均已同步修改。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 修改行上次由紧凑模式 toolbox 高度修复（PMS #225507、#262c9ea8）触及。本次修复保留动态 `toolbox_height` 变量，不回退这些历史修复。
- `togglePopup` 的 4 个调用者（mainwindow.cpp:1280、mainwindow.cpp:2064、platform_mainwindow.cpp:1341、platform_mainwindow.cpp:2119）仅使用展开/收起行为，不依赖内部几何值——无调用者受影响。

### 业务影响范围

影响播放列表显示模块——展开/收起动画的起始和终止位置。用户在全屏切换且播放列表已打开时不再看到 5-10px 跳变，X11 和 Wayland 环境均修复。

### 验证建议

回归测试重点：全屏切换且播放列表已打开（窗口→全屏和全屏→窗口）、Wayland 环境、紧凑模式（DSizeMode）。

PMS: BUG-166305

## Summary by Sourcery

Unify playlist popup geometry across platforms and window-state transitions to prevent visual jumps during fullscreen changes.

Bug Fixes:
- Align playlist popup geometry across toggle and resize/fullscreen handling to eliminate visible position jumps.
- Add Wayland-aware playlist positioning for popup expansion and collapse.

Enhancements:
- Apply consistent platform-specific playlist dimensions and offsets across composited and platform widget implementations while preserving compact-mode sizing.