### PR TITLE
fix(mpv): force hwdec=vaapi for wmv on inno-codec GPUs

### DIFF
--- a/src/backends/mpv/mpv_proxy.cpp
+++ b/src/backends/mpv/mpv_proxy.cpp
@@ -1820,6 +1820,19 @@ void MpvProxy::refreshDecode()
             my_set_property_async(m_handle, "vo", "gpu", 0);
         }
 
+        // 芯动(inno-codec) wmv 硬解覆盖（仅限wmv）
+        {
+            QDir innodir("/sys/bus/platform/drivers/inno-codec");
+            if (innodir.exists()) {
+                const bool isWmv = codec.toLower().contains("wmv") || name.toLower().contains("wmv");
+                if (isWmv) {
+                    qDebug() << "DEBUG: Inno-codec driver detected with wmv. Force hwdec=vaapi, vo=gpu.";
+                    my_set_property_async(m_handle, "hwdec", "vaapi", 0);
+                    my_set_property_async(m_handle, "vo", "gpu", 0);
+                }
+            }
+        }
+
         if (!CompositingManager::get().composited()) {
             if (CompositingManager::get().isSpecialControls()) {
                 my_set_property_async(m_handle, "hwdec","vaapi", 0);
@@ -1893,6 +1906,20 @@ void MpvProxy::refreshDecode()
         if(utils::isSietiumGPUPresent()) {
             my_set_property_async(m_handle, "hwdec", "vaapi", 0);
             my_set_property_async(m_handle, "vo", "gpu", 0);
+        }
+
+        // 芯动(inno-codec) wmv 硬解覆盖（仅限wmv）
+        {
+            QDir innodir("/sys/bus/platform/drivers/inno-codec");
+            if (innodir.exists()) {
+                const auto codec = currentInfo.mi.videoCodec();
+                const auto name = _file.fileName();
+                if (codec.toLower().contains("wmv") || name.toLower().contains("wmv")) {
+                    qDebug() << "DEBUG: Inno-codec driver detected with wmv. Force hwdec=vaapi, vo=gpu.";
+                    my_set_property_async(m_handle, "hwdec", "vaapi", 0);
+                    my_set_property_async(m_handle, "vo", "gpu", 0);
+                }
+            }
         }
 
         PlaylistModel *playMode = dynamic_cast<PlayerEngine *>(m_pParentWidget)->getplaylist();


### PR DESCRIPTION
## 修改说明

芯动(inno-codec)显卡环境下，wmv格式视频默认使用软解，导致播放体验不佳。

### 改动

- 文件：`src/backends/mpv/mpv_proxy.cpp`（+27 行）
- 在 `refreshDecode()` 的 AUTO 分支和 HARDWARE 分支中，各插入 inno-codec wmv 硬解覆盖块
- 检测 `/sys/bus/platform/drivers/inno-codec` 目录是否存在（与既有 inno-codec 检测写法一致）
- 若存在且当前视频为 wmv 格式，强制设置 `hwdec=vaapi` 和 `vo=gpu`

### 影响

芯动风华二号显卡（VendorID:DeviceID = 1ec8:9810）上 wmv 视频改为硬解，提升播放体验。

PMS: TASK-394427

## Summary by Sourcery

Bug Fixes:
- Force WMV playback to use VA-API hardware decoding on systems with the inno-codec driver, improving playback on affected GPUs.