### PR TITLE
fix: show pause/play button in no-compositor mode and shrink its size

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1108,7 +1108,8 @@ Platform_MainWindow::Platform_MainWindow(QWidget *parent)
 
     m_pWMDBus = new QDBusInterface("com.deepin.WMSwitcher", "/com/deepin/WMSwitcher", "com.deepin.WMSwitcher", QDBusConnection::sessionBus());
     QDBusReply<QString> reply_string = m_pWMDBus->call("CurrentWM");
-    m_bIsWM = reply_string.value().contains("deepin wm");
+    m_bRealIsWM = reply_string.value().contains("deepin wm");
+    m_bIsWM = m_bRealIsWM;
     m_pCommHintWid->setWM(m_bIsWM);
     connect(m_pWMDBus, SIGNAL(WMChanged(QString)), this, SLOT(slotWMChanged(QString)));
 
@@ -1118,7 +1119,8 @@ Platform_MainWindow::Platform_MainWindow(QWidget *parent)
     if (CompositingManager::get().platform() != Platform::X86 && m_bIsWM) {
         m_pAnimationlabel->setGeometry(width() / 2 - 100, height() / 2 - 100, 200, 200);
     } else {
-        m_pAnimationlabel->setGeometry(width() / 2 - 100, height() / 2, 100, 100);
+        int nS = Platform_AnimationLabel::kNonWMSize;
+        m_pAnimationlabel->setGeometry(width() / 2 - nS / 2, height() / 2 - nS / 2, nS, nS);
     }
     m_pPopupWid = new Platform_MessageWindow(this);
     m_pPopupWid->hide();
