### PR TITLE
fix: hide platform tooltip while screen is locked

### DIFF
--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -4698,6 +4698,9 @@ void Platform_MainWindow::sleepStateChanged(bool bSleep)
 void Platform_MainWindow::lockStateChanged(bool bLock)
 {
     qInfo() << __func__ << bLock;
+    //锁屏时隐藏并抑制左上角提示，避免提示显示在锁屏界面之上
+    m_pCommHintWid->setLocked(bLock);
+    m_pDVDHintWid->setLocked(bLock);
     //锁屏退出投屏
     if(bLock && m_pMircastShowWidget && m_pMircastShowWidget->isVisible()) {
         slotExitMircast();
@@ -4889,6 +4892,11 @@ void Platform_MainWindow::setMusicShortKeyState(bool bState)
 
 void Platform_MainWindow::onSysLockState(QString, QVariantMap key2value, QStringList)
 {
+    //同步系统锁屏状态到提示控件，兜底保证锁屏期间不显示提示
+    const bool bLock = key2value.value("Locked").value<bool>();
+    m_pCommHintWid->setLocked(bLock);
+    m_pDVDHintWid->setLocked(bLock);
+
     if (m_bStartSleep) {
         m_bStateInLock = true;       //如果进入了休眠状态后进入锁屏,则默认执行了暂停操作
     }

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -4699,8 +4699,12 @@ void Platform_MainWindow::lockStateChanged(bool bLock)
 {
     qInfo() << __func__ << bLock;
     //锁屏时隐藏并抑制左上角提示，避免提示显示在锁屏界面之上
-    m_pCommHintWid->setLocked(bLock);
-    m_pDVDHintWid->setLocked(bLock);
+    if (m_pCommHintWid) {
+        m_pCommHintWid->setLocked(bLock);
+    }
+    if (m_pDVDHintWid) {
+        m_pDVDHintWid->setLocked(bLock);
+    }
     //锁屏退出投屏
     if(bLock && m_pMircastShowWidget && m_pMircastShowWidget->isVisible()) {
         slotExitMircast();
@@ -4892,11 +4896,6 @@ void Platform_MainWindow::setMusicShortKeyState(bool bState)
 
 void Platform_MainWindow::onSysLockState(QString, QVariantMap key2value, QStringList)
 {
-    //同步系统锁屏状态到提示控件，兜底保证锁屏期间不显示提示
-    const bool bLock = key2value.value("Locked").value<bool>();
-    m_pCommHintWid->setLocked(bLock);
-    m_pDVDHintWid->setLocked(bLock);
-
     if (m_bStartSleep) {
         m_bStateInLock = true;       //如果进入了休眠状态后进入锁屏,则默认执行了暂停操作
     }
@@ -4913,6 +4912,14 @@ void Platform_MainWindow::onSysLockState(QString, QVariantMap key2value, QString
 void Platform_MainWindow::slotProperChanged(QString, QVariantMap key2value, QStringList)
 {
     qInfo() << __func__ << key2value;
+    //同步系统锁屏状态到提示控件，兜底保证锁屏期间不显示提示
+    const bool bLock = key2value.value("Locked").value<bool>();
+    if (m_pCommHintWid) {
+        m_pCommHintWid->setLocked(bLock);
+    }
+    if (m_pDVDHintWid) {
+        m_pDVDHintWid->setLocked(bLock);
+    }
     if (key2value.value("Active").value<bool>() && m_pEngine->state() == PlayerEngine::CoreState::Playing) {
         m_pEngine->seekAbsolute(m_pEngine->elapsed());
     }

--- a/src/widgets/platform/platform_notification_widget.cpp
+++ b/src/widgets/platform/platform_notification_widget.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2020 ~ 2021, Deepin Technology Co., Ltd. <support@deepin.org>
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -231,6 +231,11 @@ void Platform_NotificationWidget::popup(const QString &msg, bool flag)
  */
 void Platform_NotificationWidget::updateWithMessage(const QString &newMsg, bool flag)
 {
+    //锁屏期间不显示任何提示，避免显示在锁屏界面之上
+    if (m_bLocked) {
+        return;
+    }
+
     if (m_pIconLabel) {
         m_pIconLabel->setVisible(false);
     }

--- a/src/widgets/platform/platform_notification_widget.cpp
+++ b/src/widgets/platform/platform_notification_widget.cpp
@@ -133,6 +133,11 @@ void Platform_NotificationWidget::syncPosition(QRect rect)
  */
 void Platform_NotificationWidget::popup(const QString &msg, bool flag)
 {
+    //锁屏期间不显示任何提示，避免显示在锁屏界面之上
+    if (m_bLocked) {
+        return;
+    }
+
     m_pMainLayout->setContentsMargins(14, 4, 14, 4);
     if (m_pMainLayout->indexOf(m_pMsgLabel) == -1) {
         m_pMainLayout->addWidget(m_pMsgLabel);
@@ -314,6 +319,7 @@ void Platform_NotificationWidget::initMember()
     m_pAnchor = ANCHOR_NONE;
     m_nAnchorDist = 10;
     m_bIsWheel = true;
+    m_bLocked = false;
 }
 
 }

--- a/src/widgets/platform/platform_notification_widget.h
+++ b/src/widgets/platform/platform_notification_widget.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/widgets/platform/platform_notification_widget.h
+++ b/src/widgets/platform/platform_notification_widget.h
@@ -53,6 +53,11 @@ public:
     void setAnchorPoint(const QPoint& p) { m_anchorPoint = p; }
 
     void setWM(bool isWM) { m_bIsWM = isWM; }
+    /**
+     * @brief setLocked 设置锁屏状态，锁屏期间不显示任何提示
+     * @param locked 是否锁屏
+     */
+    void setLocked(bool locked) { m_bLocked = locked; if (locked) hide(); }
 
 public slots:
     /**
@@ -111,6 +116,7 @@ private:
     QPoint m_anchorPoint;         ///控件位置点
     bool m_bIsWheel;              ///
     bool m_bIsWM;
+    bool m_bLocked;               ///锁屏期间不显示提示
 };
 
 }


### PR DESCRIPTION
The overlap detection and isActiveWindow() checks cannot prevent the top-left hint from showing on top of the lock screen:
- dde-lock is a dedicated fullscreen layer not present in currentWorkspaceWindowIdList(), so the overlap check never sees it.
- isActiveWindow() is not a reliable lock signal.

Route the lock state into the hint widget via the existing lock signals (com.deepin.dde.lockFront Visible and login1 Locked property): the widget hides itself and suppresses any popup() while locked.

Bug: https://pms.uniontech.com/bug-view-375059.html

## Summary by Sourcery

Keep platform hints hidden while the screen is locked by propagating system lock state to notification widgets.

Bug Fixes:
- Prevent platform notification hints from appearing over the lock screen by hiding them and suppressing new popups while locked.
- Synchronize lock state from both lock-screen visibility and system lock property signals to ensure hints remain hidden during locking.