### PR TITLE
chore: update version to 6.5.56

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-movie-reborn (6.5.56) unstable; urgency=medium
+
+  * fix(settings): handle legacy decode effect index
+
+ -- Wang Yu <wangyu@uniontech.com>  Fri, 28 Aug 2026 09:04:41 +0800
+
 deepin-movie-reborn (6.5.55) unstable; urgency=medium
 
   * chore: Update version to 6.5.55

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.55.1
+  version: 6.5.56.1
   kind: app
   description: |
     movie for deepin os.


### PR DESCRIPTION
- bump version to 6.5.56

Log : bump version to 6.5.56

## Summary by Sourcery

Chores:
- Update the Debian package and application metadata to version 6.5.56.