### PR TITLE
chore: update version to 6.5.57

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-movie-reborn (6.5.57) unstable; urgency=medium
+
+  * fix(mpv): force hwdec=vaapi for wmv on inno-codec GPUs
+
+ -- xiepengfei <xiepengfei@uniontech.com>  Thu, 03 Sep 2026 13:26:31 +0800
+
 deepin-movie-reborn (6.5.56) unstable; urgency=medium
 
   * fix(settings): handle legacy decode effect index

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.movie
   name: "deepin-movie"
-  version: 6.5.56.1
+  version: 6.5.57.1
   kind: app
   description: |
     movie for deepin os.


### PR DESCRIPTION
Bump version from 6.5.56 to 6.5.57.

- linglong.yaml: version 6.5.56.1 → 6.5.57.1
- debian/changelog: add 6.5.57 entry

Log: bump version to 6.5.57

## Summary by Sourcery

Chores:
- Update the application package version to 6.5.57.1 and record the 6.5.57 release in the Debian changelog.