### PR TITLE
fix: force hide fullscreen/list button tooltip when toggling fullscreen

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -2225,6 +2225,8 @@ void Platform_MainWindow::requestAction(ActionFactory::ActionKind actionKind, bo
         //音量条控件打开时全屏位置异常，全屏时关掉音量条
         m_pAnimationlabel->hide();
         m_pToolbox->closeAnyPopup();
+        //全屏/退出全屏前后强制关闭工具栏按钮的悬浮提示，避免提示文字残留不消失
+        m_pToolbox->setButtonTooltipHide();
 
         if (isFullScreen()) {
             // 取消全屏前，先取消绕过合成器

--- a/src/widgets/platform/platform_toolbox_proxy.cpp
+++ b/src/widgets/platform/platform_toolbox_proxy.cpp
@@ -2565,8 +2565,17 @@ void Platform_ToolboxProxy::setVolSliderHide()
 
 void Platform_ToolboxProxy::setButtonTooltipHide()
 {
+    // 隐藏按钮内部自带的悬浮提示
     m_pListBtn->hideToolTip();
     m_pFullScreenBtn->hideToolTip();
+    // 隐藏全屏/列表按钮上独立悬浮显示的提示文字（ButtonToolTip）
+    // 该提示只在鼠标 leaved 事件时才隐藏，切全屏等场景必须主动关闭，否则部分机型概率会残留不消失
+    if (m_pFullScreenBtnTip && m_pFullScreenBtnTip->isVisible()) {
+        m_pFullScreenBtnTip->hide();
+    }
+    if (m_pListBtnTip && m_pListBtnTip->isVisible()) {
+        m_pListBtnTip->hide();
+    }
 }
 
 void Platform_ToolboxProxy::initToolTip()


### PR DESCRIPTION
When entering/exiting fullscreen, the floating tooltip of the fullscreen and list buttons is only hidden on the mouse leave event, so it can linger on screen on some machines. Force-hide both the built-in button tooltip and the independent floating tooltip before toggling fullscreen.

Log: force hide fullscreen/list button tooltip when toggling fullscreen

Influence:
1. Enter/exit fullscreen repeatedly and verify no tooltip text remains on screen
2. Verify normal hover tooltip behavior is unaffected

Bug： https://pms.uniontech.com/bug-view-374699.html

## Summary by Sourcery

Bug Fixes:
- Prevent fullscreen and list button tooltips from lingering when entering or exiting fullscreen.