### PR TITLE
fix: correct coordinate calc of overlap detection in platform tooltip

### DIFF
--- a/src/widgets/platform/platform_notification_widget.cpp
+++ b/src/widgets/platform/platform_notification_widget.cpp
@@ -141,6 +141,39 @@ void Platform_NotificationWidget::popup(const QString &msg, bool flag)
     m_pMsgLabel->setText(msg);
 
     if (flag) {
+            //按当前锚点与内容计算控件期望显示的矩形，用于重叠检测
+            //(不能直接使用this->geometry():popup()时尚未resize/定位,该值可能是0x0或残留的旧位置)
+            QRect msgRect;
+            {
+                const QSize contentSize(m_pMsgLabel->sizeHint().width()
+                                        + m_pMainLayout->contentsMargins().left()
+                                        + m_pMainLayout->contentsMargins().right(),
+                                        height());
+                switch (m_pAnchor) {
+                case ANCHOR_BOTTOM: {
+                    const QRect geom = m_pMainWindow->geometry();
+                    msgRect.setSize(contentSize);
+                    msgRect.moveTopLeft(QPoint(geom.center().x() - contentSize.width() / 2,
+                                               geom.bottom() - m_nAnchorDist - contentSize.height()));
+                    break;
+                }
+                case ANCHOR_NONE: {
+                    const QRect geom = m_pMainWindow->geometry();
+                    msgRect.setSize(contentSize);
+                    msgRect.moveCenter(geom.center());
+                    break;
+                }
+                case ANCHOR_NORTH_WEST: {
+                    msgRect.setSize(contentSize);
+                    msgRect.moveTopLeft(m_pMainWindow->mapToGlobal(m_anchorPoint));
+                    break;
+                }
+                default:
+                    Q_UNREACHABLE();
+                    break;
+                }
+            }
+
             QList<WId> currentApplicationWindowList;
             const QWindowList &list = qApp->allWindows();
 
@@ -167,7 +200,6 @@ void Platform_NotificationWidget::popup(const QString &msg, bool flag)
                     continue;
                 }
                 if (DForeignWindow *w = DForeignWindow::fromWinId(wid)) {
-                    QRect msgRect = this->geometry();
                     if (w) {
                         QRect wRect = w->geometry();
                         if (msgRect.x() < wRect.x() + wRect.width() &&


### PR DESCRIPTION
The overlap detection of the top-left resolution hint used this->geometry() which, at popup() time, has not been resized/positioned yet and may be 0x0 or a stale old position. As a result it never intersects any window, so the hint could not be hidden when covered by another window and instead showed on top of it.

Compute the expected global rect of the hint from the anchor and content size before doing the overlap check, so a covered hint now correctly returns and stays hidden.

Bug: https://pms.uniontech.com/bug-view-375059.html

## Summary by Sourcery

Bug Fixes:
- Fix platform tooltip overlap detection so covered resolution hints remain hidden when obscured by another window.