### PR TITLE
fix: 全屏进入迷你模式窗口黑色边框及恢复全屏时bypass compositor状态不完整

### DIFF
--- a/src/common/mainwindow.cpp
+++ b/src/common/mainwindow.cpp
@@ -4483,6 +4483,9 @@ void MainWindow::toggleUIMode()
         hide();
         if (isFullScreen()) {
             m_nStateBeforeMiniMode |= SBEM_Fullscreen;
+            if (windowHandle()) {
+                Utility::setBypassCompositor(windowHandle()->winId(), false);
+            }
             this->setWindowState(Qt::WindowNoState);
             setFocus();
             if (m_pFullScreenTimeLabel) {
@@ -4554,6 +4557,9 @@ void MainWindow::toggleUIMode()
             showMaximized();
         } else if (m_nStateBeforeMiniMode & SBEM_Fullscreen) {
             setWindowState(windowState() | Qt::WindowFullScreen);
+            if (windowHandle()) {
+                Utility::setBypassCompositor(windowHandle()->winId(), true);
+            }
             if (CompositingManager::get().platform() == Platform::Arm64 || CompositingManager::get().platform() == Platform::Alpha) {
                 if (m_pEngine->state() != PlayerEngine::CoreState::Idle) {
                     int pixelsWidth = m_pToolbox->getfullscreentimeLabel()->width() + m_pToolbox->getfullscreentimeLabelend()->width();

--- a/src/common/platform/platform_mainwindow.cpp
+++ b/src/common/platform/platform_mainwindow.cpp
@@ -4472,6 +4472,9 @@ void Platform_MainWindow::toggleUIMode()
         hide();
         if (isFullScreen()) {
             m_nStateBeforeMiniMode |= SBEM_Fullscreen;
+            if (windowHandle()) {
+                Utility::setBypassCompositor(windowHandle()->winId(), false);
+            }
             this->setWindowState(Qt::WindowNoState);
         } else if (isMaximized()) {
             m_nStateBeforeMiniMode |= SBEM_Maximized;
@@ -4534,6 +4537,9 @@ void Platform_MainWindow::toggleUIMode()
             showMaximized();
         } else if (m_nStateBeforeMiniMode & SBEM_Fullscreen) {
             setWindowState(windowState() | Qt::WindowFullScreen);
+            if (windowHandle()) {
+                Utility::setBypassCompositor(windowHandle()->winId(), true);
+            }
         } else {
             if (m_pToolbox->listBtn()->isChecked()) {
                 m_pToolbox->listBtn()->setChecked(false);


### PR DESCRIPTION
PMS: BUG-375359

问题：影院在全屏模式下通过右键菜单切换到迷你模式后，迷你模式窗口
（380x380）出现黑色边框。此外，从迷你模式恢复全屏时未重新设置
bypass compositor，导致全屏时绕过合成器的性能优化丢失。

根因：toggleUIMode() 函数在两个方向的状态转换中都缺少 bypass
compositor 属性管理：
1. 全屏→迷你模式：通过 setWindowState(Qt::WindowNoState) 退出全屏 时未调用 setBypassCompositor(false)，导致迷你窗口在合成器被绕过 状态下渲染，产生黑色边框。
2. 迷你→恢复全屏：通过 setWindowState(windowState() | Qt::WindowFullScreen) 恢复全屏时未调用 setBypassCompositor(true)，导致全屏时绕过合成器的 性能优化丢失，与原始行为不一致。

修复：在 toggleUIMode() 中补全两个方向的 bypass compositor 管理：
1. 全屏→迷你模式：在 setWindowState(Qt::WindowNoState) 之前添加 Utility::setBypassCompositor(windowHandle()->winId(), false)
2. 迷你→恢复全屏：在 setWindowState(windowState() | Qt::WindowFullScreen) 之后添加 Utility::setBypassCompositor(windowHandle()->winId(), true)

与 mipsShowFullScreen() 中设置 bypass compositor(true) 和 ToggleFullscreen handler 中清除 bypass compositor(false) 的已有做法一致。

改动文件：
- src/common/mainwindow.cpp（2 处）
- src/common/platform/platform_mainwindow.cpp（2 处）

## Summary by Sourcery

Maintain bypass compositor state consistently when toggling between fullscreen and mini modes.

Bug Fixes:
- Fix black borders when switching from fullscreen to mini mode by clearing bypass compositor state.
- Restore bypass compositor optimization when returning from mini mode to fullscreen.