@@ -1438,10 +1440,10 @@ void Platform_MainWindow::animatePlayState()
     if (!m_bInBurstShootMode && m_pEngine->state() == PlayerEngine::CoreState::Paused
             && !m_bMiniMode && !m_pMircastShowWidget->isVisible()) {
             if (CompositingManager::get().platform() == Platform::X86) {
-                m_pAnimationlabel->resize(100, 100);
+                m_pAnimationlabel->resize(Platform_AnimationLabel::kNonWMSize, Platform_AnimationLabel::kNonWMSize);
             } else {
                 if (!m_bIsWM) {
-                    m_pAnimationlabel->resize(100, 100);
+                    m_pAnimationlabel->resize(Platform_AnimationLabel::kNonWMSize, Platform_AnimationLabel::kNonWMSize);
                 } else {
                     m_pAnimationlabel->resize(200, 200);
                     m_pAnimationlabel->setGeometry(width() / 2 - 100, height() / 2 - 100, 200, 200);
@@ -2234,6 +2236,11 @@ void Platform_MainWindow::requestAction(ActionFactory::ActionKind actionKind, bo
                 Utility::setBypassCompositor(windowHandle()->winId(), false);
             }
 
+            // 取消绕过合成器后，恢复真实的窗口特效状态，使暂停/播放控件重新使用合成器渲染效果
+            m_bIsWM = m_bRealIsWM;
+            m_pAnimationlabel->setWM(m_bIsWM);
+            m_pCommHintWid->setWM(m_bIsWM);
+
             setWindowState(windowState() & ~Qt::WindowFullScreen);
 
             if (m_bMaximized) {
@@ -2254,6 +2261,10 @@ void Platform_MainWindow::requestAction(ActionFactory::ActionKind actionKind, bo
             if (!m_pToolbox->getbAnimationFinash())
                 return;
             m_bMaximized = isMaximized();  // 记录全屏前是否是最大化窗口
+            // 全屏后绕过合成器，窗口透明/动画效果失效，切换为非WM模式使暂停/播放控件正常显示
+            m_bIsWM = false;
+            m_pAnimationlabel->setWM(m_bIsWM);
+            m_pCommHintWid->setWM(m_bIsWM);
             mipsShowFullScreen();
             if (m_pProgIndicator && isFullScreen()) {
                 QRect screenGeo = windowHandle()->screen()->geometry();
@@ -2637,10 +2648,10 @@ void Platform_MainWindow::requestAction(ActionFactory::ActionKind actionKind, bo
                 //startPlayStateAnimation(true);
                 if (!m_bMiniMode) {
                     if (CompositingManager::get().platform() == Platform::X86) {
-                        m_pAnimationlabel->resize(100, 100);
+                        m_pAnimationlabel->resize(Platform_AnimationLabel::kNonWMSize, Platform_AnimationLabel::kNonWMSize);
                     } else {
                         if (!m_bIsWM) {
-                            m_pAnimationlabel->resize(100, 100);
+                            m_pAnimationlabel->resize(Platform_AnimationLabel::kNonWMSize, Platform_AnimationLabel::kNonWMSize);
                         } else {
                             m_pAnimationlabel->resize(200, 200);
                             m_pAnimationlabel->setGeometry(width() / 2 - 100, height() / 2 - 100, 200, 200);
@@ -3299,10 +3310,10 @@ void Platform_MainWindow::checkWarningMpvLogsChanged(const QString sPrefix, cons
             //startPlayStateAnimation(true);
             if (!m_bMiniMode) {
                 if (CompositingManager::get().platform() == Platform::X86) {
-                    m_pAnimationlabel->resize(100, 100);
+                    m_pAnimationlabel->resize(Platform_AnimationLabel::kNonWMSize, Platform_AnimationLabel::kNonWMSize);
                 } else {
                     if (!m_bIsWM) {
-                        m_pAnimationlabel->resize(100, 100);
+                        m_pAnimationlabel->resize(Platform_AnimationLabel::kNonWMSize, Platform_AnimationLabel::kNonWMSize);
                     } else {
                         m_pAnimationlabel->setGeometry(width() / 2 - 100, height() / 2 - 100, 200, 200);
                     }
@@ -3535,13 +3546,17 @@ void Platform_MainWindow::slotVolumeChanged(int nVolume)
 void Platform_MainWindow::slotWMChanged(QString msg)
 {
     if (msg.contains("deepin metacity")) {
-        m_bIsWM = false;
+        m_bRealIsWM = false;
     } else {
-        m_bIsWM = true;
+        m_bRealIsWM = true;
     }
 
-    m_pAnimationlabel->setWM(m_bIsWM);
-    m_pCommHintWid->setWM(m_bIsWM);
+    //全屏期间绕过合成器，暂停/播放控件需保持非WM模式显示，退出全屏后再恢复真实状态
+    if (!isFullScreen()) {
+        m_bIsWM = m_bRealIsWM;
+        m_pAnimationlabel->setWM(m_bIsWM);
+        m_pCommHintWid->setWM(m_bIsWM);
+    }
 }
 
 void Platform_MainWindow::mircastSuccess(QString name)

--- a/src/common/platform/platform_mainwindow.h
+++ b/src/common/platform/platform_mainwindow.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -583,7 +583,8 @@ private:
     MircastShowWidget *m_pMircastShowWidget;          ///投屏展示界面
     qint64 m_nFullscreenTime;                         ///全屏操作间隔时间
     QDBusInterface *m_pWMDBus {nullptr};              ///窗口特效dbus接口
-    bool m_bIsWM {true};                              ///是否开启窗口特效
+    bool m_bIsWM {true};                              ///是否开启窗口特效（全屏绕过合成器期间会被临时置为false）
+    bool m_bRealIsWM {true};                          ///真实的窗口特效状态，用于退出全屏后恢复m_bIsWM
     bool m_bMaximized;                                ///全屏前最大化窗口记录
     bool m_bLocked{true};
     bool m_bShowTime {false};                         ///全屏显示影片时间信息

--- a/src/widgets/platform/platform_animationlabel.cpp
+++ b/src/widgets/platform/platform_animationlabel.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -38,7 +38,7 @@ Platform_AnimationLabel::Platform_AnimationLabel(QWidget *parent, QWidget *pMain
     if(m_bIsWM){
         resize(200, 200);
     } else {
-        resize(100, 100);
+        resize(kNonWMSize, kNonWMSize);
     }
 }
 
@@ -53,7 +53,7 @@ void Platform_AnimationLabel::pauseAnimation()
     if (m_bIsWM)
         setFixedSize(200, 200);
     else
-        setFixedSize(100, 100);
+        setFixedSize(kNonWMSize, kNonWMSize);
     if(!isShowPopup()) return;
     m_pPlayAnimationGroup->start();
     if(!isVisible()) {
@@ -72,7 +72,7 @@ void Platform_AnimationLabel::playAnimation()
     if (m_bIsWM)
         setFixedSize(200, 200);
     else
-        setFixedSize(100, 100);
+        setFixedSize(kNonWMSize, kNonWMSize);
     if(!isShowPopup()) return;
     m_pPauseAnimationGroup->start();
     if(!isVisible()) {

--- a/src/widgets/platform/platform_animationlabel.h
+++ b/src/widgets/platform/platform_animationlabel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -27,6 +27,8 @@ class Platform_AnimationLabel : public QFrame
     Q_PROPERTY(int fps READ fps WRITE setFps)
 
 public:
+    static const int kNonWMSize = 80;  ///无合成器(非WM)模式下动画控件尺寸
+
     /**
      * @brief AnimationLabel构造函数
      * @param parent 父窗口


### PR DESCRIPTION
When entering fullscreen the window bypasses the compositor, breaking transparency/animation of the pause/play overlay. Force non-WM rendering state while fullscreen and restore the real WM state on exit. Also reduce the no-compositor button size via a shared kNonWMSize constant.

log: fix bug

bug: https://pms.uniontech.com/bug-view-373499.html

## Summary by Sourcery

Keep pause/play controls working in fullscreen no-compositor mode and restore window effects correctly afterward.

Bug Fixes:
- Ensure the pause/play overlay remains visible and functional when entering fullscreen without compositor rendering.
- Restore the actual window-manager effects state after leaving fullscreen.

Enhancements:
- Reduce the non-compositor pause/play control size to 80 pixels using a shared size definition.